### PR TITLE
Added slf4j-simple as a dependency to close #18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,14 @@
       	    <version>2.3.2</version>
       	</dependency>
 
+      	<!-- Adds a StaticLoggerBinder for logging -->
+      	<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-simple</artifactId>
+          <version>1.7.25</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,7 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>3.8.1</version>
-            <scope>test</scope>
-        </dependency>
+        <!-- For processing command line arguments -->
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
@@ -30,12 +25,13 @@
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/net.sourceforge.owlapi/jfact -->
-      	<dependency>
-      	    <groupId>net.sourceforge.owlapi</groupId>
-      	    <artifactId>jfact</artifactId>
-      	    <version>5.0.1</version>
-      	</dependency>
+        <dependency>
+            <groupId>net.sourceforge.owlapi</groupId>
+            <artifactId>jfact</artifactId>
+            <version>5.0.1</version>
+        </dependency>
 
+        <!-- For producing testing output -->
         <dependency>
             <groupId>org.tap4j</groupId>
             <artifactId>tap4j</artifactId>
@@ -44,42 +40,50 @@
 
         <!-- For creating a webserver -->
         <dependency>
-          	<groupId>org.nanohttpd</groupId>
-          	<artifactId>nanohttpd</artifactId>
-          	<version>2.3.1</version>
+            <groupId>org.nanohttpd</groupId>
+            <artifactId>nanohttpd</artifactId>
+            <version>2.3.1</version>
         </dependency>
 
         <!-- For writing JSON -->
         <!-- https://mvnrepository.com/artifact/org.json/json -->
-    		<dependency>
-    		    <groupId>org.json</groupId>
-    		    <artifactId>json</artifactId>
-    		    <version>20180130</version>
-    		</dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20180130</version>
+        </dependency>
 
         <!-- For reading and writing JSON-LD -->
         <!-- https://mvnrepository.com/artifact/org.eclipse.rdf4j/rdf4j-rio-jsonld -->
         <dependency>
-    		    <groupId>org.eclipse.rdf4j</groupId>
-    		    <artifactId>rdf4j-rio-jsonld</artifactId>
-    		    <version>2.3.2</version>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-jsonld</artifactId>
+            <version>2.3.2</version>
             <scope>runtime</scope>
         </dependency>
 
-      	<dependency>
-      	    <groupId>org.eclipse.rdf4j</groupId>
-      	    <artifactId>rdf4j-rio-api</artifactId>
-      	    <version>2.3.2</version>
-      	</dependency>
-
-      	<!-- Adds a StaticLoggerBinder for logging -->
-      	<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
         <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-simple</artifactId>
-          <version>1.7.25</version>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-api</artifactId>
+            <version>2.3.2</version>
         </dependency>
 
+        <!-- Adds a StaticLoggerBinder for logging (as per phyloref/jphyloref#18) -->
+        <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+
+        <!-- We use JUnit for testing -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        
     </dependencies>
 
     <build>


### PR DESCRIPTION
Adding `slf4j-simple` as a dependency provides us with StaticLoggerBinder, which eliminates a warning we see when running JPhyloRef. Closes #18.