### PR TITLE
Phyloreference status support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,15 @@ Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 
 ## [Unreleased]
 
+## 0.2 - 2018-06-20
+- Added support for phyloreference statuses using the Publication Status Ontology
+  as per [phyloref/curation-tool#25](https://github.com/phyloref/curation-tool/issues/25).
+- Added a `--no-reasoner` mode to testing, allowing pre-reasoned ontologies to be
+  tested.
+- Fixed some spacing and line-ending issues.
+
 ## 0.1 - 2018-06-20
 - Initial release, with support for testing phyloreferences expressed in OWL
   and stored in RDF/XML.
 
-[Unreleased]: https://github.com/phyloref/jphyloref/compare/v0.1...HEAD
+[Unreleased]: https://github.com/phyloref/jphyloref/compare/v0.2...HEAD

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.phyloref</groupId>
     <artifactId>jphyloref</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>jphyloref</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,35 +1,35 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.phyloref</groupId>
-  <artifactId>jphyloref</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-  <packaging>jar</packaging>
+    <groupId>org.phyloref</groupId>
+    <artifactId>jphyloref</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
-  <name>jphyloref</name>
+    <name>jphyloref</name>
 
-  <properties>
-  	<mainClass>org.phyloref.jphyloref.JPhyloRef</mainClass>  
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-  </properties>
+    <properties>
+        <mainClass>org.phyloref.jphyloref.JPhyloRef</mainClass>  
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-    	<groupId>commons-cli</groupId>
-    	<artifactId>commons-cli</artifactId>
-    	<version>1.4</version>
-    </dependency>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.4</version>
+        </dependency>
     
-    <!-- https://mvnrepository.com/artifact/net.sourceforge.owlapi/jfact --> 
+        <!-- https://mvnrepository.com/artifact/net.sourceforge.owlapi/jfact --> 
 	<dependency>
 	    <groupId>net.sourceforge.owlapi</groupId>
 	    <artifactId>jfact</artifactId>
@@ -37,58 +37,57 @@
 	</dependency>
 	
 	<dependency>
-	  <groupId>org.tap4j</groupId>
-	  <artifactId>tap4j</artifactId>
-	  <version>4.2.1</version>
+            <groupId>org.tap4j</groupId>
+            <artifactId>tap4j</artifactId>
+            <version>4.2.1</version>
 	</dependency>
-	
-  </dependencies>
-  
-  <build>
-	  <plugins>
-	  	<plugin>
-			<groupId>org.codehaus.mojo</groupId>
-			<artifactId>exec-maven-plugin</artifactId>
-			<version>1.2.1</version>
-			<executions>
-				<execution>
-					<phase>verify</phase>
-					<goals>
-						<goal>java</goal>
-					</goals>
-					<configuration>
-						<mainClass>${mainClass}</mainClass>
-						<arguments>
-						</arguments>
-					</configuration>
-				</execution>
-			</executions>
-		</plugin>
-		<plugin>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-shade-plugin</artifactId>
-			<version>3.0.0</version>
-			<configuration>
-				<transformers>
-					<transformer
-						implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-						<manifestEntries>
-							<Main-Class>${mainClass}</Main-Class>
-							<X-Compile-Source-JDK>${maven.compile.source}</X-Compile-Source-JDK>
-							<X-Compile-Target-JDK>${maven.compile.target}</X-Compile-Target-JDK>
-						</manifestEntries>
-					</transformer>
-				</transformers>
-			</configuration>
-			<executions>
-				<execution>
-					<phase>package</phase>
-					<goals>
-						<goal>shade</goal>
-					</goals>
-				</execution>
-			</executions>
-		</plugin>
-	  </plugins>
-  </build>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>${mainClass}</mainClass>
+                            <arguments>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                  </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <transformers>
+                        <transformer
+                            implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <manifestEntries>
+                                <Main-Class>${mainClass}</Main-Class>
+                                <X-Compile-Source-JDK>${maven.compile.source}</X-Compile-Source-JDK>
+                                <X-Compile-Target-JDK>${maven.compile.target}</X-Compile-Target-JDK>
+                            </manifestEntries>
+                        </transformer>
+                    </transformers>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -2,7 +2,6 @@ package org.phyloref.jphyloref;
 
 import java.util.Arrays;
 import java.util.List;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
@@ -15,79 +14,77 @@ import org.phyloref.jphyloref.commands.TestCommand;
 /**
  * Main class for JPhyloRef. Contains a list of Commands,
  * as well as the code for determining which Command to
- * execute. 
+ * execute.
  *
  */
-public class JPhyloRef 
-{
-	/** Version of JPhyloRef */
-	public static final String VERSION = "0.0.1-SNAPSHOT";
-	
-	/** List of all commands included in JPhyloRef */
-	private List<Command> commands = Arrays.asList(
-		new HelpCommand(),
-		new TestCommand(),
-		new ReasonCommand()
-	);
-	
-	/**
-	 * Interpret the command line arguments to determine which command
-	 * to execute.
-	 * 
-	 * @param args Command line arguments
-	 */
+public class JPhyloRef {
+    /** Version of JPhyloRef. */
+    public static final String VERSION = "0.0.1-SNAPSHOT";
+
+    /** List of all commands included in JPhyloRef. */
+    private List<Command> commands = Arrays.asList(
+        new HelpCommand(),
+        new TestCommand(),
+        new ReasonCommand()
+    );
+
+    /**
+     * Interpret the command line arguments to determine which command
+     * to execute.
+     *
+     * @param args Command line arguments
+     */
     public void execute(String[] args) {
-    	// Display version information.
-    	System.err.println("jphyloref/" + VERSION + "\n");
-        
+        // Display version information.
+        System.err.println("jphyloref/" + VERSION + "\n");
+
         // Prepare to parse command line arguments.
         Options opts = new Options();
         for(Command cmd: commands) {
-        	cmd.addCommandLineOptions(opts);
+            cmd.addCommandLineOptions(opts);
         }
-        
+
         // Parse command line arguments.
         CommandLine cmdLine;
         try {
-        	cmdLine = new DefaultParser().parse(opts, args);
+            cmdLine = new DefaultParser().parse(opts, args);
         } catch(ParseException ex) {
-        	System.err.println("Could not parse command line options: " + ex);
-        	System.exit(1);
-        	return;
+            System.err.println("Could not parse command line options: " + ex);
+            System.exit(1);
+            return;
         }
-        
+
         // Are there any command line arguments?
         if(cmdLine.getArgList().isEmpty()) {
-        	// No command line arguments -- display help!
-        	HelpCommand help = new HelpCommand();
-        	help.execute(cmdLine);
+            // No command line arguments -- display help!
+            HelpCommand help = new HelpCommand();
+            help.execute(cmdLine);
         } else {
-        	// The first unprocessed argument should be the command.
-        	String command = cmdLine.getArgList().get(0);
+            // The first unprocessed argument should be the command.
+            String command = cmdLine.getArgList().get(0);
 
-        	// Look for a Command with the name specified. 
-        	for(Command cmd: commands) {
-        		if(cmd.getName().equalsIgnoreCase(command)) {
-        			// Found a match!
-        			cmd.execute(cmdLine);
-        			System.exit(0);
-        			return;
-        		}
-        	}
-        	
-        	// Could not find any command.
-        	System.err.println("Error: command '" + command + "' has not been implemented.");
-        	System.exit(1);
-        	return;
+            // Look for a Command with the name specified.
+            for(Command cmd: commands) {
+                if(cmd.getName().equalsIgnoreCase(command)) {
+                    // Found a match!
+                    cmd.execute(cmdLine);
+                    System.exit(0);
+                    return;
+                }
+            }
+
+            // Could not find any command.
+            System.err.println("Error: command '" + command + "' has not been implemented.");
+            System.exit(1);
         }
     }
-    
-	/** 
-	 * Main method for JPhyloRef. Creates the JPhyloRef instance
-	 * and tells it to start processing the command line arguments.
-	 *  
-	 * @param args Command line arguments
-	 */
+
+    /**
+     * Main method for JPhyloRef. Creates the JPhyloRef instance
+     * and tells it to start processing the command line arguments.
+     *
+     * @param args Command line arguments
+     */
     public static void main( String[] args )
     {
         JPhyloRef jphyloref = new JPhyloRef();
@@ -100,44 +97,44 @@ public class JPhyloRef
      * just entering "jphyloref" without any command.
      */
     private class HelpCommand implements Command {
-    	/** This command is named "help", and so can be executed as "jphyloref help" */
-		public String getName() { return "help"; }
-		
-		/** Returns a description of the Help command */
-		public String getDescription() { return "Provides help on all jphyloref commands"; }
-		
-		/** There are no command line options for the Help command. */
-		public void addCommandLineOptions(Options opts) { }
-		
-		/** Display a list of Commands that can be executed on the command line. */
-		public void execute(CommandLine cmdLine) {
-			// Display a synopsis.
-			System.err.println("Synopsis: jphyloref <command> <options>\n");
-			
-			// Display a list of currently included Commands.
-			System.err.println("Where command is one of:");
-			for(Command cmd: commands) {
-				// Display the description of the command.
-				System.err.println(" - " + cmd.getName() + ": " + cmd.getDescription());
-				
-				// Display all the command line options supported by that command.
-				Options opts = new Options();
-				cmd.addCommandLineOptions(opts);
-				
-				for(Option opt: opts.getOptions()) {
-					String longOpt = "";
-					if(opt.getLongOpt() != null)
-						longOpt = ", " + opt.getLongOpt();
-					
-					System.err.println("    - "
-						+ opt.getOpt() + longOpt + ": "
-						+ opt.getDescription()
-					);
-				}
-			}
-			
-			// One final blank line, please.
-			System.err.println("");
-		}
+        /** This command is named "help", and so can be executed as "jphyloref help". */
+        public String getName() { return "help"; }
+
+        /** Returns a description of the Help command. */
+        public String getDescription() { return "Provides help on all jphyloref commands"; }
+
+        /** There are no command line options for the Help command. */
+        public void addCommandLineOptions(Options opts) { }
+
+        /** Display a list of Commands that can be executed on the command line. */
+        public void execute(CommandLine cmdLine) {
+            // Display a synopsis.
+            System.err.println("Synopsis: jphyloref <command> <options>\n");
+
+            // Display a list of currently included Commands.
+            System.err.println("Where command is one of:");
+            for(Command cmd: commands) {
+                // Display the description of the command.
+                System.err.println(" - " + cmd.getName() + ": " + cmd.getDescription());
+
+                // Display all the command line options supported by that command.
+                Options opts = new Options();
+                cmd.addCommandLineOptions(opts);
+
+                for(Option opt: opts.getOptions()) {
+                    String longOpt = "";
+                    if(opt.getLongOpt() != null)
+                        longOpt = ", " + opt.getLongOpt();
+
+                    System.err.println("    - "
+                        + opt.getOpt() + longOpt + ": "
+                        + opt.getDescription()
+                    );
+                }
+            }
+
+            // One final blank line, please.
+            System.err.println("");
+        }
     }
 }

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -104,6 +104,9 @@ public class JPhyloRef {
 
         /** Display a list of Commands that can be executed on the command line. */
         public void execute(CommandLine cmdLine) {
+					  // Display version number.
+						System.out.println("JPhyloRef/" + JPhyloRef.VERSION);
+
             // Display a synopsis.
             System.out.println("Synopsis: jphyloref <command> <options>\n");
 

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -19,7 +19,7 @@ import org.phyloref.jphyloref.commands.TestCommand;
  */
 public class JPhyloRef {
     /** Version of JPhyloRef. */
-    public static final String VERSION = "0.1-SNAPSHOT";
+    public static final String VERSION = "0.2-SNAPSHOT";
 
     /** List of all commands included in JPhyloRef. */
     private List<Command> commands = Arrays.asList(

--- a/src/main/java/org/phyloref/jphyloref/commands/Command.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/Command.java
@@ -11,29 +11,29 @@ import org.apache.commons.cli.Options;
  *
  */
 public interface Command {
-	/** 
-	 * The name of this command. The command is usually 
-	 * invoked as "jphyloref command ...".
-	 * 
-	 * @return The name of this command.
-	 */
-	public String getName();
-	
-	/**
-	 * A one-line description of this command.
-	 * 
-	 * @return
-	 */
-	public String getDescription();
-	
-	/**
-	 * A list of valid command line options. These should
-	 * be added to the provided Options object.
-	 */
-	public void addCommandLineOptions(Options opts);
-	
-	/**
-	 * Execute this command with the provided command line options. 
-	 */
-	public void execute(CommandLine cmdLine);
+    /** 
+     * The name of this command. The command is usually 
+     * invoked as "jphyloref command ...".
+     * 
+     * @return The name of this command.
+     */
+    public String getName();
+
+    /**
+     * A one-line description of this command.
+     * 
+     * @return
+     */
+    public String getDescription();
+
+    /**
+     * A list of valid command line options. These should
+     * be added to the provided Options object.
+     */
+    public void addCommandLineOptions(Options opts);
+
+    /**
+     * Execute this command with the provided command line options. 
+     */
+    public void execute(CommandLine cmdLine);
 }

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -58,7 +58,7 @@ import uk.ac.manchester.cs.jfact.kernel.options.JFactReasonerConfiguration;
 public class TestCommand implements Command {
     /**
      * This command is named "test". It should be
-     * involved "java -jar jphyloref.jar test ..."
+     * invoked as "java -jar jphyloref.jar test ..."
      */
 
     @Override
@@ -112,15 +112,11 @@ public class TestCommand implements Command {
         }
 
         if(str_input == null) {
-            throw new RuntimeException("Error: no input ontology specified (use '-i input.owl')");
+            throw new IllegalArgumentException("Error: no input ontology specified (use '-i input.owl')");
         }
 
         // Create File object to load
         File inputFile = new File(str_input);
-        if(!inputFile.exists() || !inputFile.canRead()) {
-            throw new RuntimeException("Error: cannot read from input ontology '" + str_input + "'");
-        }
-
         System.err.println("Input: " + inputFile);
 
         // Set up an OWL Ontology Manager to work with.
@@ -270,9 +266,9 @@ public class TestCommand implements Command {
                 	// We only found nodes that expected this phyloref -- success!
                 	result.addComment(new Comment("The following nodes were matched and expected this phyloreference: " + String.join("; ", nodeLabelsWithExpectedPhylorefs)));
                 } else if(!nodeLabelsWithoutExpectedPhylorefs.isEmpty()) {
-                	// We only have nodes that did not expect this phyloref -- failure!
-                	result.addComment(new Comment("The following nodes were matched but did not expect this phyloreference: " + String.join("; ", nodeLabelsWithoutExpectedPhylorefs)));
-                    testFailed = true;
+                        // We only have nodes that did not expect this phyloref -- failure!
+                        result.addComment(new Comment("The following nodes were matched but did not expect this phyloreference: " + String.join("; ", nodeLabelsWithoutExpectedPhylorefs)));
+                        testFailed = true;
                 } else {
                 	// No nodes matched. This should have been caught earlier, but just in case.
                 	throw new RuntimeException("No nodes were matched, which should have been caught earlier. Programmer error!");
@@ -372,9 +368,9 @@ public class TestCommand implements Command {
                     } else {
                         // No, we do not expect this phyloreference to resolve. Report a TODO.
                         countTODO++;
-            		result.setStatus(StatusValues.NOT_OK);
-            		result.setDirective(new Directive(DirectiveValues.TODO, "Phyloreference did not resolve, but has status " + statuses));
-            		testSet.addTapLine(result);
+                        result.setStatus(StatusValues.NOT_OK);
+                        result.setDirective(new Directive(DirectiveValues.TODO, "Phyloreference did not resolve, but has status " + statuses));
+                        testSet.addTapLine(result);
                     }
             	} else {
                     // Okay, it's a failure, but we do know that there are unmatched specifiers.

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -248,6 +248,11 @@ public class TestCommand implements Command {
                 		.append("]")
                 		.toString();
 
+                	// Is this blank? If so, let's use the node's IRI as its label so we can debug issues with resolution.
+                	if(expectedPhylorefsNamed.isEmpty()) {
+                		nodeLabel = node.getIRI().toString();
+                	}
+
                 	// Does this node have an expected phyloreference identical to the phyloref being tested?
                 	if(expectedPhylorefsNamed.contains(phylorefLabel)) {
                 		nodeLabelsWithExpectedPhylorefs.add(nodeLabel);

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -144,12 +144,8 @@ public class TestCommand implements Command {
         Set<OWLNamedIndividual> phylorefs;
 
         // Get a list of all phyloreferences.
-        if(flag_no_reasoner) {
-            phylorefs = PhylorefHelper.getPhyloreferences(ontology);
-        } else {
-            reasoner = new JFactReasoner(ontology, config, BufferingMode.BUFFERING);
-            phylorefs = PhylorefHelper.getPhyloreferences(ontology, reasoner);
-        }
+        if(!flag_no_reasoner) reasoner = new JFactReasoner(ontology, config, BufferingMode.BUFFERING);
+        phylorefs = PhylorefHelper.getPhyloreferences(ontology, reasoner);
 
         // Okay, time to start testing! Each phyloreference counts as one test.
         // TAP (https://testanything.org/) can be read by downstream software

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -22,7 +22,6 @@ import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLDataProperty;
 import org.semanticweb.owlapi.model.OWLDataPropertyAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLLiteral;
 import org.semanticweb.owlapi.model.OWLNamedIndividual;
 import org.semanticweb.owlapi.model.OWLObjectProperty;
 import org.semanticweb.owlapi.model.OWLOntology;
@@ -227,51 +226,51 @@ public class TestCommand implements Command {
             	Set<String> nodeLabelsWithoutExpectedPhylorefs = new HashSet<>();
 
                 for(OWLNamedIndividual node: nodes) {
-                	// Get a list of all expected phyloreference labels from the OWL file.
-                	Set<String> expectedPhylorefsNamed = node.getDataPropertyValues(expectedPhyloreferenceNamedProperty, ontology)
-                		.stream()
-                		.map(literal -> literal.getLiteral()) // We ignore languages for now.
-                		.collect(Collectors.toSet());
+                    // Get a list of all expected phyloreference labels from the OWL file.
+                    Set<String> expectedPhylorefsNamed = node.getDataPropertyValues(expectedPhyloreferenceNamedProperty, ontology)
+                        .stream()
+                        .map(literal -> literal.getLiteral()) // We ignore languages for now.
+                        .collect(Collectors.toSet());
 
-                	// Add the label of the node as well.
-                	Set<String> nodeLabels = OWLHelper.getLabelsInEnglish(node, ontology);
-                	expectedPhylorefsNamed.addAll(nodeLabels);
+                    // Add the label of the node as well.
+                    Set<String> nodeLabels = OWLHelper.getLabelsInEnglish(node, ontology);
+                    expectedPhylorefsNamed.addAll(nodeLabels);
 
-                	// Build a new node label that describes this node.
-                	String nodeLabel = new StringBuilder()
-                		.append("[")
-                		.append(String.join(", ", expectedPhylorefsNamed))
-                		.append("]")
-                		.toString();
+                    // Build a new node label that describes this node.
+                    String nodeLabel = new StringBuilder()
+                        .append("[")
+                        .append(String.join(", ", expectedPhylorefsNamed))
+                        .append("]")
+                        .toString();
 
-                	// Is this blank? If so, let's use the node's IRI as its label so we can debug issues with resolution.
-                	if(expectedPhylorefsNamed.isEmpty()) {
-                		nodeLabel = node.getIRI().toString();
-                	}
+                    // Is this blank? If so, let's use the node's IRI as its label so we can debug issues with resolution.
+                    if(expectedPhylorefsNamed.isEmpty()) {
+                        nodeLabel = node.getIRI().toString();
+                    }
 
-                	// Does this node have an expected phyloreference identical to the phyloref being tested?
-                	if(expectedPhylorefsNamed.contains(phylorefLabel)) {
-                		nodeLabelsWithExpectedPhylorefs.add(nodeLabel);
-                	} else {
-                		nodeLabelsWithoutExpectedPhylorefs.add(nodeLabel);
-                	}
+                    // Does this node have an expected phyloreference identical to the phyloref being tested?
+                    if(expectedPhylorefsNamed.contains(phylorefLabel)) {
+                        nodeLabelsWithExpectedPhylorefs.add(nodeLabel);
+                    } else {
+                        nodeLabelsWithoutExpectedPhylorefs.add(nodeLabel);
+                    }
                 }
 
                 // What happened?
                 if(!nodeLabelsWithExpectedPhylorefs.isEmpty() && !nodeLabelsWithoutExpectedPhylorefs.isEmpty()) {
-                	// We found nodes that expected this phyloref, as well as nodes that did not -- success!
-                	result.addComment(new Comment("The following nodes were matched and expected this phyloreference: " + String.join("; ", nodeLabelsWithExpectedPhylorefs)));
-                	result.addComment(new Comment("Also, the following nodes were matched but did not expect this phyloreference: " + String.join("; ", nodeLabelsWithoutExpectedPhylorefs)));
+                    // We found nodes that expected this phyloref, as well as nodes that did not -- success!
+                    result.addComment(new Comment("The following nodes were matched and expected this phyloreference: " + String.join("; ", nodeLabelsWithExpectedPhylorefs)));
+                    result.addComment(new Comment("Also, the following nodes were matched but did not expect this phyloreference: " + String.join("; ", nodeLabelsWithoutExpectedPhylorefs)));
                 } else if(!nodeLabelsWithExpectedPhylorefs.isEmpty()) {
-                	// We only found nodes that expected this phyloref -- success!
-                	result.addComment(new Comment("The following nodes were matched and expected this phyloreference: " + String.join("; ", nodeLabelsWithExpectedPhylorefs)));
+                    // We only found nodes that expected this phyloref -- success!
+                    result.addComment(new Comment("The following nodes were matched and expected this phyloreference: " + String.join("; ", nodeLabelsWithExpectedPhylorefs)));
                 } else if(!nodeLabelsWithoutExpectedPhylorefs.isEmpty()) {
-                        // We only have nodes that did not expect this phyloref -- failure!
-                        result.addComment(new Comment("The following nodes were matched but did not expect this phyloreference: " + String.join("; ", nodeLabelsWithoutExpectedPhylorefs)));
-                        testFailed = true;
+                    // We only have nodes that did not expect this phyloref -- failure!
+                    result.addComment(new Comment("The following nodes were matched but did not expect this phyloreference: " + String.join("; ", nodeLabelsWithoutExpectedPhylorefs)));
+                    testFailed = true;
                 } else {
-                	// No nodes matched. This should have been caught earlier, but just in case.
-                	throw new RuntimeException("No nodes were matched, which should have been caught earlier. Programmer error!");
+                    // No nodes matched. This should have been caught earlier, but just in case.
+                    throw new RuntimeException("No nodes were matched, which should have been caught earlier. Programmer error!");
                 }
             }
 
@@ -284,7 +283,7 @@ public class TestCommand implements Command {
                     // Therefore, any NamedIndividuals that are not phyloref should be added to
                     // unmatched_specifiers!
                     for(OWLNamedIndividual ni: axiom.getIndividualsInSignature()) {
-                            if(ni != phyloref) unmatched_specifiers.add(ni);
+                        if(ni != phyloref) unmatched_specifiers.add(ni);
                     }
             	}
             }

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -135,6 +135,7 @@ public class TestCommand implements Command {
 
         // Is purl.obolibrary.org down? No worries, we store local copies of all our ontologies!
         AutoIRIMapper mapper = new AutoIRIMapper(new File("ontologies"), true);
+        System.err.println("Found local ontologies: " + mapper.getOntologyIRIs());
         manager.addIRIMapper(mapper);
 
         // Load the ontology using OWLManager.

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -349,7 +349,7 @@ public class TestCommand implements Command {
                 }
             }
 
-            System.err.println("Active statuses: " + statuses);
+            // System.err.println("Active statuses: " + statuses);
 
             // Based on the phyloreference status, we can determine whether or not
             // we expect the phyloreference to actually resolve: we do if there

--- a/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
@@ -21,7 +21,7 @@ import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
  *
  */
 public final class OWLHelper {
-	/** A variable we use to cache rdfs:label */ 
+    /** A variable we use to cache rdfs:label */ 
     private static OWLAnnotationProperty cache_labelProperty = null;
     
     /** 

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -34,6 +34,11 @@ public class PhylorefHelper {
     public static final IRI IRI_PHYLOREF_UNMATCHED_SPECIFIER = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#has_unmatched_specifier");
     public static final IRI IRI_CLADE_DEFINITION = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#clade_definition");
     
+    /**
+     * Get a list of phyloreferences in this ontology. This method does not use
+     * the reasoner, and so will only find individuals asserted to have a type
+     * of phyloref:Phyloreference.
+     */
     public static Set<OWLNamedIndividual> getPhyloreferences(OWLOntology ontology) {
         // Get a list of all phyloreferences. First, we need to know what a Phyloreference is.
         Set<OWLEntity> set_phyloref_Phyloreference = ontology.getEntitiesInSignature(IRI_PHYLOREFERENCE);
@@ -49,19 +54,24 @@ public class PhylorefHelper {
         Set<OWLClassAssertionAxiom> classAssertions = ontology.getAxioms(AxiomType.CLASS_ASSERTION);
         
         for(OWLClassAssertionAxiom classAssertion: classAssertions) {
-        	// Does this assertion involve class:Phyloreference and a named individual?
-        	if(
-        		classAssertion.getIndividual().isNamed() &&
-        		classAssertion.getClassesInSignature().contains(phyloref_Phyloreference)
-        	) {
-        		// If so, then the individuals are phyloreferences!
-        		phylorefs.add(classAssertion.getIndividual().asOWLNamedIndividual());
-        	}
+            // Does this assertion involve class:Phyloreference and a named individual?
+            if(
+                classAssertion.getIndividual().isNamed() &&
+                classAssertion.getClassesInSignature().contains(phyloref_Phyloreference)
+            ) {
+                // If so, then the individual is a phyloreferences!
+                phylorefs.add(classAssertion.getIndividual().asOWLNamedIndividual());
+            }
         }
-        
+
         return phylorefs;
     }
-    
+ 
+    /**
+     * Get a list of phyloreferences in this ontology. This method uses the
+     * reasoner, and so will find all individuals determined to be of 
+     * type phyloref:Phyloreference.
+     */   
     public static Set<OWLNamedIndividual> getPhyloreferences(OWLOntology ontology, OWLReasoner reasoner) {
         // Get a list of all phyloreferences. First, we need to know what a Phyloreference is.
         Set<OWLEntity> set_phyloref_Phyloreference = ontology.getEntitiesInSignature(IRI_PHYLOREFERENCE);

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -24,7 +24,7 @@ import org.semanticweb.owlapi.reasoner.OWLReasoner;
 public class PhylorefHelper {
     // IRIs used in this package.
 
-	/** IRI for OWL class Phyloreference */
+    /** IRI for OWL class Phyloreference */
     public static final IRI IRI_PHYLOREFERENCE = IRI.create("http://phyloinformatics.net/phyloref.owl#Phyloreference");
 
     /** IRI for the OWL object property indicating which phylogeny a node belongs to */
@@ -90,5 +90,4 @@ public class PhylorefHelper {
         OWLClass phyloref_Phyloreference = set_phyloref_Phyloreference.iterator().next().asOWLClass();
         return reasoner.getInstances(phyloref_Phyloreference, true).getFlattened();
     }
-
 }

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -40,11 +40,11 @@ public class PhylorefHelper {
     public static final IRI IRI_CLADE_DEFINITION = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#clade_definition");
 
     /**
-     * Get a list of phyloreferences in this ontology. This method does not use
+     * Get a list of phyloreferences in this ontology without reasoning. This method does not use
      * the reasoner, and so will only find individuals asserted to have a type
      * of phyloref:Phyloreference.
      */
-    public static Set<OWLNamedIndividual> getPhyloreferences(OWLOntology ontology) {
+    public static Set<OWLNamedIndividual> getPhyloreferencesWithoutReasoning(OWLOntology ontology) {
         // Get a list of all phyloreferences. First, we need to know what a Phyloreference is.
         Set<OWLEntity> set_phyloref_Phyloreference = ontology.getEntitiesInSignature(IRI_PHYLOREFERENCE);
         if (set_phyloref_Phyloreference.isEmpty()) {
@@ -76,8 +76,16 @@ public class PhylorefHelper {
      * Get a list of phyloreferences in this ontology. This method uses the
      * reasoner, and so will find all individuals determined to be of
      * type phyloref:Phyloreference.
+     * 
+     * @param ontology The OWL Ontology within with we should look for phylorefs
+     * @param reasoner The reasoner to use. May be null.
      */
     public static Set<OWLNamedIndividual> getPhyloreferences(OWLOntology ontology, OWLReasoner reasoner) {
+        // If no reasoner is provided, we can't find all individuals that are
+        // inferred to be phyloref:Phyloreference, but we can still find all
+        // individuals that are stated to be phyloref:Phyloreference. So let's do that!
+        if(reasoner == null) return PhylorefHelper.getPhyloreferencesWithoutReasoning(ontology);
+        
         // Get a list of all phyloreferences. First, we need to know what a Phyloreference is.
         Set<OWLEntity> set_phyloref_Phyloreference = ontology.getEntitiesInSignature(IRI_PHYLOREFERENCE);
         if (set_phyloref_Phyloreference.isEmpty()) {


### PR DESCRIPTION
Add support for phyloreference statuses expressed using the Publication Status Ontology (as per phyloref/curation-tool#25), which marks failing phyloreferences whose status is not "pso:submitted" or "pso:published" to be marked as TODO rather than as test failures. In order to test this easily, I added a command-line option (`--no-reasoner`) which allows the tests to be run without running the reasoner.