### PR TITLE
Fixes bug in running JPhyloRef without specifying which reasoner to use

### DIFF
--- a/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
@@ -79,8 +79,8 @@ public class ReasonerHelper {
 		if(cmdLine.hasOption("reasoner")) {
 			return getReasonerFactory(cmdLine.getOptionValue("reasoner")); 				
 		} else {
-			// No reasoner provided? Throw an exception!
-			return getReasonerFactory("");
+			// No reasoner provided? Default to JFact.
+			return new JFactFactory();
 		}
 	}
 	


### PR DESCRIPTION
Currently, JPhyloRef won't reason over any files unless a reasoner is specified with the `--reasoner` command line. This PR sets JFact as the default reasoner if no reasoner is specified.