### PR TITLE
Mark failing phyloreferences with unmatched specifiers as TODO

### DIFF
--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -188,9 +188,10 @@ public class TestCommand implements Command {
                     testFailed = true;
                 } else {
                     // Okay, the phyloreference didn't resolve, but now we know
-                    // why -- because these specifiers did not resolve.
+                    // why -- because these specifiers did not match.
+                    result.setStatus(StatusValues.NOT_OK);
                     result.addComment(new Comment("No nodes matched, but " + specifiers.size() + " specifiers did not match."));
-                    // We don't explicitly mark this as a test failure by itself.
+                    testFailed = true;
                 }
             } else {
                 // Make a list of every expected phyloreference for input node.

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -26,6 +26,8 @@ public class PhylorefHelper {
     public static final IRI IRI_PHYLOREFERENCE = IRI.create("http://phyloinformatics.net/phyloref.owl#Phyloreference");
     public static final IRI IRI_PHYLOGENY_CONTAINING_NODE = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#in_phylogeny");
     public static final IRI IRI_NAME_OF_EXPECTED_PHYLOREF = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#expected_phyloreference_named");
+    public static final IRI IRI_PHYLOREF_UNMATCHED_SPECIFIER = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#has_unmatched_specifier");
+    public static final IRI IRI_CLADE_DEFINITION = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#clade_definition");
     
     public static Set<OWLNamedIndividual> getPhyloreferences(OWLOntology ontology, OWLReasoner reasoner) {
         // Get a list of all phyloreferences. First, we need to know what a Phyloreference is.


### PR DESCRIPTION
Recognizes unmatched specifiers in a phyloreference (indicated by the `testcase:has_unmatched_specifier` object property). Phyloreferences that fail but contain at least one unmatched specifier will be marked as 'TODO' and will not prevent the entire study from passing.

The JAR file produced has been incorporated into phyloref/curation-workflow#11.

I tried to rebase this to master or to squash some of those commits, but fixing differences between this branch and master became extremely complex, because master has changed quite dramatically in #1. I could have resplit this branch and cherry-picked individual changes onto it, but I don't think it's worth it for keeping these few changes separate. I therefore just ended up merging master into this. We can squash this into a single commit when we merge.