### PR TITLE
Phyloref status extraction now works whether start/end dates are interpreted as Annotations or Datatype Properties

### DIFF
--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -317,7 +317,7 @@ public class TestCommand implements Command {
             }
 
             // Get a list of phyloref statuses for this phyloreference.
-            List<PhylorefHelper.PhylorefStatus> statuses = PhylorefHelper.getCurrentStatusesForPhyloref(phyloref, ontology);
+            List<PhylorefHelper.PhylorefStatus> statuses = PhylorefHelper.getPhylorefStatuses(phyloref, ontology);
 
             // Instead of checking which time interval we are currently in, we take a simpler approach:
             // we look for all statuses asserted to be "active", i.e. those with a start time but no end time.

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -383,8 +383,8 @@ public class TestCommand implements Command {
         System.out.println(tapProducer.dump(testSet));
         System.err.println("Testing complete:" + countSuccess + " successes, " + countFailure + " failures, " + countTODO + " failures marked TODO, " + countSkipped + " skipped.");
 
-        // Exit with error unless we have zero failures.
-        if(countSuccess == 0) System.exit(-1);
+        // Exit with the number of failures. If there are zero, then command line tools
+        // will treat this test as successful.
         System.exit(countFailure);
     }
 }

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -227,7 +228,7 @@ public class PhylorefHelper {
       OWLAnnotationProperty timeinterval_hasIntervalEndDate = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TIMEINT_HAS_INTERVAL_END_DATE);
 
       // Retrieve holdsStatusInTime to determine the active status of this phyloreference.
-      List<OWLAnnotation> holdsStatusInTime = EntitySearcher.getAnnotations(phylorefAsClass, ontology, pso_holdsStatusInTime).collect(Collectors.toList());
+      Collection<OWLAnnotation> holdsStatusInTime = EntitySearcher.getAnnotations(phylorefAsClass, ontology, pso_holdsStatusInTime);
 
       // Read through the list of OWLAnnotations to create corresponding PhylorefStatus objects.
       for(OWLAnnotation statusInTime: holdsStatusInTime) {


### PR DESCRIPTION
hasIntervalStartDate should be interpreted by OWLAPI as an AnnotationProperty, but it is sometimes interpreted as an OWLDataProperty. (This also applies to hasIntervalEndDate.) We appear to have a consistent example of this: the Brochu 2003 example file is interpreted as an Annotation Property when the OWL is generated by the Curation Tool and rdfpipe, but it is interpreted as a Datatype Property when the OWL is generated by the Clade Ontology test suite (see [Gist for these files](https://gist.github.com/gaurav/db2f7ca63055328ee33c090f3ae8e9e3)). This PR provides one quick-and-dirty workaround, which is to simply look for both annotation properties or datatype properties, but it's only the first step in (1) figuring out why this is happening, and (2) writing a test to make sure that this doesn't keep happening, as these issues are difficult to debug.

**Do not merge**: This is not a good fix for this problem, and I still need to figure out why we need this additional code to make this work for the Curation Tool. Also, this is just crying out for an automated test, so this is a good excuse to finally give JPhyloRef a test suite (probably in a different PR).