### PR TITLE
Add support for FaCT++ as an alternate reasoner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Eclipse files
 .classpath
 .settings/
+bin/
 
 # Compiled class file
 *.class

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# JNI libraries
+*.jnilib
+
 # Eclipse files
 .classpath
 .settings/

--- a/lib/factplusplus/HOWTO.txt
+++ b/lib/factplusplus/HOWTO.txt
@@ -1,6 +1,0 @@
-
-Installing factplusplus:
-    - Download 'uk.ac.manchester.cs.owl.factplusplus-P5.x-v1.6.5.jar' from https://bitbucket.org/dtsarkov/factplusplus/downloads/
-    - Install it locally using:
-        mvn install:install-file -Dfile=/home/vaidyagi/code/phyloref/jphyloref/lib/uk.ac.manchester.cs.owl.factplusplus-P5.x-v1.6.5.jar -DgroupId=uk.ac.manchester.cs -DartifactId=factplusplus -Dversion=1.6.5 -Dpackaging=jar -DgeneratePom=true
-    -

--- a/lib/factplusplus/HOWTO.txt
+++ b/lib/factplusplus/HOWTO.txt
@@ -1,0 +1,6 @@
+
+Installing factplusplus:
+    - Download 'uk.ac.manchester.cs.owl.factplusplus-P5.x-v1.6.5.jar' from https://bitbucket.org/dtsarkov/factplusplus/downloads/
+    - Install it locally using:
+        mvn install:install-file -Dfile=/home/vaidyagi/code/phyloref/jphyloref/lib/uk.ac.manchester.cs.owl.factplusplus-P5.x-v1.6.5.jar -DgroupId=uk.ac.manchester.cs -DartifactId=factplusplus -Dversion=1.6.5 -Dpackaging=jar -DgeneratePom=true
+    -

--- a/lib/factplusplus/README.md
+++ b/lib/factplusplus/README.md
@@ -1,0 +1,14 @@
+# Using FaCT++ with JPhyloRef
+
+JPhyloRef picks up the latest version of FaCT++ published to a Maven repository
+(currently [Factplusplus 1.5.2] on Berkeley BOP), but this doesn't include the
+native libraries necessary to make the reasoner work. You will need to download
+them separately from the [factplusplus Google Code Archive].
+
+When invoking JPhyloRef from the command line, you may need to provide the path
+to the native library using the `java.library.path` setting, such as:
+
+    java -Djava.library.path='lib/factplusplus/FaCT++-OSX-v1.5.2/64bit/' -jar target/jphyloref-0.2-SNAPSHOT.jar webserver --reasoner fact++
+
+[Factplusplus 1.5.2]: https://mvnrepository.com/artifact/uk.ac.manchester.cs/factplusplus/1.5.2
+[factplusplus Google Code Archive]: https://code.google.com/archive/p/factplusplus/downloads

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,14 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>BBOP</id>
+            <name>Berkeley BOP</name>
+            <url>http://code.berkeleybop.org/maven/repository/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -28,13 +36,6 @@
             <artifactId>commons-cli</artifactId>
             <version>1.4</version>
         </dependency>
-
-        <!-- https://mvnrepository.com/artifact/net.sourceforge.owlapi/jfact -->
-      	<dependency>
-      	    <groupId>net.sourceforge.owlapi</groupId>
-      	    <artifactId>jfact</artifactId>
-      	    <version>5.0.1</version>
-      	</dependency>
 
         <dependency>
             <groupId>org.tap4j</groupId>
@@ -72,12 +73,36 @@
       	    <version>2.3.2</version>
       	</dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.github.jsonld-java/jsonld-java -->
+        <dependency>
+            <groupId>com.github.jsonld-java</groupId>
+            <artifactId>jsonld-java</artifactId>
+            <version>0.12.0</version>
+        </dependency>
+
       	<!-- Adds a StaticLoggerBinder for logging -->
       	<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
         <dependency>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-simple</artifactId>
           <version>1.7.25</version>
+        </dependency>
+
+        <!-- REASONERS -->
+
+        <!-- JFact is our default reasoner -->
+        <!-- https://mvnrepository.com/artifact/net.sourceforge.owlapi/jfact -->
+      	<dependency>
+      	    <groupId>net.sourceforge.owlapi</groupId>
+      	    <artifactId>jfact</artifactId>
+      	    <version>4.0.4</version>
+      	</dependency>
+
+        <!-- Fact++ is a very fast JNI-based reasoner -->
+        <dependency>
+            <groupId>uk.ac.manchester.cs</groupId>
+            <artifactId>factplusplus</artifactId>
+            <version>1.5.2</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,14 @@
       	    <version>2.3.2</version>
       	</dependency>
 
+      	<!-- Adds a StaticLoggerBinder for logging -->
+      	<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-simple</artifactId>
+          <version>1.7.25</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -2,6 +2,8 @@ package org.phyloref.jphyloref;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
@@ -11,6 +13,13 @@ import org.phyloref.jphyloref.commands.Command;
 import org.phyloref.jphyloref.commands.ReasonCommand;
 import org.phyloref.jphyloref.commands.TestCommand;
 import org.phyloref.jphyloref.commands.WebserverCommand;
+import org.phyloref.jphyloref.helpers.ReasonerHelper;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.reasoner.OWLReasoner;
+import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
+import org.semanticweb.owlapi.util.Version;
 import org.semanticweb.owlapi.util.VersionInfo;
 
 /**
@@ -60,6 +69,9 @@ public class JPhyloRef {
             HelpCommand help = new HelpCommand();
             help.execute(cmdLine);
         } else {
+        	// Look for global options:
+        	//	--reasoner: Set the reasoner.
+        	
             // The first unprocessed argument should be the command.
             String command = cmdLine.getArgList().get(0);
 
@@ -133,6 +145,15 @@ public class JPhyloRef {
                         + opt.getDescription()
                     );
                 }
+            }
+            
+            // Display global options, including the list of possible reasoners.
+            System.out.println("\nWe also accept some global options, including:");
+            System.out.println(" --reasoner <reasonerName>: sets the reasoner name, which should be one of:");
+            Map<String, OWLReasonerFactory> reasonerList = ReasonerHelper.getReasonerFactories();
+            for(String name: reasonerList.keySet()) {
+            	OWLReasonerFactory factory = reasonerList.get(name);            	
+            	System.out.println("    '" + name + "': " + reasonerList.get(name).getReasonerName() + "/" + ReasonerHelper.getReasonerFactoryVersionString(factory));
             }
 
             // One final blank line, please.

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -49,6 +49,11 @@ public class JPhyloRef {
     public void execute(String[] args) {
         // Prepare to parse command line arguments.
         Options opts = new Options();
+        
+        // Add global options.
+        ReasonerHelper.addCommandLineOptions(opts);
+        
+        // Add per-command options.
         for(Command cmd: commands) {
             cmd.addCommandLineOptions(opts);
         }
@@ -153,7 +158,7 @@ public class JPhyloRef {
             Map<String, OWLReasonerFactory> reasonerList = ReasonerHelper.getReasonerFactories();
             for(String name: reasonerList.keySet()) {
             	OWLReasonerFactory factory = reasonerList.get(name);            	
-            	System.out.println("    '" + name + "': " + reasonerList.get(name).getReasonerName() + "/" + ReasonerHelper.getReasonerFactoryVersionString(factory));
+            	System.out.println("    '" + name + "': " + ReasonerHelper.getReasonerNameAndVersion(factory));
             }
 
             // One final blank line, please.

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -140,7 +140,7 @@ public class TestCommand implements Command {
 
         // Reason over the loaded ontology -- but only if the user wants that!
         // Set up an OWLReasoner to work with.
-        OWLReasonerFactory reasonerFactory = ReasonerHelper.getReasonerFromCmdLine(cmdLine);
+        OWLReasonerFactory reasonerFactory = ReasonerHelper.getReasonerFactoryFromCmdLine(cmdLine);
         OWLReasoner reasoner = null;
         if(reasonerFactory != null) reasoner = reasonerFactory.createReasoner(ontology);
         Set<OWLNamedIndividual> phylorefs;

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -210,11 +210,11 @@ public class TestCommand implements Command {
             Set<OWLNamedIndividual> nodes;
             if(reasoner != null) {
             	// Use the reasoner to determine which nodes are members of this phyloref as a class
-            	nodes = reasoner.getInstances(phylorefAsClass, false).entities()
+            	nodes = reasoner.getInstances(phylorefAsClass, false).getFlattened().stream()
 	                // This includes the phyloreference itself. We only want to
 	                // look at phylogeny nodes here. So, let's filter down to named
 	                // individuals that are asserted to be cdao:Nodes.
-	                .filter(indiv -> EntitySearcher.getTypes(indiv, ontology).anyMatch(
+	                .filter(indiv -> EntitySearcher.getTypes(indiv, ontology).stream().anyMatch(
 	                    type -> (!type.getClassExpressionType().equals(ClassExpressionType.OWL_CLASS)) ||
 	                			type.asOWLClass().getIRI().equals(PhylorefHelper.IRI_CDAO_NODE)
 	                ))
@@ -252,7 +252,7 @@ public class TestCommand implements Command {
 
                 for(OWLNamedIndividual node: nodes) {
                     // Get a list of all expected phyloreference labels from the OWL file.
-                    Set<String> expectedPhylorefsNamed = EntitySearcher.getDataPropertyValues(node, expectedPhyloreferenceNamedProperty, ontology)
+                    Set<String> expectedPhylorefsNamed = EntitySearcher.getDataPropertyValues(node, expectedPhyloreferenceNamedProperty, ontology).stream()
                         .map(literal -> literal.getLiteral()) // We ignore languages for now.
                         .collect(Collectors.toSet());
 
@@ -299,7 +299,7 @@ public class TestCommand implements Command {
             }
 
             // Look for all unmatched specifiers reported for this phyloreference
-            Set<OWLAxiom> axioms = EntitySearcher.getReferencingAxioms(phyloref, ontology).collect(Collectors.toSet());
+            Set<OWLAxiom> axioms = new HashSet<>(EntitySearcher.getReferencingAxioms(phyloref, ontology));
             Set<OWLNamedIndividual> unmatched_specifiers = new HashSet<>();
             for(OWLAxiom axiom: axioms) {
             	if(axiom.containsEntityInSignature(unmatchedSpecifierProperty)) {
@@ -323,7 +323,7 @@ public class TestCommand implements Command {
             }
 
             // Retrieve holdsStatusInTime to determine the active status of this phyloreference.
-            Set<OWLAnnotation> holdsStatusInTime = EntitySearcher.getAnnotations(phylorefAsClass, ontology, pso_holdsStatusInTime).collect(Collectors.toSet());
+            Set<OWLAnnotation> holdsStatusInTime = new HashSet<>(EntitySearcher.getAnnotations(phylorefAsClass, ontology, pso_holdsStatusInTime));
 
             // Instead of checking which time interval were are in, we take a simpler approach: we look for all
             // statuses that have a start date but not an end date, i.e. those which have yet to end.

--- a/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
@@ -6,7 +6,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.semanticweb.owlapi.model.OWLAnnotation;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
 import org.semanticweb.owlapi.model.OWLEntity;
 import org.semanticweb.owlapi.model.OWLLiteral;
@@ -90,7 +89,7 @@ public final class OWLHelper {
         Map<String, Set<String>> valuesByLanguage = new HashMap<>();
 
         // Go through all known annotations, looking for OWLLiterals.
-        EntitySearcher.getAnnotations(entity, ontology, annotationProperty)
+        EntitySearcher.getAnnotations(entity, ontology, annotationProperty).stream()
             .filter(annotation -> annotation.getValue() instanceof OWLLiteral)
             .forEach(annotation -> {
                 OWLLiteral val = (OWLLiteral) annotation.getValue();

--- a/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
@@ -11,6 +11,7 @@ import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 import org.semanticweb.owlapi.util.Version;
 
+import uk.ac.manchester.cs.factplusplus.owlapiv3.FaCTPlusPlusReasonerFactory;
 import uk.ac.manchester.cs.jfact.JFactFactory;
 
 /**
@@ -30,6 +31,7 @@ public class ReasonerHelper {
 		 */
 		reasonerFactories.put("null", null);
 		reasonerFactories.put("jfact", new JFactFactory());
+		reasonerFactories.put("fact++", new FaCTPlusPlusReasonerFactory());
 	}
 
 	/**
@@ -41,8 +43,8 @@ public class ReasonerHelper {
 			return reasonerFactories.get(name);
 		}
 		
-		// If all else fails, we default to JFact.
-		return new JFactFactory();
+		// If all else fails, throw an exception.
+		throw new IllegalArgumentException("No reasoner named '" + name + "'; must be one of: " + reasonerFactories.keySet().toString());
 	}
 	
 	/**
@@ -77,7 +79,7 @@ public class ReasonerHelper {
 		if(cmdLine.hasOption("reasoner")) {
 			return getReasonerFactory(cmdLine.getOptionValue("reasoner")); 				
 		} else {
-			// No reasoner provided? We use the default.
+			// No reasoner provided? Throw an exception!
 			return getReasonerFactory("");
 		}
 	}

--- a/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
@@ -1,0 +1,73 @@
+package org.phyloref.jphyloref.helpers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.reasoner.OWLReasoner;
+import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
+import org.semanticweb.owlapi.util.Version;
+
+import uk.ac.manchester.cs.jfact.JFactFactory;
+
+/**
+ * The ReasonerHelper provides methods to help create and manage
+ * OWL Reasoners, and to allow the user to choose a different
+ * reasoner to carry out any specified task. 
+ * 
+ * @author Gaurav Vaidya <gaurav@ggvaidya.com>
+ */
+public class ReasonerHelper {
+	/** A map of reasoner names and the corresponding reasoner factory */
+	private static Map<String, OWLReasonerFactory> reasonerFactories = new HashMap<>();
+	
+	static {
+		/*
+		 * Set up a list of reasoner names and their corresponding reasoner factory.
+		 */
+		reasonerFactories.put("jfact", new JFactFactory());
+	}
+
+	/**
+	 * Get reasoner factory by name.
+	 */
+	public OWLReasonerFactory getReasonerFactory(String name) {
+		// Look it up.
+		if(reasonerFactories.containsKey(name)) {
+			return reasonerFactories.get(name);
+		}
+		
+		// If all else fails, we default to JFact.
+		return new JFactFactory();
+	}
+	
+	/**
+	 * Get all reasoner factories.
+	 */
+	public static Map<String, OWLReasonerFactory> getReasonerFactories() {
+		return reasonerFactories;
+	}
+	
+	/**
+	 * Get the Version of a particular reasoner factory. Unfortunately, the only way to
+	 * determine this is to create an OWLReasoner, but we can cache that. 
+	 */
+	public static Version getReasonerFactoryVersion(OWLReasonerFactory factory) {
+		try {
+			OWLReasoner reasoner = factory.createNonBufferingReasoner(OWLManager.createOWLOntologyManager().createOntology());
+			return reasoner.getReasonerVersion();
+		} catch (OWLOntologyCreationException e) {
+			return new Version(0, 0, 0, 0);
+		}
+	}
+	
+	/**
+	 * Get the version of a particular reasoner factory as a String.
+	 */
+	public static String getReasonerFactoryVersionString(OWLReasonerFactory factory) {
+		Version version = getReasonerFactoryVersion(factory);
+	
+		return version.getMajor() + "." + version.getMinor() + "." + version.getBuild() + "." + version.getPatch();
+	}
+}

--- a/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
@@ -53,7 +53,7 @@ public class ReasonerHelper {
 	}
 	
 	public static String getReasonerNameAndVersion(OWLReasonerFactory factory) {
-		if(factory == null) return "Deactivate reasoner (all tests will fail!)";
+		if(factory == null) return "No reasoner used";
 		
 		String versionString;
 		try {
@@ -73,7 +73,7 @@ public class ReasonerHelper {
 	 * For now, we only look for one setting -- '--reasoner' -- and identify a reasoner based on that,
 	 * but in the future we might support additional options that allow you to configure the reasoner.
 	 */
-	public static OWLReasonerFactory getReasonerFromCmdLine(CommandLine cmdLine) {
+	public static OWLReasonerFactory getReasonerFactoryFromCmdLine(CommandLine cmdLine) {
 		if(cmdLine.hasOption("reasoner")) {
 			return getReasonerFactory(cmdLine.getOptionValue("reasoner")); 				
 		} else {


### PR DESCRIPTION
This PR adds a `--reasoner` command line option which can be used to change reasoners, and adds the FaCT++ 1.5.2 reasoner as an optional reasoner. Since FaCT++ depends on OWL 4.x, it reverts the OWLAPI from 5.0.4 to 4.2.7, which required a few minor code changes. Since FaCT++ uses native libraries (through the Java Native Interface), I've also added a README that explains how to download and set up those libraries.