### PR TITLE
Rewrote phyloreference testing code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change log for JPhyloref
+
+Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
+
+## [Unreleased]
+
+## 0.1 - 2018-06-20
+- Initial release, with support for testing phyloreferences expressed in OWL
+  and stored in RDF/XML.
+
+[Unreleased]: https://github.com/phyloref/jphyloref/compare/v0.1...HEAD

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.phyloref</groupId>
   <artifactId>jphyloref</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>jphyloref</name>

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -37,9 +37,6 @@ public class JPhyloRef
 	 * @param args Command line arguments
 	 */
     public void execute(String[] args) {
-    	// Display version information.
-    	System.err.println("jphyloref/" + VERSION + "\n");
-        
         // Prepare to parse command line arguments.
         Options opts = new Options();
         for(Command cmd: commands) {
@@ -71,14 +68,12 @@ public class JPhyloRef
         			// Found a match!
         			cmd.execute(cmdLine);
         			System.exit(0);
-        			return;
         		}
         	}
         	
         	// Could not find any command.
         	System.err.println("Error: command '" + command + "' has not been implemented.");
         	System.exit(1);
-        	return;
         }
     }
     
@@ -112,13 +107,13 @@ public class JPhyloRef
 		/** Display a list of Commands that can be executed on the command line. */
 		public void execute(CommandLine cmdLine) {
 			// Display a synopsis.
-			System.err.println("Synopsis: jphyloref <command> <options>\n");
+			System.out.println("Synopsis: jphyloref <command> <options>\n");
 			
 			// Display a list of currently included Commands.
-			System.err.println("Where command is one of:");
+			System.out.println("Where command is one of:");
 			for(Command cmd: commands) {
 				// Display the description of the command.
-				System.err.println(" - " + cmd.getName() + ": " + cmd.getDescription());
+				System.out.println(" - " + cmd.getName() + ": " + cmd.getDescription());
 				
 				// Display all the command line options supported by that command.
 				Options opts = new Options();
@@ -129,7 +124,7 @@ public class JPhyloRef
 					if(opt.getLongOpt() != null)
 						longOpt = ", " + opt.getLongOpt();
 					
-					System.err.println("    - "
+					System.out.println("    - "
 						+ opt.getOpt() + longOpt + ": "
 						+ opt.getDescription()
 					);
@@ -137,7 +132,7 @@ public class JPhyloRef
 			}
 			
 			// One final blank line, please.
-			System.err.println("");
+			System.out.println("");
 		}
     }
 }

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -13,27 +13,31 @@ import org.phyloref.jphyloref.commands.ReasonCommand;
 import org.phyloref.jphyloref.commands.TestCommand;
 
 /**
- * Main class for JPhyloRef. Figures out what the user 
- * wants us to do. 
+ * Main class for JPhyloRef. Contains a list of Commands,
+ * as well as the code for determining which Command to
+ * execute. 
  *
  */
 public class JPhyloRef 
 {
+	/** Version of JPhyloRef */
 	public static final String VERSION = "0.0.1-SNAPSHOT";
 	
+	/** List of all commands included in JPhyloRef */
 	private List<Command> commands = Arrays.asList(
 		new HelpCommand(),
 		new TestCommand(),
 		new ReasonCommand()
 	);
 	
-    public static void main( String[] args )
-    {
-        JPhyloRef jphyloref = new JPhyloRef();
-        jphyloref.execute(args);
-    }
-    
+	/**
+	 * Interpret the command line arguments to determine which command
+	 * to execute.
+	 * 
+	 * @param args Command line arguments
+	 */
     public void execute(String[] args) {
+    	// Display version information.
     	System.err.println("jphyloref/" + VERSION + "\n");
         
         // Prepare to parse command line arguments.
@@ -52,42 +56,71 @@ public class JPhyloRef
         	return;
         }
         
-        // The first unprocessed argument should be the command.
+        // Are there any command line arguments?
         if(cmdLine.getArgList().isEmpty()) {
-        	// No command provided! Activate help.
+        	// No command line arguments -- display help!
         	HelpCommand help = new HelpCommand();
         	help.execute(cmdLine);
         } else {
+        	// The first unprocessed argument should be the command.
         	String command = cmdLine.getArgList().get(0);
-        	
+
+        	// Look for a Command with the name specified. 
         	for(Command cmd: commands) {
         		if(cmd.getName().equalsIgnoreCase(command)) {
-        			// match!
+        			// Found a match!
         			cmd.execute(cmdLine);
         			System.exit(0);
         			return;
         		}
         	}
         	
+        	// Could not find any command.
         	System.err.println("Error: command '" + command + "' has not been implemented.");
         	System.exit(1);
         	return;
         }
     }
     
+	/** 
+	 * Main method for JPhyloRef. Creates the JPhyloRef instance
+	 * and tells it to start processing the command line arguments.
+	 *  
+	 * @param args Command line arguments
+	 */
+    public static void main( String[] args )
+    {
+        JPhyloRef jphyloref = new JPhyloRef();
+        jphyloref.execute(args);
+    }
+
+    /**
+     * HelpCommand is a special command that lists help information on all currently
+     * implemented Commands. You can activate it by running "jphyloref help" or by
+     * just entering "jphyloref" without any command.
+     */
     private class HelpCommand implements Command {
+    	/** This command is named "help", and so can be executed as "jphyloref help" */
 		public String getName() { return "help"; }
+		
+		/** Returns a description of the Help command */
 		public String getDescription() { return "Provides help on all jphyloref commands"; }
+		
+		/** There are no command line options for the Help command. */
 		public void addCommandLineOptions(Options opts) { }
+		
+		/** Display a list of Commands that can be executed on the command line. */
 		public void execute(CommandLine cmdLine) {
-			// No arguments are provided.
-			
+			// Display a synopsis.
 			System.err.println("Synopsis: jphyloref <command> <options>\n");
 			
+			// Display a list of currently included Commands.
 			System.err.println("Where command is one of:");
 			for(Command cmd: commands) {
+				// Display the description of the command.
 				System.err.println(" - " + cmd.getName() + ": " + cmd.getDescription());
 				
+				// Display all the command line options supported by that command.
 				Options opts = new Options();
 				cmd.addCommandLineOptions(opts);
 				

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -21,7 +21,7 @@ import org.phyloref.jphyloref.commands.TestCommand;
 public class JPhyloRef 
 {
 	/** Version of JPhyloRef */
-	public static final String VERSION = "0.0.1-SNAPSHOT";
+	public static final String VERSION = "0.1-SNAPSHOT";
 	
 	/** List of all commands included in JPhyloRef */
 	private List<Command> commands = Arrays.asList(

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -51,7 +51,7 @@ import uk.ac.manchester.cs.jfact.kernel.options.JFactReasonerConfiguration;
 public class TestCommand implements Command {
     /**
      * This command is named Test. It should be 
-     * involved "java -jar jphyloref.jar test ..."
+     * invoked as "java -jar jphyloref.jar test ..."
      */
 
     @Override

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -1,30 +1,24 @@
 package org.phyloref.jphyloref.commands;
 
-import org.phyloref.jphyloref.helpers.PhylorefHelper;
-import org.phyloref.jphyloref.helpers.OWLHelper;
-
 import java.io.File;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
+import org.phyloref.jphyloref.helpers.OWLHelper;
+import org.phyloref.jphyloref.helpers.PhylorefHelper;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLDataProperty;
-import org.semanticweb.owlapi.model.OWLLiteral;
 import org.semanticweb.owlapi.model.OWLNamedIndividual;
 import org.semanticweb.owlapi.model.OWLObjectProperty;
-import org.semanticweb.owlapi.model.OWLObjectPropertyExpression;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
@@ -39,24 +33,24 @@ import org.tap4j.producer.TapProducer;
 import org.tap4j.producer.TapProducerFactory;
 import org.tap4j.util.DirectiveValues;
 import org.tap4j.util.StatusValues;
+
 import uk.ac.manchester.cs.jfact.JFactReasoner;
 import uk.ac.manchester.cs.jfact.kernel.options.JFactReasonerConfiguration;
 
 /**
  * Test whether the phyloreferences in the provided ontology resolve correctly.
+ * This currently supports RDF/XML input only, but we will eventually modify
+ * this to support PHYX files directly.
  *
- * At the moment, this works on OWL ontologies, but there's really no reason we
- * couldn't test the labeled.json file directly! Maybe at a later date?
- *
- * I can't resist using the Test Anything Protocol here, which has nice
- * libraries in both Python and Java.
+ * I use the Test Anything Protocol here, which has nice libraries in both 
+ * Python and Java.
  *
  * @author Gaurav Vaidya <gaurav@ggvaidya.com>
  *
  */
 public class TestCommand implements Command {
     /**
-     * This command is named "test". It should be 
+     * This command is named Test. It should be 
      * involved "java -jar jphyloref.jar test ..."
      */
 
@@ -66,6 +60,8 @@ public class TestCommand implements Command {
     }
     
     /**
+     * A description of the Test command.
+     * 
      * @return A description of this command.
      */
     @Override
@@ -74,7 +70,8 @@ public class TestCommand implements Command {
     }
 
     /**
-     * Add command-line options specific to this command.
+     * Add command-line options specific to this command. There is only one:
+     * -i or --input can be used to set the RDF/XML file to read.
      * 
      * @param opts The command-line options to modify for this command.
      */
@@ -178,7 +175,7 @@ public class TestCommand implements Command {
                 phylorefLabel = phyloref.getIRI().toString();
             result.setDescription("Phyloreference '" + phylorefLabel + "'");
 
-            // Which nodes did this phyloreference resolved to?
+            // Which nodes did this phyloreference resolve to?
             OWLClass phylorefAsClass = manager.getOWLDataFactory().getOWLClass(phyloref.getIRI()); 
             Set<OWLNamedIndividual> nodes = reasoner.getInstances(phylorefAsClass, false).getFlattened();
 

--- a/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
@@ -43,7 +43,7 @@ public final class OWLHelper {
      */
     public static Set<String> getLabelsInEnglish(OWLNamedIndividual individual, OWLOntology ontology) {
         OWLAnnotationProperty labelProperty = getLabelProperty(ontology);
-        return OWLHelper.getAnnotationLiteralsForEntity(ontology, individual, labelProperty, Arrays.asList("", "en"));
+        return OWLHelper.getAnnotationLiteralsForEntity(ontology, individual, labelProperty, Arrays.asList("en"));
     }
     
     /**

--- a/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
@@ -15,7 +15,7 @@ import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
 
 /**
- * OWLHelper contains methods that make it that make it easy to access information encoded in OWL.
+ * OWLHelper contains methods simplify accessing information from the OWL API.
  * 
  * @author Gaurav Vaidya <gaurav@ggvaidya.com>
  *

--- a/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
@@ -15,46 +15,53 @@ import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
 
 /**
- * OWLHelper contains helpful functions.
+ * OWLHelper contains methods that make it that make it easy to access information encoded in OWL.
  * 
  * @author Gaurav Vaidya <gaurav@ggvaidya.com>
  *
  */
 public final class OWLHelper {
+	/** A variable we use to cache rdfs:label */ 
     private static OWLAnnotationProperty cache_labelProperty = null;
+    
+    /** 
+     * Returns OWL property rdfs:label, using a cache so we don't 
+     * need to load the property using the data property. 
+     */ 
     public static OWLAnnotationProperty getLabelProperty(OWLOntology ontology) {
         if(cache_labelProperty != null) return cache_labelProperty;
         cache_labelProperty = ontology.getOWLOntologyManager().getOWLDataFactory().getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI());
         return cache_labelProperty;
     }
     
+    /**
+     * Return a list of labels for an OWLNamedIndividual with either no language provided or in English. 
+     * 
+     * @param individual The OWLNamedIndividual whose labels need to be retrieved.
+     * @param ontology The ontology within which this individual is defined.
+     * @return A list of labels as Java Strings.
+     */
     public static Set<String> getLabelsInEnglish(OWLNamedIndividual individual, OWLOntology ontology) {
         OWLAnnotationProperty labelProperty = getLabelProperty(ontology);
         return OWLHelper.getAnnotationLiteralsForEntity(ontology, individual, labelProperty, Arrays.asList("", "en"));
     }
     
-    public static Map<String, Set<String>> getAnnotationLiteralsForEntity(OWLOntology ontology, OWLEntity entity, OWLAnnotationProperty annotationProperty) {
-        Map<String, Set<String>> valuesByLanguage = new HashMap<>();
-
-        for (OWLAnnotation annotation : entity.getAnnotations(ontology, annotationProperty)) {
-            if (annotation.getValue() instanceof OWLLiteral) {
-                OWLLiteral val = (OWLLiteral) annotation.getValue();
-                String lang = val.getLang();
-
-                if (!valuesByLanguage.containsKey(lang)) {
-                    valuesByLanguage.put(lang, new HashSet<>());
-                }
-
-                valuesByLanguage.get(lang).add(val.getLiteral());
-            }
-        }
-
-        return valuesByLanguage;
-    }
-
+    /**
+     * Extract values for an annotation property applied to an OWL entity in an ontology for a particular set of languages.
+     * 
+     * @param ontology The ontology containing the entity and the annotation property to extract
+     * @param entity The entity to extract annotations for
+     * @param annotationProperty The annotation property to extract (usually rdfs:label)
+     * @param langs Languages to extract annotation literals for, in order of importance  
+     * @return Set of annotation property values for the first matched language, or those associated with no languages
+     */
     public static Set<String> getAnnotationLiteralsForEntity(OWLOntology ontology, OWLEntity entity, OWLAnnotationProperty annotationProperty, List<String> langs) {
+    	// Get the map of all strings for all languages for this annotation property
         Map<String, Set<String>> valuesByLanguage = getAnnotationLiteralsForEntity(ontology, entity, annotationProperty);
 
+        // Look for the languages requested. Note that we return the annotation property
+        // values for the first language we can find, NOT the union of all the annotation
+        // properties.
         for (String lang : langs) {
             if (valuesByLanguage.containsKey(lang)) {
                 return valuesByLanguage.get(lang);
@@ -67,5 +74,35 @@ public final class OWLHelper {
         } else {
             return new HashSet<>();
         }
+    }
+
+    /**
+     * Return a Map that contains all known values for a given annotation property for a given OWL entity, 
+     * organized by language. 
+     * 
+     * @param ontology The ontology containing the OWL entity and the annotation property to query 
+     * @param entity The OWL entity to query
+     * @param annotationProperty The annotation property to query
+     * @return A Map of annotation values organized into Sets by language.  
+     */
+    public static Map<String, Set<String>> getAnnotationLiteralsForEntity(OWLOntology ontology, OWLEntity entity, OWLAnnotationProperty annotationProperty) {
+        Map<String, Set<String>> valuesByLanguage = new HashMap<>();
+
+        // Go through all known annotations, looking for OWLLiterals.
+        for (OWLAnnotation annotation : entity.getAnnotations(ontology, annotationProperty)) {
+            if (annotation.getValue() instanceof OWLLiteral) {
+                OWLLiteral val = (OWLLiteral) annotation.getValue();
+                String lang = val.getLang();
+
+                // Organize values by language.
+                if (!valuesByLanguage.containsKey(lang)) {
+                    valuesByLanguage.put(lang, new HashSet<>());
+                }
+
+                valuesByLanguage.get(lang).add(val.getLiteral());
+            }
+        }
+
+        return valuesByLanguage;
     }
 }

--- a/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
@@ -28,9 +28,9 @@ public final class OWLHelper {
         return cache_labelProperty;
     }
     
-    public static Set<String> getLabel(OWLNamedIndividual individual, OWLOntology ontology) {
+    public static Set<String> getLabelsInEnglish(OWLNamedIndividual individual, OWLOntology ontology) {
         OWLAnnotationProperty labelProperty = getLabelProperty(ontology);
-        return OWLHelper.getAnnotationLiteralsForEntity(ontology, individual, labelProperty, Arrays.asList("en"));
+        return OWLHelper.getAnnotationLiteralsForEntity(ontology, individual, labelProperty, Arrays.asList("", "en"));
     }
     
     public static Map<String, Set<String>> getAnnotationLiteralsForEntity(OWLOntology ontology, OWLEntity entity, OWLAnnotationProperty annotationProperty) {

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -45,10 +45,10 @@ public class PhylorefHelper {
         // Get a list of all phyloreferences. First, we need to know what a Phyloreference is.
         Set<OWLEntity> set_phyloref_Phyloreference = ontology.getEntitiesInSignature(IRI_PHYLOREFERENCE);
         if (set_phyloref_Phyloreference.isEmpty()) {
-            throw new RuntimeException("Class " + IRI_PHYLOREFERENCE + " is not defined in ontology.");
+            throw new IllegalArgumentException("Class " + IRI_PHYLOREFERENCE + " is not defined in ontology.");
         }
         if (set_phyloref_Phyloreference.size() > 1) {
-            throw new RuntimeException("Class " + IRI_PHYLOREFERENCE + " is defined multiple times in ontology.");
+            throw new IllegalArgumentException("Class " + IRI_PHYLOREFERENCE + " is defined multiple times in ontology.");
         }
 
         // Get all instances of IRI_PHYLOREFERENCE.

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package org.phyloref.jphyloref.helpers;
 
 import java.util.Set;
@@ -23,22 +18,40 @@ import org.semanticweb.owlapi.reasoner.OWLReasoner;
  */
 public class PhylorefHelper {
     // IRIs used in this package.
+	
+	/** IRI for OWL class Phyloreference */
     public static final IRI IRI_PHYLOREFERENCE = IRI.create("http://phyloinformatics.net/phyloref.owl#Phyloreference");
+    
+    /** IRI for the OWL object property indicating which phylogeny a node belongs to */
     public static final IRI IRI_PHYLOGENY_CONTAINING_NODE = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#in_phylogeny");
+    
+    /** IRI for the OWL data property indicating the label of the expected phyloreference */ 
     public static final IRI IRI_NAME_OF_EXPECTED_PHYLOREF = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#expected_phyloreference_named");
+
+    /** IRI for the OWL object property indicating which specifiers had not been matched */
     public static final IRI IRI_PHYLOREF_UNMATCHED_SPECIFIER = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#has_unmatched_specifier");
+
+    /** IRI for the OWL data property with the verbatim clade definition */  
     public static final IRI IRI_CLADE_DEFINITION = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#clade_definition");
     
+    /**
+     * Extract a list of phyloreferences, i.e. instances of IRI_PHYLOREFERENCE that are punned as OWL classes.
+     *  
+     * @param ontology The ontology to extract the phyloreferences from
+     * @param reasoner A reasoner to use in extracting the phyloreferences
+     * @return A Set of OWLNamedIndividuals corresponding to phyloreferences in the specified ontology
+     */
     public static Set<OWLNamedIndividual> getPhyloreferences(OWLOntology ontology, OWLReasoner reasoner) {
         // Get a list of all phyloreferences. First, we need to know what a Phyloreference is.
         Set<OWLEntity> set_phyloref_Phyloreference = ontology.getEntitiesInSignature(IRI_PHYLOREFERENCE);
         if (set_phyloref_Phyloreference.isEmpty()) {
-            throw new RuntimeException("Class 'phyloref:Phyloreference' is not defined in ontology.");
+            throw new RuntimeException("Class " + IRI_PHYLOREFERENCE + " is not defined in ontology.");
         }
         if (set_phyloref_Phyloreference.size() > 1) {
-            throw new RuntimeException("Class 'phyloref:Phyloreference' is defined multiple times in ontology.");
+            throw new RuntimeException("Class " + IRI_PHYLOREFERENCE + " is defined multiple times in ontology.");
         }
 
+        // Get all instances of IRI_PHYLOREFERENCE.
         OWLEntity phyloref_Phyloreference = set_phyloref_Phyloreference.iterator().next();
         return reasoner.getInstances(phyloref_Phyloreference.asOWLClass(), true).getFlattened();
     }


### PR DESCRIPTION
The current version of the phyloreference testing code had evolved through several different cycles, was badly written, and appeared to not be correctly testing phyloreferences using the `expected_phyloreference_named` property. I replaced it with cleaner, easier to read code that appears to be testing phyloreferences correctly.

This has now been tested by its incorporation into #9 and it's use in phyloref/clade-ontology#29, so it's ready to be reviewed and merged.