### PR TITLE
Updated jphyloref to latest specification and code cleanup

### DIFF
--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -1,40 +1,29 @@
 package org.phyloref.jphyloref.commands;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.phyloref.jphyloref.helpers.OWLHelper;
+import org.phyloref.jphyloref.helpers.PhylorefHelper;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLAnnotationProperty;
-import org.semanticweb.owlapi.model.OWLAnnotation;
-import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLAnnotationObjectVisitorEx;
-import org.semanticweb.owlapi.model.OWLAnnotationPropertyDomainAxiom;
-import org.semanticweb.owlapi.model.OWLAnnotationPropertyRangeAxiom;
-import org.semanticweb.owlapi.model.OWLAnonymousIndividual;
 import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLDataProperty;
-import org.semanticweb.owlapi.model.OWLEntity;
 import org.semanticweb.owlapi.model.OWLLiteral;
 import org.semanticweb.owlapi.model.OWLNamedIndividual;
-import org.semanticweb.owlapi.model.OWLObjectProperty;
 import org.semanticweb.owlapi.model.OWLObjectPropertyExpression;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
-import org.semanticweb.owlapi.model.OWLSubAnnotationPropertyOfAxiom;
 import org.semanticweb.owlapi.reasoner.BufferingMode;
-import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
 import org.tap4j.model.Comment;
 import org.tap4j.model.Plan;
 import org.tap4j.model.TestResult;
@@ -48,243 +37,213 @@ import uk.ac.manchester.cs.jfact.kernel.options.JFactReasonerConfiguration;
 
 /**
  * Test whether the phyloreferences in the provided ontology resolve correctly.
- * 
- * At the moment, this works on OWL ontologies, but there's really no reason
- * we couldn't test the labeled.json file directly! Maybe at a later date?
- * 
- * I can't resist using the Test Anything Protocol here, which has nice libraries
- * in both Python and Java.
- * 
+ *
+ * At the moment, this works on OWL ontologies, but there's really no reason we
+ * couldn't test the labeled.json file directly! Maybe at a later date?
+ *
+ * I can't resist using the Test Anything Protocol here, which has nice
+ * libraries in both Python and Java.
+ *
  * @author Gaurav Vaidya <gaurav@ggvaidya.com>
  *
  */
 public class TestCommand implements Command {
-	public String getName() { return "test"; }
-	public String getDescription() { return "Test the phyloreferences in the provided ontology to determine if they resolved correctly."; }
-	
-	public void addCommandLineOptions(Options opts) {
-		opts.addOption("i", "input", true, "The input ontology to read in RDF/XML (can also be provided without the '-i')");
-		opts.addOption("debug_specifiers", false, "Identify unmatched specifiers");
-	}
-	
-	/**
-	 * Execute this command with the provided command line options. 
-	 */
-	public void execute(CommandLine cmdLine) throws RuntimeException {
-		String str_debug_specifiers = cmdLine.getOptionValue("debug_specifiers");
-		boolean flag_debug_specifiers = (str_debug_specifiers != null);
-		
-		String str_input = cmdLine.getOptionValue("input");
-		
-		if(str_input == null && cmdLine.getArgList().size() > 1) {
-			// No 'input'? Maybe it's just provided as a left-over option?
-			str_input = cmdLine.getArgList().get(1); 
-		}
-		
-		if(str_input == null) {
-			throw new RuntimeException("Error: no input ontology specified (use '-i input.owl')");
-		}
-		
-		File inputFile = new File(str_input);
-		if(!inputFile.exists() || !inputFile.canRead()) {
-			throw new RuntimeException("Error: cannot read from input ontology '" + str_input + "'");
-		}
-		
-		System.err.println("Input: " + str_input);
-		
-		// Load the ontology into inputOntology.
-		OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
-		OWLOntology ontology;
-		try {
-			ontology = manager.loadOntologyFromOntologyDocument(inputFile);
-		} catch (OWLOntologyCreationException ex) {
-			throw new RuntimeException("Could not load ontology '" + inputFile + "': " + ex);
-		}
-		
-		// Ontology loaded.
-		System.err.println("Loaded ontology: " + ontology);
-		
-		// Now to reason.
-		JFactReasonerConfiguration config = new JFactReasonerConfiguration();
-		JFactReasoner reasoner = new JFactReasoner(ontology, config, BufferingMode.BUFFERING);
-		
-		// Get a list of all phyloreferences. First, we need to know what a Phyloreference is.
-		IRI iri_class_Phyloreference = IRI.create("http://phyloinformatics.net/phyloref.owl#Phyloreference");
-		Set<OWLEntity> optClassPhyloreference = ontology.getEntitiesInSignature(iri_class_Phyloreference);
-		if(optClassPhyloreference.isEmpty()) {
-			throw new RuntimeException("Class 'phyloref:Phyloreference' is not defined in ontology.");
-		}
-		if(optClassPhyloreference.size() > 1) {
-			throw new RuntimeException("Class 'phyloref:Phyloreference' is defined multiple times in ontology.");
-		}
-		
-		OWLEntity class_Phyloreference = optClassPhyloreference.iterator().next();
-		
-		// Find all classes that have an rdf:type of http://phyloinformatics.net/phyloref.owl#Phyloreference.
-		Set<OWLNamedIndividual> phylorefs = reasoner.getInstances(class_Phyloreference.asOWLClass(), true).getFlattened();
-		
-		// Okay, time to start testing! Each phyloreference counts as one test.
-		TapProducer tapProducer = TapProducerFactory.makeTap13Producer();
-		TestSet testSet = new TestSet();
-		testSet.setPlan(new Plan(phylorefs.size()));
-		
-		// Get some additional properties.
-		OWLAnnotationProperty labelAnnotationProperty = manager.getOWLDataFactory().getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI());
-                OWLDataProperty matchedNameProperty = manager.getOWLDataFactory().getOWLDataProperty(IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#matchedName"));
-		OWLObjectPropertyExpression inPhylogenyProperty = 
-			manager.getOWLDataFactory().getOWLObjectProperty(IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#inPhylogeny"));
-		
-		// Loop
-		int testNumber = 0;
-		int countSuccess = 0;
-		int countFailure = 0;
-		for(OWLNamedIndividual phyloref: phylorefs) {
-			testNumber++;
-			TestResult result = new TestResult();
-			result.setTestNumber(testNumber);
-			boolean testFailed = false;
-			
-			// Write out test information.
-			String phylorefLabel = OWLHelper.getAnnotationLiteralsForEntity(ontology, phyloref, labelAnnotationProperty, Arrays.asList("en"))
-				.stream().collect(Collectors.joining("; "));
-			
-			if(phylorefLabel.equals("")) phylorefLabel = phyloref.getIRI().toString();
-			result.setDescription("Phyloreference '" + phylorefLabel + "'");
-			
-			// Which nodes are this phyloreference resolved to?
-			OWLClass phylorefAsClass = manager.getOWLDataFactory().getOWLClass(phyloref.getIRI()); 
-			Set<OWLNamedIndividual> nodes = reasoner.getInstances(phylorefAsClass, false).getFlattened();
-			
-			if(nodes.isEmpty()) {
-				result.setStatus(StatusValues.NOT_OK);
-				result.addComment(new Comment("No nodes matched"));
-				testFailed = true;
-				
-				if(flag_debug_specifiers) {
-					// If no nodes were matched, was this because one or more of the specifiers
-					// couldn't be matched? Let's check!
-					OWLObjectProperty hasSpecifierProperty = manager.getOWLDataFactory().getOWLObjectProperty(IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#hasSpecifier"));
-					Set<OWLNamedIndividual> specifiers = reasoner.getObjectPropertyValues(phyloref, hasSpecifierProperty).getFlattened();
-					
-					for(OWLNamedIndividual specifier: specifiers) {
-						OWLClass specifierAsClass = manager.getOWLDataFactory().getOWLClass(specifier.getIRI());
-						Set<OWLNamedIndividual> matchedNodes = reasoner.getInstances(specifierAsClass, false).getFlattened();
-						
-						if(matchedNodes.isEmpty()) {
-							Set<OWLDataProperty> dataProps = specifier.getDataPropertiesInSignature();
-							
-							result.addComment(new Comment("dataProps extracted: " + dataProps));
-							
-							String dataPropsString = dataProps.stream()
-								.flatMap(dp -> {
-									// Change to use reasoner if necessary, but I'm hopeful all
-									// the useful stuff will already be associated with the specifier.
-									Set<OWLLiteral> values = specifier.getDataPropertyValues(dp, ontology);
-									
-									return values.stream().map(v -> "(" + 
-										dp.getIRI().getShortForm() + ": '" + 
-										v.getLiteral() + "'@'" + v.getLang() + "')"
-									);
-								})
-								.collect(Collectors.joining(", "));
-								
-							result.addComment(new Comment("Specifier " + specifier.getIRI().toString() + " matched zero nodes: " + dataPropsString));
-						} else {
-							// result.addComment(new Comment("Specifier " + specifier.getIRI().toString() + " matched " + matchedNodes.size() + " nodes"));  
-						}
-					}
-				}
-			} else {
-				// Each phyloref should only resolve to one node on each phylogeny. So let's
-				// map each phyloref to its phylogeny. Also, let's grab their labels while we're
-				// at it.
-				Map<OWLNamedIndividual, Set<OWLLiteral>> matchedNamesByNode = new HashMap<>();
-				
-				for(OWLNamedIndividual node: nodes) {
-					// Which phylogeny does this node belong to?
-					// The relation is Object(<phylogeny> tbd:nodes <node>)
-					
-					Set<OWLNamedIndividual> phylogenies = reasoner.getObjectPropertyValues(node, inPhylogenyProperty).getFlattened();
-					if(phylogenies.isEmpty()) {
-						result.addComment(new Comment("Node '" + node.getIRI().toString() + "' is not found in any phylogeny."));
-						testFailed = true;
-						break;
-					}
-					
-					if(phylogenies.size() > 1) {
-						result.addComment(new Comment(
-							"Node '" + node.getIRI().toString() + "' is found in " + phylogenies.size() + " phylogenies: " +
-							phylogenies.stream()
-								.map(phylogeny -> phylogeny.asOWLNamedIndividual().getIRI().toString())
-								.collect(Collectors.joining("; "))
-						));
-						testFailed = true;
-						break;
-					}
-					
-					// What are the labels associated with these nodes?
-					// The relation is Datatype(<node> tnrs:matchedName <value>)
-					matchedNamesByNode.put(
-                                            node,
-                                            node.getDataPropertyValues(matchedNameProperty, ontology)
-                                        );
-				}
-                                
-				// Okay, which labels do we have? We fail if we have more than one OWLLiteral
-				Set<OWLLiteral> labels = matchedNamesByNode.values().stream().flatMap(n -> n.stream()).collect(Collectors.toSet());
-				if(labels.isEmpty()) {
-					result.addComment(new Comment("No matched nodes have matched names: " + nodes));
-					testFailed = true;
-				} else if(labels.size() > 1) {
-                                    // This is okay IF at least one of the nodes is named after this phyloreference.
+    @Override
+    public String getName() {
+        return "test";
+    }
 
-                                    List<String> otherLabels = new LinkedList<>();
+    @Override
+    public String getDescription() {
+        return "Test the phyloreferences in the provided ontology to determine if they resolved correctly.";
+    }
 
-                                    int matchCount = 0;
-                                    for(OWLLiteral label: labels) {
-                                        if(label.getLiteral().equals(phylorefLabel)) matchCount++;
-                                        else otherLabels.add(label.getLiteral());
-                                    }
+    @Override
+    public void addCommandLineOptions(Options opts) {
+        opts.addOption("i", "input", true, "The input ontology to read in RDF/XML (can also be provided without the '-i')");
+        opts.addOption("debug_specifiers", false, "Identify unmatched specifiers");
+    }
+    
+    /**
+     * Execute this command with the provided command line options.
+     *
+     * @param cmdLine The command line provided to this command.
+     */
+    @Override
+    public void execute(CommandLine cmdLine) throws RuntimeException {
+        // Read command line arguments.
+        String str_debug_specifiers = cmdLine.getOptionValue("debug_specifiers");
+        boolean flag_debug_specifiers = (str_debug_specifiers != null);
 
-                                    String otherLabelsStr = otherLabels.stream().collect(Collectors.joining("; "));
+        String str_input = cmdLine.getOptionValue("input");
+        if (str_input == null && cmdLine.getArgList().size() > 1) {
+            // No 'input'? Maybe it's just provided as a left-over option?
+            str_input = cmdLine.getArgList().get(1);
+        }
+        if (str_input == null) {
+            throw new RuntimeException("Error: no input ontology specified (use '-i input.owl')");
+        }
 
-                                    if(matchCount > 0) {
-                                        result.addComment(new Comment("Node matched on " + matchCount + " phylogenies; other matched names found included: " + otherLabelsStr));
-                                    } else {
-                                        result.addComment(new Comment("Nodes matched with multiple matched names: " + otherLabelsStr));
-                                        testFailed = true;
-                                    }
-				} else {
-                                    OWLLiteral onlyOne = labels.iterator().next();
-                                    String label = onlyOne.getLiteral();
+        File inputFile = new File(str_input);
+        if (!inputFile.exists() || !inputFile.canRead()) {
+            throw new RuntimeException("Error: cannot read from input ontology '" + str_input + "'");
+        }
 
-                                    if(label.equals(phylorefLabel)) {
-                                        result.addComment(new Comment("Node matched name '" + label + "' matched phyloref label '" + phylorefLabel + "'"));
-                                    } else {
-                                        result.addComment(new Comment("Node matched name '" + label + "' did not match phyloref label '" + phylorefLabel + "'"));
-                                        testFailed = true;
-                                    }
-				}
-			}
-			
-			if(testFailed) {
-				// Yay, failure!
-				countFailure++;
-				result.setStatus(StatusValues.NOT_OK);
-				testSet.addTapLine(result);
-			} else {
-				// Oh no, success!
-				countSuccess++;
-				result.setStatus(StatusValues.OK);
-				testSet.addTapLine(result);
-			}
-		}
-		
-		System.out.println(tapProducer.dump(testSet));
-		System.err.println("Testing complete:" + countSuccess + " successes, " + countFailure + " failures");
-		
-		// Exit.
-		if(countSuccess == 0) System.exit(-1);
-		System.exit(countFailure);
-	}
+        System.err.println("Input: " + str_input);
+
+        // Load the ontology into inputOntology.
+        OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
+        OWLDataFactory dataFactory = manager.getOWLDataFactory();
+        OWLOntology ontology;
+        try {
+            ontology = manager.loadOntologyFromOntologyDocument(inputFile);
+        } catch (OWLOntologyCreationException ex) {
+            throw new RuntimeException("Could not load ontology '" + inputFile + "': " + ex);
+        }
+
+        // Ontology loaded.
+        System.err.println("Loaded ontology: " + ontology);
+
+        // Now to reason.
+        JFactReasonerConfiguration config = new JFactReasonerConfiguration();
+        JFactReasoner reasoner = new JFactReasoner(ontology, config, BufferingMode.BUFFERING);
+
+        // Find all phyloreferences.
+        Set<OWLNamedIndividual> phylorefs = PhylorefHelper.getPhyloreferences(ontology, reasoner);
+
+        // Okay, time to start testing! Each phyloreference counts as one test.
+        TapProducer tapProducer = TapProducerFactory.makeTap13Producer();
+        TestSet testSet = new TestSet();
+        testSet.setPlan(new Plan(phylorefs.size()));
+
+        // Loop
+        int testNumber = 0;
+        int countSuccess = 0;
+        int countFailure = 0;
+        for (OWLNamedIndividual phyloref : phylorefs) {
+            testNumber++;
+            TestResult result = new TestResult();
+            result.setTestNumber(testNumber);
+            boolean testFailed = false;
+
+            // Write out test information.
+            String phylorefLabel = OWLHelper.getLabel(phyloref, ontology).stream().distinct().sorted().collect(Collectors.joining("; "));
+
+            if (phylorefLabel.equals("")) {
+                phylorefLabel = phyloref.getIRI().toString();
+            }
+            result.setDescription("Phyloreference '" + phylorefLabel + "'");
+
+            // Which nodes are this phyloreference resolved to?
+            OWLClass phyloref_asClass = dataFactory.getOWLClass(phyloref.getIRI());
+            Set<OWLNamedIndividual> nodes = reasoner.getInstances(phyloref_asClass, false).getFlattened();
+
+            if (nodes.isEmpty()) {
+                result.setStatus(StatusValues.NOT_OK);
+                result.addComment(new Comment("No nodes matched"));
+                testFailed = true;
+
+            } else {
+                // Each phyloref should only resolve to one node on each phylogeny. So let's
+                // map each phyloref to its phylogeny. Also, let's grab their labels while we're
+                // at it.
+                Map<OWLNamedIndividual, Set<OWLLiteral>> matchedNamesByNode = new HashMap<>();
+
+                for (OWLNamedIndividual node : nodes) {
+                    // Which phylogeny does this node belong to?
+                    // The relation is Object(<phylogeny> tbd:nodes <node>)
+                    
+                    OWLObjectPropertyExpression inPhylogenyProperty = 
+                        manager.getOWLDataFactory().getOWLObjectProperty(IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#inPhylogeny"));
+                    OWLDataProperty matchedNameProperty = 
+                        manager.getOWLDataFactory().getOWLDataProperty(IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#matchedName"));
+                    
+                    Set<OWLNamedIndividual> phylogenies = reasoner.getObjectPropertyValues(node, inPhylogenyProperty).getFlattened();
+                    if (phylogenies.isEmpty()) {
+                        result.addComment(new Comment("Node '" + node.getIRI().toString() + "' is not found in any phylogeny."));
+                        testFailed = true;
+                        break;
+                    }
+
+                    if (phylogenies.size() > 1) {
+                        result.addComment(new Comment(
+                                "Node '" + node.getIRI().toString() + "' is found in " + phylogenies.size() + " phylogenies: "
+                                + phylogenies.stream()
+                                        .map(phylogeny -> phylogeny.asOWLNamedIndividual().getIRI().toString())
+                                        .collect(Collectors.joining("; "))
+                        ));
+                        testFailed = true;
+                        break;
+                    }
+
+                    // What are the labels associated with these nodes?
+                    // The relation is Datatype(<node> tnrs:matchedName <value>)
+                    matchedNamesByNode.put(
+                            node,
+                            node.getDataPropertyValues(matchedNameProperty, ontology)
+                    );
+                }
+
+                // Okay, which labels do we have? We fail if we have more than one OWLLiteral
+                Set<OWLLiteral> labels = matchedNamesByNode.values().stream().flatMap(n -> n.stream()).collect(Collectors.toSet());
+                if (labels.isEmpty()) {
+                    result.addComment(new Comment("No matched nodes have matched names: " + nodes));
+                    testFailed = true;
+                } else if (labels.size() > 1) {
+                    // This is okay IF at least one of the nodes is named after this phyloreference.
+
+                    List<String> otherLabels = new LinkedList<>();
+
+                    int matchCount = 0;
+                    for (OWLLiteral label : labels) {
+                        if (label.getLiteral().equals(phylorefLabel)) {
+                            matchCount++;
+                        } else {
+                            otherLabels.add(label.getLiteral());
+                        }
+                    }
+
+                    String otherLabelsStr = otherLabels.stream().collect(Collectors.joining("; "));
+
+                    if (matchCount > 0) {
+                        result.addComment(new Comment("Node matched on " + matchCount + " phylogenies; other matched names found included: " + otherLabelsStr));
+                    } else {
+                        result.addComment(new Comment("Nodes matched with multiple matched names: " + otherLabelsStr));
+                        testFailed = true;
+                    }
+                } else {
+                    OWLLiteral onlyOne = labels.iterator().next();
+                    String label = onlyOne.getLiteral();
+
+                    if (label.equals(phylorefLabel)) {
+                        result.addComment(new Comment("Node matched name '" + label + "' matched phyloref label '" + phylorefLabel + "'"));
+                    } else {
+                        result.addComment(new Comment("Node matched name '" + label + "' did not match phyloref label '" + phylorefLabel + "'"));
+                        testFailed = true;
+                    }
+                }
+            }
+
+            if (testFailed) {
+                // Yay, failure!
+                countFailure++;
+                result.setStatus(StatusValues.NOT_OK);
+                testSet.addTapLine(result);
+            } else {
+                // Oh no, success!
+                countSuccess++;
+                result.setStatus(StatusValues.OK);
+                testSet.addTapLine(result);
+            }
+        }
+
+        System.out.println(tapProducer.dump(testSet));
+        System.err.println("Testing complete:" + countSuccess + " successes, " + countFailure + " failures");
+
+        // Exit.
+        if (countSuccess == 0) {
+            System.exit(-1);
+        }
+        System.exit(countFailure);
+    }
 }

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -179,38 +179,6 @@ public class TestCommand implements Command {
                 Map<OWLNamedIndividual, Set<OWLLiteral>> expectedPhyloreferencesByNode = new HashMap<>();
 
                 for(OWLNamedIndividual node: nodes) {
-                    /*
-                    // Which phylogeny does this node belong to?
-                    OWLObjectPropertyExpression inPhylogenyProperty = dataFactory.getOWLObjectProperty(PhylorefHelper.IRI_PHYLOGENY_CONTAINING_NODE);                
-                    Set<OWLNamedIndividual> phylogenies = reasoner.getObjectPropertyValues(node, inPhylogenyProperty).getFlattened();
-                    
-                    // Check how many phylogenies this node is found in.
-                    
-                    if(phylogenies.isEmpty()) {
-                        // Node is not found in any phylogeny.
-                        // Every node should be a part of a phylogeny!
-                        
-                        result.addComment(new Comment("Node '" + node.getIRI().toString() + "' is not found in any phylogeny."));
-                        testFailed = true;
-                        break;
-                    }
-
-                    if(phylogenies.size() > 1) {
-                        // Node is found in more than one phylogeny.
-                        // Different phylogenies might share nodes with the same
-                        // properties, but the same *node* shouldn't be asserted
-                        // to belong to more than one phylogeny.
-                        
-                        result.addComment(new Comment(
-                            "Node '" + node.getIRI().toString() + "' is found in " + phylogenies.size() + " phylogenies: " +
-                            phylogenies.stream()
-                                .map(phylogeny -> phylogeny.asOWLNamedIndividual().getIRI().toString())
-                                .collect(Collectors.joining("; "))
-                        ));
-                        testFailed = true;
-                        break;
-                    }*/
-
                     // What are the expected phyloreferences associated with these nodes?
                     expectedPhyloreferencesByNode.put(
                         node, 

--- a/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
@@ -1,20 +1,18 @@
 package org.phyloref.jphyloref.helpers;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAnnotation;
-import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
-import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLEntity;
 import org.semanticweb.owlapi.model.OWLLiteral;
 import org.semanticweb.owlapi.model.OWLNamedIndividual;
 import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
 
 /**
  * OWLHelper contains helpful functions.
@@ -23,37 +21,51 @@ import org.semanticweb.owlapi.model.OWLOntology;
  *
  */
 public final class OWLHelper {
-	public static Map<String, Set<String>> getAnnotationLiteralsForEntity(OWLOntology ontology, OWLEntity entity, OWLAnnotationProperty annotationProperty) {
-		Map<String, Set<String>> valuesByLanguage = new HashMap<>();
-		
-		for(OWLAnnotation annotation: entity.getAnnotations(ontology, annotationProperty)) {
-			if(annotation.getValue() instanceof OWLLiteral) {
-				OWLLiteral val = (OWLLiteral) annotation.getValue();
-				String lang = val.getLang();
-				
-				if(!valuesByLanguage.containsKey(lang))
-					valuesByLanguage.put(lang, new HashSet<>());
-				
-				valuesByLanguage.get(lang).add(val.getLiteral());
-			}
-		}
-		
-		return valuesByLanguage;
-	}
-		
-	public static Set<String> getAnnotationLiteralsForEntity(OWLOntology ontology, OWLEntity entity, OWLAnnotationProperty annotationProperty, List<String> langs) {
-		Map<String, Set<String>> valuesByLanguage = getAnnotationLiteralsForEntity(ontology, entity, annotationProperty);
-		
-		for(String lang: langs) {
-			if(valuesByLanguage.containsKey(lang)) {
-				return valuesByLanguage.get(lang);
-			}
-		}
-		
-		// Didn't find the lang? Use "".
-		if(valuesByLanguage.containsKey(""))
-			return valuesByLanguage.get("");
-		else
-			return new HashSet<>();
-	}
+    private static OWLAnnotationProperty cache_labelProperty = null;
+    public static OWLAnnotationProperty getLabelProperty(OWLOntology ontology) {
+        if(cache_labelProperty != null) return cache_labelProperty;
+        cache_labelProperty = ontology.getOWLOntologyManager().getOWLDataFactory().getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI());
+        return cache_labelProperty;
+    }
+    
+    public static Set<String> getLabel(OWLNamedIndividual individual, OWLOntology ontology) {
+        OWLAnnotationProperty labelProperty = getLabelProperty(ontology);
+        return OWLHelper.getAnnotationLiteralsForEntity(ontology, individual, labelProperty, Arrays.asList("en"));
+    }
+    
+    public static Map<String, Set<String>> getAnnotationLiteralsForEntity(OWLOntology ontology, OWLEntity entity, OWLAnnotationProperty annotationProperty) {
+        Map<String, Set<String>> valuesByLanguage = new HashMap<>();
+
+        for (OWLAnnotation annotation : entity.getAnnotations(ontology, annotationProperty)) {
+            if (annotation.getValue() instanceof OWLLiteral) {
+                OWLLiteral val = (OWLLiteral) annotation.getValue();
+                String lang = val.getLang();
+
+                if (!valuesByLanguage.containsKey(lang)) {
+                    valuesByLanguage.put(lang, new HashSet<>());
+                }
+
+                valuesByLanguage.get(lang).add(val.getLiteral());
+            }
+        }
+
+        return valuesByLanguage;
+    }
+
+    public static Set<String> getAnnotationLiteralsForEntity(OWLOntology ontology, OWLEntity entity, OWLAnnotationProperty annotationProperty, List<String> langs) {
+        Map<String, Set<String>> valuesByLanguage = getAnnotationLiteralsForEntity(ontology, entity, annotationProperty);
+
+        for (String lang : langs) {
+            if (valuesByLanguage.containsKey(lang)) {
+                return valuesByLanguage.get(lang);
+            }
+        }
+
+        // Didn't find the lang? Use "".
+        if (valuesByLanguage.containsKey("")) {
+            return valuesByLanguage.get("");
+        } else {
+            return new HashSet<>();
+        }
+    }
 }

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -1,0 +1,36 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.phyloref.jphyloref.helpers;
+
+import java.util.Set;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLEntity;
+import org.semanticweb.owlapi.model.OWLNamedIndividual;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.reasoner.OWLReasoner;
+
+/**
+ *
+ * @author ggvaidya
+ */
+public class PhylorefHelper {
+    public static final IRI IRI_PHYLOREFERENCE = IRI.create("http://phyloinformatics.net/phyloref.owl#Phyloreference");
+    
+    public static Set<OWLNamedIndividual> getPhyloreferences(OWLOntology ontology, OWLReasoner reasoner) {
+        // Get a list of all phyloreferences. First, we need to know what a Phyloreference is.
+        Set<OWLEntity> set_phyloref_Phyloreference = ontology.getEntitiesInSignature(IRI_PHYLOREFERENCE);
+        if (set_phyloref_Phyloreference.isEmpty()) {
+            throw new RuntimeException("Class 'phyloref:Phyloreference' is not defined in ontology.");
+        }
+        if (set_phyloref_Phyloreference.size() > 1) {
+            throw new RuntimeException("Class 'phyloref:Phyloreference' is defined multiple times in ontology.");
+        }
+
+        OWLEntity phyloref_Phyloreference = set_phyloref_Phyloreference.iterator().next();
+        return reasoner.getInstances(phyloref_Phyloreference.asOWLClass(), true).getFlattened();
+    }
+    
+}

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -22,12 +22,10 @@ import org.semanticweb.owlapi.reasoner.OWLReasoner;
  * @author Gaurav Vaidya <gaurav@ggvaidya.com>
  */
 public class PhylorefHelper {
+    // IRIs used in this package.
     public static final IRI IRI_PHYLOREFERENCE = IRI.create("http://phyloinformatics.net/phyloref.owl#Phyloreference");
-    // IRIs used in this command
-    public static IRI iri_class_Phyloreference = IRI.create("http://phyloinformatics.net/phyloref.owl#Phyloreference");
-    public static IRI iri_has_specifier = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#has_specifier");
-    public static IRI IRI_PHYLOGENY_CONTAINING_NODE = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#in_phylogeny");
-    public static IRI IRI_NAME_OF_EXPECTED_PHYLOREF = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#expected_phyloreference_named");
+    public static final IRI IRI_PHYLOGENY_CONTAINING_NODE = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#in_phylogeny");
+    public static final IRI IRI_NAME_OF_EXPECTED_PHYLOREF = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#expected_phyloreference_named");
     
     public static Set<OWLNamedIndividual> getPhyloreferences(OWLOntology ontology, OWLReasoner reasoner) {
         // Get a list of all phyloreferences. First, we need to know what a Phyloreference is.


### PR DESCRIPTION
Updated jphyloref to the latest specification, which creates a clear new term ("testcase:expected_phyloreference_named") to indicate which phyloreferences a node is expected to match. I also cleaned up the formatting and improved the documentation of the code, as well as moving some code into a separate class.

This should definitely be squashed once approved :).