### PR TITLE
Upgrade JFact to 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 
 ## [Unreleased]
+- Updated dependency to JFact 5.0.1, which necessitated some code changes.
 
 ## 0.2 - 2018-06-20
 - Added support for phyloreference statuses using the Publication Status Ontology

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <name>jphyloref</name>
 
     <properties>
-        <mainClass>org.phyloref.jphyloref.JPhyloRef</mainClass>  
+        <mainClass>org.phyloref.jphyloref.JPhyloRef</mainClass>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -28,19 +28,19 @@
             <artifactId>commons-cli</artifactId>
             <version>1.4</version>
         </dependency>
-    
-        <!-- https://mvnrepository.com/artifact/net.sourceforge.owlapi/jfact --> 
-	<dependency>
-	    <groupId>net.sourceforge.owlapi</groupId>
-	    <artifactId>jfact</artifactId>
-	    <version>1.2.4</version>
-	</dependency>
-	
-	<dependency>
+
+        <!-- https://mvnrepository.com/artifact/net.sourceforge.owlapi/jfact -->
+      	<dependency>
+      	    <groupId>net.sourceforge.owlapi</groupId>
+      	    <artifactId>jfact</artifactId>
+      	    <version>5.0.1</version>
+      	</dependency>
+
+        <dependency>
             <groupId>org.tap4j</groupId>
             <artifactId>tap4j</artifactId>
             <version>4.2.1</version>
-	</dependency>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -10,6 +10,7 @@ import org.apache.commons.cli.ParseException;
 import org.phyloref.jphyloref.commands.Command;
 import org.phyloref.jphyloref.commands.ReasonCommand;
 import org.phyloref.jphyloref.commands.TestCommand;
+import org.semanticweb.owlapi.util.VersionInfo;
 
 /**
  * Main class for JPhyloRef. Contains a list of Commands,
@@ -104,8 +105,8 @@ public class JPhyloRef {
 
         /** Display a list of Commands that can be executed on the command line. */
         public void execute(CommandLine cmdLine) {
-					  // Display version number.
-						System.out.println("JPhyloRef/" + JPhyloRef.VERSION);
+			// Display version number.
+			System.out.println("JPhyloRef/" + JPhyloRef.VERSION + " OWLAPI/" + VersionInfo.getVersionInfo().getVersion());
 
             // Display a synopsis.
             System.out.println("Synopsis: jphyloref <command> <options>\n");

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -29,6 +29,7 @@ import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.reasoner.BufferingMode;
+import org.semanticweb.owlapi.search.EntitySearcher;
 import org.semanticweb.owlapi.util.AutoIRIMapper;
 import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
 import org.tap4j.model.Comment;
@@ -239,8 +240,7 @@ public class TestCommand implements Command {
 
                 for(OWLNamedIndividual node: nodes) {
                     // Get a list of all expected phyloreference labels from the OWL file.
-                    Set<String> expectedPhylorefsNamed = node.getDataPropertyValues(expectedPhyloreferenceNamedProperty, ontology)
-                        .stream()
+                    Set<String> expectedPhylorefsNamed = EntitySearcher.getDataPropertyValues(node, expectedPhyloreferenceNamedProperty, ontology)
                         .map(literal -> literal.getLiteral()) // We ignore languages for now.
                         .collect(Collectors.toSet());
 
@@ -287,7 +287,7 @@ public class TestCommand implements Command {
             }
 
             // Look for all unmatched specifiers reported for this phyloreference
-            Set<OWLAxiom> axioms = phyloref.getReferencingAxioms(ontology);
+            Set<OWLAxiom> axioms = EntitySearcher.getReferencingAxioms(phyloref, ontology).collect(Collectors.toSet());
             Set<OWLNamedIndividual> unmatched_specifiers = new HashSet<>();
             for(OWLAxiom axiom: axioms) {
             	if(axiom.containsEntityInSignature(unmatchedSpecifierProperty)) {
@@ -311,7 +311,7 @@ public class TestCommand implements Command {
             }
 
             // Retrieve holdsStatusInTime to determine the active status of this phyloreference.
-            Set<OWLAnnotation> holdsStatusInTime = phylorefAsClass.getAnnotations(ontology, pso_holdsStatusInTime);
+            Set<OWLAnnotation> holdsStatusInTime = EntitySearcher.getAnnotations(phylorefAsClass, ontology, pso_holdsStatusInTime).collect(Collectors.toSet());
 
             // Instead of checking which time interval were are in, we take a simpler approach: we look for all
             // statuses that have a start date but not an end date, i.e. those which have yet to end.

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -12,6 +12,7 @@ import org.phyloref.jphyloref.helpers.OWLHelper;
 import org.phyloref.jphyloref.helpers.PhylorefHelper;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.AxiomType;
+import org.semanticweb.owlapi.model.ClassExpressionType;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAnnotation;
 import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
@@ -157,6 +158,9 @@ public class TestCommand implements Command {
 
         // Preload some terms we need to use in the following code.
         OWLDataFactory dataFactory = manager.getOWLDataFactory();
+        
+        // Some classes we will use.
+        OWLClass classCDAONode = dataFactory.getOWLClass(PhylorefHelper.IRI_CDAO_NODE);
 
         // Terms associated with phyloreferences
         OWLAnnotationProperty labelAnnotationProperty = dataFactory.getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI());
@@ -206,8 +210,17 @@ public class TestCommand implements Command {
             OWLClass phylorefAsClass = manager.getOWLDataFactory().getOWLClass(phyloref.getIRI());
             Set<OWLNamedIndividual> nodes;
             if(reasoner != null) {
-                // Use the reasoner to determine which nodes are members of this phyloref as a class
-            	nodes = reasoner.getInstances(phylorefAsClass, false).getFlattened();
+            	// Use the reasoner to determine which nodes are members of this phyloref as a class
+            	nodes = reasoner.getInstances(phylorefAsClass, false).entities()
+	                // This includes the phyloreference itself. We only want to
+	                // look at phylogeny nodes here. So, let's filter down to named
+	                // individuals that are asserted to be cdao:Nodes.
+	                .filter(indiv -> EntitySearcher.getTypes(indiv, ontology).anyMatch(
+	                    type -> (!type.getClassExpressionType().equals(ClassExpressionType.OWL_CLASS)) ||
+	                			type.asOWLClass().getIRI().equals(PhylorefHelper.IRI_CDAO_NODE)
+	                ))
+	                .collect(Collectors.toSet());
+                ;
             } else {
                 // No reasoner? We can also determine which nodes have been directly stated to
                 // be members of this phyloref as a class. This allows us to read a pre-reasoned

--- a/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
@@ -12,6 +12,7 @@ import org.semanticweb.owlapi.model.OWLEntity;
 import org.semanticweb.owlapi.model.OWLLiteral;
 import org.semanticweb.owlapi.model.OWLNamedIndividual;
 import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.search.EntitySearcher;
 import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
 
 /**
@@ -89,8 +90,9 @@ public final class OWLHelper {
         Map<String, Set<String>> valuesByLanguage = new HashMap<>();
 
         // Go through all known annotations, looking for OWLLiterals.
-        for (OWLAnnotation annotation : entity.getAnnotations(ontology, annotationProperty)) {
-            if (annotation.getValue() instanceof OWLLiteral) {
+        EntitySearcher.getAnnotations(entity, ontology, annotationProperty)
+            .filter(annotation -> annotation.getValue() instanceof OWLLiteral)
+            .forEach(annotation -> {
                 OWLLiteral val = (OWLLiteral) annotation.getValue();
                 String lang = val.getLang();
 
@@ -100,8 +102,7 @@ public final class OWLHelper {
                 }
 
                 valuesByLanguage.get(lang).add(val.getLiteral());
-            }
-        }
+            });
 
         return valuesByLanguage;
     }

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -23,6 +23,9 @@ import org.semanticweb.owlapi.reasoner.OWLReasoner;
  */
 public class PhylorefHelper {
     // IRIs used in this package.
+    
+    /** IRI for OWL class Phylogeny */
+    public static final IRI IRI_CDAO_NODE = IRI.create("http://purl.obolibrary.org/obo/CDAO_0000140");
 
     /** IRI for OWL class Phyloreference */
     public static final IRI IRI_PHYLOREFERENCE = IRI.create("http://phyloinformatics.net/phyloref.owl#Phyloreference");


### PR DESCRIPTION
Upgrading JFact to 5.0.1 allows us to use a more recent reasoner, which appears to work faster for some phyloreferences and has better error reporting. It also upgrades the version of the OWL API we use from 1.2.4 to 5.0.4, which required some code changes for the new API.

Note that JFact 5.0.1 can't reason over the current Phyloref ontology; it should be able to do so once phyloref/phyloref-ontology#19 has been merged.