### PR TITLE
Updated WebserverCommand to use local ontologies if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 - Added a "webserver" command that starts a webserver that provides a simple
   HTTP API for reasoning over JSON-LD file in [phyloref/jphyloref#12].
 - Removed Eclipse files that should not have been added in [phyloref/jphyloref#13].
+- WebserverCommand now looks for ontologies in the local 'ontologies/' directory.
 
 ## 0.2 - 2018-06-20
 - Added support for phyloreference statuses using the Publication Status Ontology

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -38,6 +38,7 @@ import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 import org.semanticweb.owlapi.rio.RioOWLRDFConsumerAdapter;
 import org.semanticweb.owlapi.search.EntitySearcher;
 import org.semanticweb.owlapi.util.AnonymousNodeChecker;
+import org.semanticweb.owlapi.util.AutoIRIMapper;
 import org.semanticweb.owlapi.util.VersionInfo;
 
 import fi.iki.elonen.NanoHTTPD;
@@ -158,6 +159,13 @@ public class WebserverCommand implements Command {
 
       // Prepare an ontology to fill with the provided JSON-LD file.
       OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
+
+      // Is purl.obolibrary.org down? No worries, you can access local copies
+      // of your ontologies in the 'ontologies/' folder.
+      AutoIRIMapper mapper = new AutoIRIMapper(new File("ontologies"), true);
+      System.err.println("Found local ontologies: " + mapper.getOntologyIRIs());
+      manager.addIRIMapper(mapper);
+
       OWLOntology ontology = manager.createOntology();
       OWLOntologyLoaderConfiguration config = new OWLOntologyLoaderConfiguration();
 


### PR DESCRIPTION
TestCommand (`java -jar jphyloref.jar test ...`) already supports the use of local ontologies if they are available. This PR adds support for reading ontologies from the same folder to WebserverCommand (`java -jar jphyloref.jar webserver ...`) as well.