### PR TITLE
Added a "webserver" command that provides an HTTP API for reasoning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,20 @@
             <artifactId>tap4j</artifactId>
             <version>4.2.1</version>
         </dependency>
+
+        <!-- For creating a webserver -->
+        <dependency>
+          	<groupId>org.nanohttpd</groupId>
+          	<artifactId>nanohttpd</artifactId>
+          	<version>2.3.1</version>
+        </dependency>
+
+        <!-- For reading and writing JSON-LD -->
+        <dependency>
+    		    <groupId>com.github.jsonld-java</groupId>
+    		    <artifactId>jsonld-java</artifactId>
+    		    <version>0.12.0</version>
+    		</dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,20 @@
           	<version>2.3.1</version>
         </dependency>
 
+        <!-- For writing JSONLD -->
+        <!-- https://mvnrepository.com/artifact/org.json/json -->
+    		<dependency>
+    		    <groupId>org.json</groupId>
+    		    <artifactId>json</artifactId>
+    		    <version>20180130</version>
+    		</dependency>
+
         <!-- For reading and writing JSON-LD -->
         <dependency>
-    		    <groupId>com.github.jsonld-java</groupId>
-    		    <artifactId>jsonld-java</artifactId>
-    		    <version>0.12.0</version>
-    		</dependency>
+          	<groupId>org.apache.commons</groupId>
+          	<artifactId>commons-rdf-jsonld-java</artifactId>
+          	<version>0.5.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
           	<version>2.3.1</version>
         </dependency>
 
-        <!-- For writing JSONLD -->
+        <!-- For writing JSON -->
         <!-- https://mvnrepository.com/artifact/org.json/json -->
     		<dependency>
     		    <groupId>org.json</groupId>
@@ -58,11 +58,20 @@
     		</dependency>
 
         <!-- For reading and writing JSON-LD -->
+        <!-- https://mvnrepository.com/artifact/org.eclipse.rdf4j/rdf4j-rio-jsonld -->
         <dependency>
-          	<groupId>org.apache.commons</groupId>
-          	<artifactId>commons-rdf-jsonld-java</artifactId>
-          	<version>0.5.0</version>
+    		    <groupId>org.eclipse.rdf4j</groupId>
+    		    <artifactId>rdf4j-rio-jsonld</artifactId>
+    		    <version>2.3.2</version>
+            <scope>runtime</scope>
         </dependency>
+
+      	<dependency>
+      	    <groupId>org.eclipse.rdf4j</groupId>
+      	    <artifactId>rdf4j-rio-api</artifactId>
+      	    <version>2.3.2</version>
+      	</dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -10,6 +10,7 @@ import org.apache.commons.cli.ParseException;
 import org.phyloref.jphyloref.commands.Command;
 import org.phyloref.jphyloref.commands.ReasonCommand;
 import org.phyloref.jphyloref.commands.TestCommand;
+import org.phyloref.jphyloref.commands.WebserverCommand;
 import org.semanticweb.owlapi.util.VersionInfo;
 
 /**
@@ -26,6 +27,7 @@ public class JPhyloRef {
     private List<Command> commands = Arrays.asList(
         new HelpCommand(),
         new TestCommand(),
+        new WebserverCommand(),
         new ReasonCommand()
     );
 

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -39,6 +39,7 @@ import org.semanticweb.owlapi.util.VersionInfo;
 
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.NanoHTTPD.Response.Status;
+import fi.iki.elonen.NanoHTTPD.Response.IStatus;
 import uk.ac.manchester.cs.jfact.JFactReasoner;
 import uk.ac.manchester.cs.jfact.kernel.options.JFactReasonerConfiguration;
 
@@ -370,6 +371,18 @@ public class WebserverCommand implements Command {
     }
 
     /**
+     * Set up some common items when communicating with a browser.
+     */
+    public Response createResponse(IStatus status, JSONObject result) {
+      Response response = newFixedLengthResponse(status, "application/json", result.toString());
+
+      // Indicate that any resource can access this resource.
+      response.addHeader("Access-Control-Allow-Origin", "*");
+
+      return response;
+    }
+
+    /**
      * Respond to a request sent to this webserver.
      */
   	@Override
@@ -408,20 +421,20 @@ public class WebserverCommand implements Command {
 
 				// We have a readable file! But is it JSON-LD?
 				try {
-          return newFixedLengthResponse(Status.OK, "application/json", serveReason(jsonldFile).toString());
+          return createResponse(Status.OK, serveReason(jsonldFile));
 				} catch (OWLOntologyCreationException | IOException ex) {
 					response.put("status", "error");
 					response.put("error", "Exception thrown: " + ex.getMessage());
 					ex.printStackTrace();
-					return newFixedLengthResponse(Status.INTERNAL_ERROR, "application/json", response.toString());
+					return createResponse(Status.INTERNAL_ERROR, response);
 				}
 
 			} else if(path.equals("/version")) {
-      	return newFixedLengthResponse(Status.OK, "application/json", serveVersion().toString());
+      	return createResponse(Status.OK, serveVersion());
   		} else {
   			response.put("status", "error");
   			response.put("error", "Path '" + path + "' could not be found.");
-  			return newFixedLengthResponse(Status.NOT_FOUND, "application/json", response.toString());
+  			return createResponse(Status.NOT_FOUND, response);
   		}
   	}
   }

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -11,6 +11,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
+import org.json.JSONObject;
+import org.phyloref.jphyloref.JPhyloRef;
 import org.phyloref.jphyloref.helpers.OWLHelper;
 import org.phyloref.jphyloref.helpers.PhylorefHelper;
 import org.semanticweb.owlapi.apibinding.OWLManager;
@@ -35,6 +37,7 @@ import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.reasoner.BufferingMode;
 import org.semanticweb.owlapi.search.EntitySearcher;
 import org.semanticweb.owlapi.util.AutoIRIMapper;
+import org.semanticweb.owlapi.util.VersionInfo;
 import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
 import org.tap4j.model.Comment;
 import org.tap4j.model.Directive;
@@ -116,7 +119,20 @@ public class WebserverCommand implements Command {
 
       		System.out.println(">> Request received to '" + path + "': " + params);
 
-      		return newFixedLengthResponse(Status.NOT_FOUND, "text/plain", "There is no resource at '" + path + "'\n");
+  			  JSONObject response = new JSONObject("{'status': 'ok'}");
+
+      		if(path.equals("/version")) {
+        			String owlapiVersion = VersionInfo.getVersionInfo().getVersion();
+
+        			response.put("name", "JPhyloRef/" + JPhyloRef.VERSION + " OWLAPI/" + owlapiVersion);
+        			response.put("version", JPhyloRef.VERSION);
+        			response.put("owlapiVersion", owlapiVersion);
+        			return newFixedLengthResponse(Status.OK, "application/json", response.toString());
+      		} else {
+        			response.put("status", "error");
+        			response.put("error", "Path '" + path + "' could not be found.");
+        			return newFixedLengthResponse(Status.NOT_FOUND, "application/json", response.toString());
+      		}
     	}
     }
 

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -300,6 +300,9 @@ public class WebserverCommand implements Command {
       });
 
       // Setup ready; parse the file!
+      // We could jsonldFile.toURI().toString() as the file IRI, but this points
+      // to a temporary file on the server where the JSON-LD file was stored by
+      // NanoHTTPD.
       parser.parse(new FileReader(jsonldFile), "http://example.org/jphyloref#");
       response.put("ontology", ontology.toString());
 

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -94,7 +94,7 @@ public class WebserverCommand implements Command {
     );
     opts.addOption(
       "p", "port", true,
-      "The TCP port to listen to HTTP connections on (default: 8080)"
+      "The TCP port to listen to HTTP connections on (default: 34214)"
     );
   }
 
@@ -106,7 +106,7 @@ public class WebserverCommand implements Command {
   @Override
   public void execute(CommandLine cmdLine) throws RuntimeException {
       String hostname = cmdLine.getOptionValue("host", "localhost");
-      String portString = cmdLine.getOptionValue("port", "8080");
+      String portString = cmdLine.getOptionValue("port", "34214");
       int port = Integer.parseInt(portString);
 
       try {

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -1,0 +1,141 @@
+package org.phyloref.jphyloref.commands;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.phyloref.jphyloref.helpers.OWLHelper;
+import org.phyloref.jphyloref.helpers.PhylorefHelper;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.AxiomType;
+import org.semanticweb.owlapi.model.ClassExpressionType;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnnotation;
+import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
+import org.semanticweb.owlapi.model.OWLAnonymousIndividual;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLClassAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLDataProperty;
+import org.semanticweb.owlapi.model.OWLDataPropertyAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLNamedIndividual;
+import org.semanticweb.owlapi.model.OWLObjectProperty;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.reasoner.BufferingMode;
+import org.semanticweb.owlapi.search.EntitySearcher;
+import org.semanticweb.owlapi.util.AutoIRIMapper;
+import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
+import org.tap4j.model.Comment;
+import org.tap4j.model.Directive;
+import org.tap4j.model.Plan;
+import org.tap4j.model.TestResult;
+import org.tap4j.model.TestSet;
+import org.tap4j.producer.TapProducer;
+import org.tap4j.producer.TapProducerFactory;
+import org.tap4j.util.DirectiveValues;
+import org.tap4j.util.StatusValues;
+import uk.ac.manchester.cs.jfact.JFactReasoner;
+import uk.ac.manchester.cs.jfact.kernel.options.JFactReasonerConfiguration;
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.Response.Status;
+
+/**
+ * Sets up a webserver that allows reasoning over phyloreferences
+ * over HTTP.
+ *
+ * @author Gaurav Vaidya <gaurav@ggvaidya.com>
+ *
+ */
+public class WebserverCommand implements Command {
+    /**
+     * This command is named "webserver". It should be
+     * invoked as "java -jar jphyloref.jar webserver ..."
+     */
+    @Override
+    public String getName() {
+        return "webserver";
+    }
+
+    /**
+     * A description of the Webserver command.
+     *
+     * @return A description of this command.
+     */
+    @Override
+    public String getDescription() {
+        return "Set up a webserver to allow reasoning of phyloreferences over HTTP.";
+    }
+
+    /**
+     * Add command-line options specific to this command.
+     *
+     * @param opts The command-line options to modify for this command.
+     */
+    @Override
+    public void addCommandLineOptions(Options opts) {
+        opts.addOption(
+            "h", "host", true,
+            "The hostname to listen to HTTP connections on (default: 'localhost')"
+        );
+        opts.addOption(
+            "p", "port", true,
+            "The TCP port to listen to HTTP connections on (default: 8080)"
+        );
+    }
+
+    /**
+     * The webserver we set up.
+     */
+    class Webserver extends fi.iki.elonen.NanoHTTPD {
+    	private final WebserverCommand cmd;
+
+    	public Webserver(WebserverCommand cmd, String hostname, int port) throws IOException {
+      		super(hostname, port);
+
+      		this.cmd = cmd;
+
+      		start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
+      		System.out.println("Webserver started. Try accessing it at http://" + hostname + ":" + port + "/");
+    	}
+
+    	@Override
+    	public Response serve(IHTTPSession session) {
+      		String path = session.getUri();
+      		Map<String, List<String>> params = session.getParameters();
+
+      		System.out.println(">> Request received to '" + path + "': " + params);
+
+      		return newFixedLengthResponse(Status.NOT_FOUND, "text/plain", "There is no resource at '" + path + "'\n");
+    	}
+    }
+
+    /**
+     * Set up a webserver to listen on the provided hostname and port (or their defaults).
+     *
+     * @param cmdLine The command line options provided to this command.
+     */
+    @Override
+    public void execute(CommandLine cmdLine) throws RuntimeException {
+        String hostname = cmdLine.getOptionValue("host", "localhost");
+        String portString = cmdLine.getOptionValue("port", "8080");
+        int port = Integer.parseInt(portString);
+
+        try {
+          	Webserver webserver = new Webserver(this, hostname, port);
+          	while(webserver.isAlive()) {}
+        } catch(IOException ex) {
+            System.err.println("An error occurred while running webserver: " + ex);
+        }
+    }
+}

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -110,8 +110,8 @@ public class WebserverCommand implements Command {
       int port = Integer.parseInt(portString);
 
       try {
-        	Webserver webserver = new Webserver(this, hostname, port);
-        	while(webserver.isAlive()) {}
+          Webserver webserver = new Webserver(this, hostname, port);
+          while(webserver.isAlive()) {}
       } catch(IOException ex) {
           System.err.println("An error occurred while running webserver: " + ex);
       }
@@ -125,7 +125,7 @@ public class WebserverCommand implements Command {
      * We keep a copy of the WebserverCommand that invoked us, although we
      * don't use this for now.
      */
-  	private final WebserverCommand cmd;
+    private final WebserverCommand cmd;
 
     /**
      * Create and start the webserver. It starts in another thread, so
@@ -135,14 +135,14 @@ public class WebserverCommand implements Command {
      * @param hostname The hostname under which this webserver should listen.
      * @param port The port this webserver should listen to.
      */
-  	public Webserver(WebserverCommand cmd, String hostname, int port) throws IOException {
-  		super(hostname, port);
+    public Webserver(WebserverCommand cmd, String hostname, int port) throws IOException {
+      super(hostname, port);
 
-  		this.cmd = cmd;
+      this.cmd = cmd;
 
-  		start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
-  		System.out.println("Webserver started. Try accessing it at http://" + hostname + ":" + port + "/");
-  	}
+      start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
+      System.out.println("Webserver started. Try accessing it at http://" + hostname + ":" + port + "/");
+    }
 
     /**
      * Respond to a request for reasoning over a JSON-LD file (/reason).
@@ -386,35 +386,35 @@ public class WebserverCommand implements Command {
     /**
      * Respond to a request sent to this webserver.
      */
-  	@Override
-  	public Response serve(IHTTPSession session) {
-  		// Look for web forms in the body of the HTTP request.
-  		Map<String, String> files = new HashMap<>();
-  		if(session.getMethod().equals(Method.PUT) || session.getMethod().equals(Method.POST)) {
-  			try {
-  				session.parseBody(files);
-  			} catch(IOException ex) {
-  				return newFixedLengthResponse(Response.Status.INTERNAL_ERROR, MIME_PLAINTEXT, "Server threw IOException: " + ex);
-  			} catch(ResponseException re) {
-  				return newFixedLengthResponse(re.getStatus(), MIME_PLAINTEXT, re.getMessage());
-  			}
-  		}
+    @Override
+    public Response serve(IHTTPSession session) {
+      // Look for web forms in the body of the HTTP request.
+      Map<String, String> files = new HashMap<>();
+      if(session.getMethod().equals(Method.PUT) || session.getMethod().equals(Method.POST)) {
+        try {
+          session.parseBody(files);
+        } catch(IOException ex) {
+          return newFixedLengthResponse(Response.Status.INTERNAL_ERROR, MIME_PLAINTEXT, "Server threw IOException: " + ex);
+        } catch(ResponseException re) {
+          return newFixedLengthResponse(re.getStatus(), MIME_PLAINTEXT, re.getMessage());
+        }
+      }
 
       // Errors after this point respond with a JSON object.
       JSONObject response = new JSONObject("{'status': 'ok'}");
 
-  		// Get path and parameters.
-  		String path = session.getUri();
-  		Map<String, List<String>> params = session.getParameters();
+      // Get path and parameters.
+      String path = session.getUri();
+      Map<String, List<String>> params = session.getParameters();
 
-  		System.out.println(">> Request received to '" + path + "': " + params);
+      System.out.println(">> Request received to '" + path + "': " + params);
 
-			if(path.equals("/reason")) {
+      if(path.equals("/reason")) {
         // We accept two kinds of inputs:
         //  1. A form containing 'jsonld' as a JSON-LD string to process.
         //  2. A form containing 'jsonldFile' as a JSON-LD file to read.
         String filename;
-				File jsonldFile;
+        File jsonldFile;
 
         try {
           if(params.containsKey("jsonldFile")) {
@@ -429,25 +429,25 @@ public class WebserverCommand implements Command {
 
           } else {
             response.put("status", "error");
-  					response.put("error", "Expected a form with a file upload in the 'jsonldFile' field or a JSON-LD string in the 'jsonld' field, but no such field was found");
+            response.put("error", "Expected a form with a file upload in the 'jsonldFile' field or a JSON-LD string in the 'jsonld' field, but no such field was found");
             return createResponse(Status.BAD_REQUEST, response);
           }
 
           return createResponse(Status.OK, serveReason(jsonldFile));
-				} catch (OWLOntologyCreationException | IOException ex) {
-					response.put("status", "error");
-					response.put("error", "Exception thrown: " + ex.getMessage());
-					ex.printStackTrace();
-					return createResponse(Status.INTERNAL_ERROR, response);
-				}
+        } catch (OWLOntologyCreationException | IOException ex) {
+          response.put("status", "error");
+          response.put("error", "Exception thrown: " + ex.getMessage());
+          ex.printStackTrace();
+          return createResponse(Status.INTERNAL_ERROR, response);
+        }
 
-			} else if(path.equals("/version")) {
-      	return createResponse(Status.OK, serveVersion());
-  		} else {
-  			response.put("status", "error");
-  			response.put("error", "Path '" + path + "' could not be found.");
-  			return createResponse(Status.NOT_FOUND, response);
-  		}
-  	}
+      } else if(path.equals("/version")) {
+        return createResponse(Status.OK, serveVersion());
+      } else {
+        response.put("status", "error");
+        response.put("error", "Path '" + path + "' could not be found.");
+        return createResponse(Status.NOT_FOUND, response);
+      }
+    }
   }
 }


### PR DESCRIPTION
Added a "webserver" command that starts a webserver which provides an HTTP API for reasoning over JSON-LD files. These files are internally converted into OWL Ontologies and reasoned over, and then the results are provided in JSON as a dictionary of phyloreference IRIs along with lists of node IRIs they resolved to.

This pull request also cleans up some Eclipse files that shouldn't have been included in the first place.

**Ready for review!**