### PR TITLE
Refactored Phyloref status checking code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 - Added a "webserver" command that starts a webserver that provides a simple
   HTTP API for reasoning over JSON-LD file in [phyloref/jphyloref#12].
 - Removed Eclipse files that should not have been added in [phyloref/jphyloref#13].
+- Moved code for determining Phyloref statuses to PhylorefHelper. This is part of
+  [phyloref/jphyloref#8].
 
 ## 0.2 - 2018-06-20
 - Added support for phyloreference statuses using the Publication Status Ontology
@@ -23,3 +25,4 @@ Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 [phyloref/curation-tool#25]: https://github.com/phyloref/curation-tool/issues/25
 [phyloref/jphyloref#13]: https://github.com/phyloref/jphyloref/pull/13
 [phyloref/jphyloref#12]: https://github.com/phyloref/jphyloref/pull/12
+[phyloref/jphyloref#8]: https://github.com/phyloref/jphyloref/issues/8

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -331,13 +331,13 @@ public class TestCommand implements Command {
             if(activeStatuses.isEmpty())
               flag_expected_to_resolve = true;
             else
-              // If there are active statuses, we default to assuming that we expect phyloreferences NOT to resolve,
-              // unless they are actively in the "submitted" or "published" statuses.
-              flag_expected_to_resolve = activeStatuses.stream()
-                .anyMatch(ps ->
-                  ps.getStatus().equals(PhylorefHelper.IRI_PSO_STATUS_SUBMITTED) ||
-                  ps.getStatus().equals(PhylorefHelper.IRI_PSO_PUBLISHED)
-                );
+            	// If there are active statuses, we default to assuming that we expect phyloreferences NOT to resolve,
+            	// unless they are actively in the "submitted" or "published" statuses.
+            	flag_expected_to_resolve = activeStatuses.stream()
+            	  .anyMatch(ps ->
+            		  ps.getStatus().equals(PhylorefHelper.IRI_PSO_SUBMITTED) ||
+            		  ps.getStatus().equals(PhylorefHelper.IRI_PSO_PUBLISHED)
+            	  );
 
             // Determine if this phyloreference has failed or succeeded.
             if(testFailed) {
@@ -360,9 +360,9 @@ public class TestCommand implements Command {
                     countTODO++;
                     result.setStatus(StatusValues.NOT_OK);
                     result.setDirective(new Directive(DirectiveValues.TODO, "Phyloreference could not be tested, as one or more specifiers did not match."));
-                    if(!statuses.contains(IRI.create("http://purl.org/spar/pso/draft"))) {
+                    if(!activeStatuses.stream().anyMatch(st -> st.getStatus().equals(PhylorefHelper.IRI_PSO_DRAFT))) {
                         result.addComment(new Comment(
-                            "Since specifiers remain unmatched, this phyloreference should have a status of 'pso:draft' but instead its status is " + statuses
+                            "Since specifiers remain unmatched, this phyloreference should have a status of 'pso:draft' but instead its status is " + activeStatuses
                         ));
                     }
                     testSet.addTapLine(result);

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -171,8 +171,8 @@ public class TestCommand implements Command {
         OWLAnnotationProperty pso_holdsStatusInTime = dataFactory.getOWLAnnotationProperty(IRI.create("http://purl.org/spar/pso/holdsStatusInTime"));
         OWLAnnotationProperty pso_withStatus = dataFactory.getOWLAnnotationProperty(IRI.create("http://purl.org/spar/pso/withStatus"));
         OWLAnnotationProperty tvc_atTime = dataFactory.getOWLAnnotationProperty(IRI.create("http://www.essepuntato.it/2012/04/tvc/atTime"));
-        OWLDataProperty timeinterval_hasIntervalStartDate = dataFactory.getOWLDataProperty(IRI.create("http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#hasIntervalStartDate"));
-        OWLDataProperty timeinterval_hasIntervalEndDate = dataFactory.getOWLDataProperty(IRI.create("http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#hasIntervalEndDate"));
+        OWLAnnotationProperty timeinterval_hasIntervalStartDate = dataFactory.getOWLAnnotationProperty(IRI.create("http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#hasIntervalStartDate"));
+        OWLAnnotationProperty timeinterval_hasIntervalEndDate = dataFactory.getOWLAnnotationProperty(IRI.create("http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#hasIntervalEndDate"));
 
         // Count the number of test results.
         int testNumber = 0;
@@ -341,7 +341,7 @@ public class TestCommand implements Command {
                     for(OWLAnnotationAssertionAxiom axiom: ontology.getAnnotationAssertionAxioms(indiv_statusInTime)) {
                         if(axiom.getProperty().equals(tvc_atTime)) {
                             for(OWLAnonymousIndividual indiv_atTime: axiom.getValue().getAnonymousIndividuals()) {
-                                for(OWLDataPropertyAssertionAxiom axiom_interval: ontology.getDataPropertyAssertionAxioms(indiv_atTime)) {
+                                for(OWLAnnotationAssertionAxiom axiom_interval: ontology.getAnnotationAssertionAxioms(indiv_atTime)) {
                                     // Look for timeinterval:hasIntervalStartDate and timeinterval:hasIntervalEndDate data properties.
                                     if(axiom_interval.getProperty().equals(timeinterval_hasIntervalStartDate)) {
                                         hasIntervalStartDate = true;

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -157,7 +157,7 @@ public class TestCommand implements Command {
 
         // Preload some terms we need to use in the following code.
         OWLDataFactory dataFactory = manager.getOWLDataFactory();
-        
+
         // Some classes we will use.
         OWLClass classCDAONode = dataFactory.getOWLClass(PhylorefHelper.IRI_CDAO_NODE);
 
@@ -168,11 +168,11 @@ public class TestCommand implements Command {
         // OWLDataProperty specifierDefinitionProperty = dataFactory.getOWLDataProperty(PhylorefHelper.IRI_CLADE_DEFINITION);
 
         // Terms assocated with publication status
-        OWLAnnotationProperty pso_holdsStatusInTime = dataFactory.getOWLAnnotationProperty(IRI.create("http://purl.org/spar/pso/holdsStatusInTime"));
-        OWLAnnotationProperty pso_withStatus = dataFactory.getOWLAnnotationProperty(IRI.create("http://purl.org/spar/pso/withStatus"));
-        OWLAnnotationProperty tvc_atTime = dataFactory.getOWLAnnotationProperty(IRI.create("http://www.essepuntato.it/2012/04/tvc/atTime"));
-        OWLAnnotationProperty timeinterval_hasIntervalStartDate = dataFactory.getOWLAnnotationProperty(IRI.create("http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#hasIntervalStartDate"));
-        OWLAnnotationProperty timeinterval_hasIntervalEndDate = dataFactory.getOWLAnnotationProperty(IRI.create("http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#hasIntervalEndDate"));
+        OWLAnnotationProperty pso_holdsStatusInTime = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_PSO_HOLDS_STATUS_IN_TIME);
+        OWLAnnotationProperty pso_withStatus = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_PSO_WITH_STATUS);
+        OWLAnnotationProperty tvc_atTime = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TVC_AT_TIME);
+        OWLAnnotationProperty timeinterval_hasIntervalStartDate = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TIMEINT_HAS_INTERVAL_START_DATE);
+        OWLAnnotationProperty timeinterval_hasIntervalEndDate = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TIMEINT_HAS_INTERVAL_END_DATE);
 
         // Count the number of test results.
         int testNumber = 0;

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -3,6 +3,7 @@ package org.phyloref.jphyloref.commands;
 import java.io.File;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -117,7 +118,7 @@ public class TestCommand implements Command {
         // Create File object to load
         File inputFile = new File(str_input);
         System.err.println("Input: " + inputFile);
-        
+
         // Set up an OWL Ontology Manager to work with.
         OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
 
@@ -166,13 +167,6 @@ public class TestCommand implements Command {
         OWLDataProperty expectedPhyloreferenceNamedProperty = dataFactory.getOWLDataProperty(PhylorefHelper.IRI_NAME_OF_EXPECTED_PHYLOREF);
         OWLObjectProperty unmatchedSpecifierProperty = dataFactory.getOWLObjectProperty(PhylorefHelper.IRI_PHYLOREF_UNMATCHED_SPECIFIER);
         // OWLDataProperty specifierDefinitionProperty = dataFactory.getOWLDataProperty(PhylorefHelper.IRI_CLADE_DEFINITION);
-
-        // Terms assocated with publication status
-        OWLAnnotationProperty pso_holdsStatusInTime = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_PSO_HOLDS_STATUS_IN_TIME);
-        OWLAnnotationProperty pso_withStatus = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_PSO_WITH_STATUS);
-        OWLAnnotationProperty tvc_atTime = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TVC_AT_TIME);
-        OWLAnnotationProperty timeinterval_hasIntervalStartDate = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TIMEINT_HAS_INTERVAL_START_DATE);
-        OWLAnnotationProperty timeinterval_hasIntervalEndDate = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TIMEINT_HAS_INTERVAL_END_DATE);
 
         // Count the number of test results.
         int testNumber = 0;
@@ -322,63 +316,28 @@ public class TestCommand implements Command {
                 }
             }
 
-            // Retrieve holdsStatusInTime to determine the active status of this phyloreference.
-            Set<OWLAnnotation> holdsStatusInTime = new HashSet<>(EntitySearcher.getAnnotations(phylorefAsClass, ontology, pso_holdsStatusInTime));
+            // Get a list of phyloref statuses for this phyloreference.
+            List<PhylorefHelper.PhylorefStatus> statuses = PhylorefHelper.getCurrentStatusesForPhyloref(phyloref, ontology);
 
-            // Instead of checking which time interval were are in, we take a simpler approach: we look for all
-            // statuses that have a start date but not an end date, i.e. those which have yet to end.
-            Set<IRI> statuses = new HashSet<>();
-            for(OWLAnnotation statusInTime: holdsStatusInTime) {
-                // Each statusInTime entry should have one status (pso:withStatus)
-                // and a number of time intervals (tvc:atTime). We collect all
-                // statusues and test to see if any of those time intervals are
-                // "incomplete", i.e. they have a start date but no end date.
-            	Set<IRI> currentStatuses = new HashSet<>();
-                boolean hasIntervalStartDate = false;
-                boolean hasIntervalEndDate = false;
+            // Instead of checking which time interval we are currently in, we take a simpler approach:
+            // we look for all statuses asserted to be "active", i.e. those with a start time but no end time.
+            boolean flag_expected_to_resolve = false;
 
-            	for(OWLAnonymousIndividual indiv_statusInTime: statusInTime.getAnonymousIndividuals()) {
-                    for(OWLAnnotationAssertionAxiom axiom: ontology.getAnnotationAssertionAxioms(indiv_statusInTime)) {
-                        if(axiom.getProperty().equals(tvc_atTime)) {
-                            for(OWLAnonymousIndividual indiv_atTime: axiom.getValue().getAnonymousIndividuals()) {
-                                for(OWLAnnotationAssertionAxiom axiom_interval: ontology.getAnnotationAssertionAxioms(indiv_atTime)) {
-                                    // Look for timeinterval:hasIntervalStartDate and timeinterval:hasIntervalEndDate data properties.
-                                    if(axiom_interval.getProperty().equals(timeinterval_hasIntervalStartDate)) {
-                                        hasIntervalStartDate = true;
-                                    }
-                                    if(axiom_interval.getProperty().equals(timeinterval_hasIntervalEndDate)) {
-                                        hasIntervalEndDate = true;
-                                    }
-                                }
-                            }
-                        }
+            List<PhylorefHelper.PhylorefStatus> activeStatuses = statuses.stream()
+              .filter(ps -> ps.getIntervalStart() != null && ps.getIntervalEnd() == null)
+              .collect(Collectors.toList());
 
-                        else if(axiom.getProperty().equals(pso_withStatus)) {
-                            currentStatuses.add((IRI)axiom.getValue());
-                        } else {
-                            System.err.println("Unknown axiom: " + axiom);
-                            System.exit(-1);
-                        }
-                    }
-            	}
-
-                // Did the current statuses have a start date but no end date, i.e. are they currently active?
-                if(hasIntervalStartDate && !hasIntervalEndDate) {
-                    statuses.addAll(currentStatuses);
-                }
-            }
-
-            // System.err.println("Active statuses: " + statuses);
-
-            // Based on the phyloreference status, we can determine whether or not
-            // we expect the phyloreference to actually resolve: we do if there
-            // were no statuses, or if the statuses include submitted or published.
-            // In all other cases, we're not expecting the phyloreference to resolve.
-            boolean flag_expected_to_resolve = (
-                statuses.isEmpty() ||
-                statuses.contains(IRI.create("http://purl.org/spar/pso/submitted")) ||
-                statuses.contains(IRI.create("http://purl.org/spar/pso/published"))
-            );
+            // If there are no active statuses, we default to assuming that we expect phyloreferences to resolve.
+            if(activeStatuses.isEmpty())
+              flag_expected_to_resolve = true;
+            else
+              // If there are active statuses, we default to assuming that we expect phyloreferences NOT to resolve,
+              // unless they are actively in the "submitted" or "published" statuses.
+              flag_expected_to_resolve = activeStatuses.stream()
+                .anyMatch(ps ->
+                  ps.getStatus().equals(PhylorefHelper.IRI_PSO_STATUS_SUBMITTED) ||
+                  ps.getStatus().equals(PhylorefHelper.IRI_PSO_PUBLISHED)
+                );
 
             // Determine if this phyloreference has failed or succeeded.
             if(testFailed) {

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -74,9 +74,10 @@ public class PhylorefHelper {
 
     /** IRI for the publication status of "Submitted" */
     public static final IRI IRI_PSO_SUBMITTED = IRI.create("http://purl.org/spar/pso/submitted");
+
     /** IRI for the publication status of "Published" */
     public static final IRI IRI_PSO_PUBLISHED = IRI.create("http://purl.org/spar/pso/published");
-    
+
     /**
      * Get a list of phyloreferences in this ontology without reasoning. This method does not use
      * the reasoner, and so will only find individuals asserted to have a type
@@ -136,154 +137,152 @@ public class PhylorefHelper {
         OWLClass phyloref_Phyloreference = set_phyloref_Phyloreference.iterator().next().asOWLClass();
         return reasoner.getInstances(phyloref_Phyloreference, true).getFlattened();
     }
-    
+
     /**
      * A wrapper for a phyloref status at a particular point in time.
      */
     public static class PhylorefStatus {
-    	private OWLNamedIndividual phyloref;
-    	private IRI statusIRI;
-    	private Instant intervalStart;
-    	private Instant intervalEnd;
-    	
-    	/**
-    	 * Create a PhylorefStatus. All arguments except status are optional, and may be null.
-    	 * 
-    	 * @param phyloref The phyloreference containing this status.
-    	 * @param status The status of this phyloreference, as an individual in the class http://purl.org/spar/pso/PublicationStatus. Required.
-    	 * @param intervalStart The interval at which this status starts.
-    	 * @param intervalEnd The interval at which this status ends. May be null if this status hasn't ended yet.
-    	 */
-    	public PhylorefStatus(OWLNamedIndividual phyloref, IRI status, Instant intervalStart, Instant intervalEnd) {
-    		this.phyloref = phyloref;
-    		this.statusIRI = status;
-    		this.intervalStart = intervalStart;
-    		this.intervalEnd = intervalEnd;
-    		
-    		if(status == null) throw new IllegalArgumentException("No status provided to PhylorefStatus, which is a required argument");
-    	}
-    	
-    	/**
-    	 * @return the phyloreference this status is associated with. May be null.
-    	 */
-    	public OWLNamedIndividual getPhyloref() {
-    		return phyloref;
-    	}
-    	
-    	/**
-    	 * @return the status of this phyloreference, as an individual in the class http://purl.org/spar/pso/PublicationStatus
-    	 */
-    	public IRI getStatus() {
-    		return statusIRI;
-    	}
-    	
-    	/**
-    	 * @return the interval at which this status starts.
-    	 */
-    	public Instant getIntervalStart() {
-    		return intervalStart;
-    	}
-    	
-    	/**
-    	 * @return the interval at which this status ends. May be null if this status hasn't ended yet.
-    	 */
-    	public Instant getIntervalEnd() {
-    		return intervalEnd;
-    	}
-    	
-    	/**
-    	 * @return a String representation of this phyloref status
-    	 */
-    	@Override
-    	public String toString() {
-    		StringBuffer statusString = new StringBuffer("phyloreference status " + statusIRI);
-    		
-    		if(getIntervalStart() != null) statusString.append(" starting at " + getIntervalStart().toString());
-    		if(getIntervalEnd() != null) statusString.append(" ending at " + getIntervalEnd().toString());
-    		
-    		return statusString.toString();
-    	}
+      private OWLNamedIndividual phyloref;
+      private IRI statusIRI;
+      private Instant intervalStart;
+      private Instant intervalEnd;
+
+      /**
+       * Create a PhylorefStatus. All arguments except status are optional, and may be null.
+       *
+       * @param phyloref The phyloreference containing this status.
+       * @param status The status of this phyloreference, as an individual in the class http://purl.org/spar/pso/PublicationStatus. Required.
+       * @param intervalStart The interval at which this status starts.
+       * @param intervalEnd The interval at which this status ends. May be null if this status hasn't ended yet.
+       */
+      public PhylorefStatus(OWLNamedIndividual phyloref, IRI status, Instant intervalStart, Instant intervalEnd) {
+        this.phyloref = phyloref;
+        this.statusIRI = status;
+        this.intervalStart = intervalStart;
+        this.intervalEnd = intervalEnd;
+
+        if(status == null) throw new IllegalArgumentException("No status provided to PhylorefStatus, which is a required argument");
+      }
+
+      /**
+       * @return the phyloreference this status is associated with. May be null.
+       */
+      public OWLNamedIndividual getPhyloref() {
+        return phyloref;
+      }
+
+      /**
+       * @return the status of this phyloreference, as an individual in the class http://purl.org/spar/pso/PublicationStatus
+       */
+      public IRI getStatus() {
+        return statusIRI;
+      }
+
+      /**
+       * @return the interval at which this status starts.
+       */
+      public Instant getIntervalStart() {
+        return intervalStart;
+      }
+
+      /**
+       * @return the interval at which this status ends. May be null if this status hasn't ended yet.
+       */
+      public Instant getIntervalEnd() {
+        return intervalEnd;
+      }
+
+      /**
+       * @return a String representation of this phyloref status
+       */
+      @Override
+      public String toString() {
+        StringBuffer statusString = new StringBuffer("phyloreference status " + statusIRI);
+
+        if(getIntervalStart() != null) statusString.append(" starting at " + getIntervalStart().toString());
+        if(getIntervalEnd() != null) statusString.append(" ending at " + getIntervalEnd().toString());
+
+        return statusString.toString();
+      }
     }
-    
+
     /**
      * Return a list of PhylorefStatuses associated with a particular phyloreference in the provided ontology.
-     * 
+     *
      * @param phyloref The phyloreference whose statuses are being queried.
      * @param ontology The ontology within which this phyloreference is defined.
      * @return A list of phyloref statuses.
      */
-	public static List<PhylorefStatus> getCurrentStatusesForPhyloref(OWLNamedIndividual phyloref, OWLOntology ontology) {
-		List<PhylorefStatus> statuses = new ArrayList<>();
-		
-		// Set up the OWL annotation properties we need to look up the phyloref statuses.
-		OWLDataFactory dataFactory = ontology.getOWLOntologyManager().getOWLDataFactory();
-		OWLClass phylorefAsClass = dataFactory.getOWLClass(phyloref.getIRI());
-		
-        OWLAnnotationProperty pso_holdsStatusInTime = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_PSO_HOLDS_STATUS_IN_TIME);
-        OWLAnnotationProperty pso_withStatus = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_PSO_WITH_STATUS);
-        OWLAnnotationProperty tvc_atTime = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TVC_AT_TIME);
-        OWLAnnotationProperty timeinterval_hasIntervalStartDate = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TIMEINT_HAS_INTERVAL_START_DATE);
-        OWLAnnotationProperty timeinterval_hasIntervalEndDate = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TIMEINT_HAS_INTERVAL_END_DATE);
+    public static List<PhylorefStatus> getCurrentStatusesForPhyloref(OWLNamedIndividual phyloref, OWLOntology ontology) {
+      List<PhylorefStatus> statuses = new ArrayList<>();
 
-		// Retrieve holdsStatusInTime to determine the active status of this phyloreference.
-		List<OWLAnnotation> holdsStatusInTime = EntitySearcher.getAnnotations(phylorefAsClass, ontology, pso_holdsStatusInTime).collect(Collectors.toList());
+      // Set up the OWL annotation properties we need to look up the phyloref statuses.
+      OWLDataFactory dataFactory = ontology.getOWLOntologyManager().getOWLDataFactory();
+      OWLClass phylorefAsClass = dataFactory.getOWLClass(phyloref.getIRI());
 
-		// Read through the list of OWLAnnotations to create corresponding PhylorefStatus objects.
-		for(OWLAnnotation statusInTime: holdsStatusInTime) {
-		    // Each statusInTime entry should have one status (pso:withStatus)
-		    // and a number of time intervals (tvc:atTime). We collect all
-		    // statusues and test to see if any of those time intervals are
-		    // "incomplete", i.e. they have a start date but no end date.
-			IRI phylorefStatusIRI = null;
-			Instant intervalStartDate = null;
-			Instant intervalEndDate = null;
-			
-			for(OWLAnonymousIndividual indiv_statusInTime: statusInTime.getAnonymousIndividuals()) {
-		        for(OWLAnnotationAssertionAxiom axiom: ontology.getAnnotationAssertionAxioms(indiv_statusInTime)) {
-		            if(axiom.getProperty().equals(tvc_atTime)) {
-		                for(OWLAnonymousIndividual indiv_atTime: axiom.getValue().getAnonymousIndividuals()) {
-		                    for(OWLAnnotationAssertionAxiom axiom_interval: ontology.getAnnotationAssertionAxioms(indiv_atTime)) {
-		                        // Look for timeinterval:hasIntervalStartDate and timeinterval:hasIntervalEndDate data properties.
-		                        if(axiom_interval.getProperty().equals(timeinterval_hasIntervalStartDate)) {
-		                        	try {
-			                        	intervalStartDate = ZonedDateTime.parse(
-			                        		axiom_interval.getValue().asLiteral().get().getLiteral()
-			                        	).toInstant();
-		                        	} catch(DateTimeParseException ex) {
-		                        		// If we have a start date but can't parse it, record it as the earliest possible time.
-		                        		intervalStartDate = Instant.MIN;
-		                        	}
-		                        }
-		                        if(axiom_interval.getProperty().equals(timeinterval_hasIntervalEndDate)) {
-		                        	try {
-			                            intervalEndDate = ZonedDateTime.parse(
-		                            		axiom_interval.getValue().asLiteral().get().getLiteral()
-			                        	).toInstant();
-		                        	} catch(DateTimeParseException ex) {
-		                        		// If we have an end date but can't parse it, record it at the latest possible time.
-		                        		intervalEndDate = Instant.MAX;
-		                        	}
-		                        }
-		                    }
-		                }
-		            }
+      OWLAnnotationProperty pso_holdsStatusInTime = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_PSO_HOLDS_STATUS_IN_TIME);
+      OWLAnnotationProperty pso_withStatus = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_PSO_WITH_STATUS);
+      OWLAnnotationProperty tvc_atTime = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TVC_AT_TIME);
+      OWLAnnotationProperty timeinterval_hasIntervalStartDate = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TIMEINT_HAS_INTERVAL_START_DATE);
+      OWLAnnotationProperty timeinterval_hasIntervalEndDate = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TIMEINT_HAS_INTERVAL_END_DATE);
 
-		            else if(axiom.getProperty().equals(pso_withStatus)) {
-		            	phylorefStatusIRI = (IRI) axiom.getValue();
-		            } else {
-		                throw new IllegalArgumentException("Phyloreference " + phyloref + " contains an unknown axiom: " + axiom);
-		            }
-		        }
-			}
-			
-			statuses.add(new PhylorefHelper.PhylorefStatus(
-				phyloref,
-				phylorefStatusIRI,
-				intervalStartDate,
-				intervalEndDate
-			));
-		}
-		
-		return statuses;
-	}
+      // Retrieve holdsStatusInTime to determine the active status of this phyloreference.
+      List<OWLAnnotation> holdsStatusInTime = EntitySearcher.getAnnotations(phylorefAsClass, ontology, pso_holdsStatusInTime).collect(Collectors.toList());
+
+      // Read through the list of OWLAnnotations to create corresponding PhylorefStatus objects.
+      for(OWLAnnotation statusInTime: holdsStatusInTime) {
+        // Each statusInTime entry should have one status (pso:withStatus)
+        // and a number of time intervals (tvc:atTime). We collect all
+        // statusues and test to see if any of those time intervals are
+        // "incomplete", i.e. they have a start date but no end date.
+        IRI phylorefStatusIRI = null;
+        Instant intervalStartDate = null;
+        Instant intervalEndDate = null;
+
+        for(OWLAnonymousIndividual indiv_statusInTime: statusInTime.getAnonymousIndividuals()) {
+          for(OWLAnnotationAssertionAxiom axiom: ontology.getAnnotationAssertionAxioms(indiv_statusInTime)) {
+            if(axiom.getProperty().equals(tvc_atTime)) {
+              for(OWLAnonymousIndividual indiv_atTime: axiom.getValue().getAnonymousIndividuals()) {
+                for(OWLAnnotationAssertionAxiom axiom_interval: ontology.getAnnotationAssertionAxioms(indiv_atTime)) {
+                  // Look for timeinterval:hasIntervalStartDate and timeinterval:hasIntervalEndDate data properties.
+                  if(axiom_interval.getProperty().equals(timeinterval_hasIntervalStartDate)) {
+                    try {
+                      intervalStartDate = ZonedDateTime.parse(
+                        axiom_interval.getValue().asLiteral().get().getLiteral()
+                      ).toInstant();
+                    } catch(DateTimeParseException ex) {
+                      // If we have a start date but can't parse it, record it as the earliest possible time.
+                      intervalStartDate = Instant.MIN;
+                    }
+                  }
+                  if(axiom_interval.getProperty().equals(timeinterval_hasIntervalEndDate)) {
+                    try {
+                      intervalEndDate = ZonedDateTime.parse(
+                        axiom_interval.getValue().asLiteral().get().getLiteral()
+                      ).toInstant();
+                    } catch(DateTimeParseException ex) {
+                      // If we have an end date but can't parse it, record it at the latest possible time.
+                      intervalEndDate = Instant.MAX;
+                    }
+                  }
+                }
+              }
+            } else if(axiom.getProperty().equals(pso_withStatus)) {
+              phylorefStatusIRI = (IRI) axiom.getValue();
+            } else {
+              throw new IllegalArgumentException("Phyloreference " + phyloref + " contains an unknown axiom: " + axiom);
+            }
+          }
+        }
+
+        statuses.add(new PhylorefHelper.PhylorefStatus(
+          phyloref,
+          phylorefStatusIRI,
+          intervalStartDate,
+          intervalEndDate
+        ));
+      }
+
+      return statuses;
+    }
 }

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -23,7 +23,7 @@ import org.semanticweb.owlapi.reasoner.OWLReasoner;
  */
 public class PhylorefHelper {
     // IRIs used in this package.
-    
+
     /** IRI for OWL class Phylogeny */
     public static final IRI IRI_CDAO_NODE = IRI.create("http://purl.obolibrary.org/obo/CDAO_0000140");
 
@@ -41,6 +41,21 @@ public class PhylorefHelper {
 
     /** IRI for the OWL data property with the verbatim clade definition */
     public static final IRI IRI_CLADE_DEFINITION = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#clade_definition");
+
+    /** IRI for the OWL object property that associates a publication with its publication status at a particular time. */
+    public static final IRI IRI_PSO_HOLDS_STATUS_IN_TIME = IRI.create("http://purl.org/spar/pso/holdsStatusInTime");
+
+    /** IRI for the OWL object property that indicates the publication status of a publication status at a particular time. */
+    public static final IRI IRI_PSO_WITH_STATUS = IRI.create("http://purl.org/spar/pso/withStatus");
+
+    /** IRI for the OWL object property that associates a publication status at a particular time with a particular time. */
+    public static final IRI IRI_TVC_AT_TIME = IRI.create("http://www.essepuntato.it/2012/04/tvc/atTime");
+
+    /** IRI for the OWL data property that indicates when a publication status time begins */
+    public static final IRI IRI_TIMEINT_HAS_INTERVAL_START_DATE = IRI.create("http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#hasIntervalStartDate");
+
+    /** IRI for the OWL data property that indicates when a publication status time ends */
+    public static final IRI IRI_TIMEINT_HAS_INTERVAL_END_DATE = IRI.create("http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#hasIntervalEndDate");
 
     /**
      * Get a list of phyloreferences in this ontology without reasoning. This method does not use
@@ -79,7 +94,7 @@ public class PhylorefHelper {
      * Get a list of phyloreferences in this ontology. This method uses the
      * reasoner, and so will find all individuals determined to be of
      * type phyloref:Phyloreference.
-     * 
+     *
      * @param ontology The OWL Ontology within with we should look for phylorefs
      * @param reasoner The reasoner to use. May be null.
      */
@@ -88,7 +103,7 @@ public class PhylorefHelper {
         // inferred to be phyloref:Phyloreference, but we can still find all
         // individuals that are stated to be phyloref:Phyloreference. So let's do that!
         if(reasoner == null) return PhylorefHelper.getPhyloreferencesWithoutReasoning(ontology);
-        
+
         // Get a list of all phyloreferences. First, we need to know what a Phyloreference is.
         Set<OWLEntity> set_phyloref_Phyloreference = ontology.getEntitiesInSignature(IRI_PHYLOREFERENCE);
         if (set_phyloref_Phyloreference.isEmpty()) {

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -69,9 +69,11 @@ public class PhylorefHelper {
     /** IRI for the OWL data property that indicates when a publication status time ends */
     public static final IRI IRI_TIMEINT_HAS_INTERVAL_END_DATE = IRI.create("http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#hasIntervalEndDate");
 
+    /** IRI for the publication status of "Draft" */
+    public static final IRI IRI_PSO_DRAFT = IRI.create("http://purl.org/spar/pso/draft");
+
     /** IRI for the publication status of "Submitted" */
-    public static final IRI IRI_PSO_STATUS_SUBMITTED = IRI.create("http://purl.org/spar/pso/submitted");
-    
+    public static final IRI IRI_PSO_SUBMITTED = IRI.create("http://purl.org/spar/pso/submitted");
     /** IRI for the publication status of "Published" */
     public static final IRI IRI_PSO_PUBLISHED = IRI.create("http://purl.org/spar/pso/published");
     

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -1,16 +1,28 @@
 package org.phyloref.jphyloref.helpers;
 
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.semanticweb.owlapi.model.AxiomType;
 import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnnotation;
+import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
+import org.semanticweb.owlapi.model.OWLAnonymousIndividual;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLClassAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLEntity;
 import org.semanticweb.owlapi.model.OWLNamedIndividual;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
+import org.semanticweb.owlapi.search.EntitySearcher;
 
 /**
  * A Phyloreference helper class. It consists of common terms and helper
@@ -57,6 +69,12 @@ public class PhylorefHelper {
     /** IRI for the OWL data property that indicates when a publication status time ends */
     public static final IRI IRI_TIMEINT_HAS_INTERVAL_END_DATE = IRI.create("http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#hasIntervalEndDate");
 
+    /** IRI for the publication status of "Submitted" */
+    public static final IRI IRI_PSO_STATUS_SUBMITTED = IRI.create("http://purl.org/spar/pso/submitted");
+    
+    /** IRI for the publication status of "Published" */
+    public static final IRI IRI_PSO_PUBLISHED = IRI.create("http://purl.org/spar/pso/published");
+    
     /**
      * Get a list of phyloreferences in this ontology without reasoning. This method does not use
      * the reasoner, and so will only find individuals asserted to have a type
@@ -116,4 +134,154 @@ public class PhylorefHelper {
         OWLClass phyloref_Phyloreference = set_phyloref_Phyloreference.iterator().next().asOWLClass();
         return reasoner.getInstances(phyloref_Phyloreference, true).getFlattened();
     }
+    
+    /**
+     * A wrapper for a phyloref status at a particular point in time.
+     */
+    public static class PhylorefStatus {
+    	private OWLNamedIndividual phyloref;
+    	private IRI statusIRI;
+    	private Instant intervalStart;
+    	private Instant intervalEnd;
+    	
+    	/**
+    	 * Create a PhylorefStatus. All arguments except status are optional, and may be null.
+    	 * 
+    	 * @param phyloref The phyloreference containing this status.
+    	 * @param status The status of this phyloreference, as an individual in the class http://purl.org/spar/pso/PublicationStatus. Required.
+    	 * @param intervalStart The interval at which this status starts.
+    	 * @param intervalEnd The interval at which this status ends. May be null if this status hasn't ended yet.
+    	 */
+    	public PhylorefStatus(OWLNamedIndividual phyloref, IRI status, Instant intervalStart, Instant intervalEnd) {
+    		this.phyloref = phyloref;
+    		this.statusIRI = status;
+    		this.intervalStart = intervalStart;
+    		this.intervalEnd = intervalEnd;
+    		
+    		if(status == null) throw new IllegalArgumentException("No status provided to PhylorefStatus, which is a required argument");
+    	}
+    	
+    	/**
+    	 * @return the phyloreference this status is associated with. May be null.
+    	 */
+    	public OWLNamedIndividual getPhyloref() {
+    		return phyloref;
+    	}
+    	
+    	/**
+    	 * @return the status of this phyloreference, as an individual in the class http://purl.org/spar/pso/PublicationStatus
+    	 */
+    	public IRI getStatus() {
+    		return statusIRI;
+    	}
+    	
+    	/**
+    	 * @return the interval at which this status starts.
+    	 */
+    	public Instant getIntervalStart() {
+    		return intervalStart;
+    	}
+    	
+    	/**
+    	 * @return the interval at which this status ends. May be null if this status hasn't ended yet.
+    	 */
+    	public Instant getIntervalEnd() {
+    		return intervalEnd;
+    	}
+    	
+    	/**
+    	 * @return a String representation of this phyloref status
+    	 */
+    	@Override
+    	public String toString() {
+    		StringBuffer statusString = new StringBuffer("phyloreference status " + statusIRI);
+    		
+    		if(getIntervalStart() != null) statusString.append(" starting at " + getIntervalStart().toString());
+    		if(getIntervalEnd() != null) statusString.append(" ending at " + getIntervalEnd().toString());
+    		
+    		return statusString.toString();
+    	}
+    }
+    
+    /**
+     * Return a list of PhylorefStatuses associated with a particular phyloreference in the provided ontology.
+     * 
+     * @param phyloref The phyloreference whose statuses are being queried.
+     * @param ontology The ontology within which this phyloreference is defined.
+     * @return A list of phyloref statuses.
+     */
+	public static List<PhylorefStatus> getCurrentStatusesForPhyloref(OWLNamedIndividual phyloref, OWLOntology ontology) {
+		List<PhylorefStatus> statuses = new ArrayList<>();
+		
+		// Set up the OWL annotation properties we need to look up the phyloref statuses.
+		OWLDataFactory dataFactory = ontology.getOWLOntologyManager().getOWLDataFactory();
+		OWLClass phylorefAsClass = dataFactory.getOWLClass(phyloref.getIRI());
+		
+        OWLAnnotationProperty pso_holdsStatusInTime = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_PSO_HOLDS_STATUS_IN_TIME);
+        OWLAnnotationProperty pso_withStatus = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_PSO_WITH_STATUS);
+        OWLAnnotationProperty tvc_atTime = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TVC_AT_TIME);
+        OWLAnnotationProperty timeinterval_hasIntervalStartDate = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TIMEINT_HAS_INTERVAL_START_DATE);
+        OWLAnnotationProperty timeinterval_hasIntervalEndDate = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TIMEINT_HAS_INTERVAL_END_DATE);
+
+		// Retrieve holdsStatusInTime to determine the active status of this phyloreference.
+		List<OWLAnnotation> holdsStatusInTime = EntitySearcher.getAnnotations(phylorefAsClass, ontology, pso_holdsStatusInTime).collect(Collectors.toList());
+
+		// Read through the list of OWLAnnotations to create corresponding PhylorefStatus objects.
+		for(OWLAnnotation statusInTime: holdsStatusInTime) {
+		    // Each statusInTime entry should have one status (pso:withStatus)
+		    // and a number of time intervals (tvc:atTime). We collect all
+		    // statusues and test to see if any of those time intervals are
+		    // "incomplete", i.e. they have a start date but no end date.
+			IRI phylorefStatusIRI = null;
+			Instant intervalStartDate = null;
+			Instant intervalEndDate = null;
+			
+			for(OWLAnonymousIndividual indiv_statusInTime: statusInTime.getAnonymousIndividuals()) {
+		        for(OWLAnnotationAssertionAxiom axiom: ontology.getAnnotationAssertionAxioms(indiv_statusInTime)) {
+		            if(axiom.getProperty().equals(tvc_atTime)) {
+		                for(OWLAnonymousIndividual indiv_atTime: axiom.getValue().getAnonymousIndividuals()) {
+		                    for(OWLAnnotationAssertionAxiom axiom_interval: ontology.getAnnotationAssertionAxioms(indiv_atTime)) {
+		                        // Look for timeinterval:hasIntervalStartDate and timeinterval:hasIntervalEndDate data properties.
+		                        if(axiom_interval.getProperty().equals(timeinterval_hasIntervalStartDate)) {
+		                        	try {
+			                        	intervalStartDate = ZonedDateTime.parse(
+			                        		axiom_interval.getValue().asLiteral().get().getLiteral()
+			                        	).toInstant();
+		                        	} catch(DateTimeParseException ex) {
+		                        		// If we have a start date but can't parse it, record it as the earliest possible time.
+		                        		intervalStartDate = Instant.MIN;
+		                        	}
+		                        }
+		                        if(axiom_interval.getProperty().equals(timeinterval_hasIntervalEndDate)) {
+		                        	try {
+			                            intervalEndDate = ZonedDateTime.parse(
+		                            		axiom_interval.getValue().asLiteral().get().getLiteral()
+			                        	).toInstant();
+		                        	} catch(DateTimeParseException ex) {
+		                        		// If we have an end date but can't parse it, record it at the latest possible time.
+		                        		intervalEndDate = Instant.MAX;
+		                        	}
+		                        }
+		                    }
+		                }
+		            }
+
+		            else if(axiom.getProperty().equals(pso_withStatus)) {
+		            	phylorefStatusIRI = (IRI) axiom.getValue();
+		            } else {
+		                throw new IllegalArgumentException("Phyloreference " + phyloref + " contains an unknown axiom: " + axiom);
+		            }
+		        }
+			}
+			
+			statuses.add(new PhylorefHelper.PhylorefStatus(
+				phyloref,
+				phylorefStatusIRI,
+				intervalStartDate,
+				intervalEndDate
+			));
+		}
+		
+		return statuses;
+	}
 }


### PR DESCRIPTION
This refactors the Phyloref status checking code while fixing a minor bug. This code has also been moved into PhylorefHelper so that it can be used outside of `jphyloref test` if needed.