### PR TITLE
Write out reasoner information during TestCommand/WebserverCommand

### DIFF
--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -186,6 +186,8 @@ public class TestCommand implements Command {
     TapProducer tapProducer = TapProducerFactory.makeTap13Producer();
     TestSet testSet = new TestSet();
     testSet.setPlan(new Plan(phylorefs.size()));
+    testSet.addComment(new Comment("Using reasoner: " +
+      ReasonerHelper.getReasonerNameAndVersion(ReasonerHelper.getReasonerFactoryFromCmdLine(cmdLine))));
 
     // Preload some terms we need to use in the following code.
     OWLDataFactory dataFactory = manager.getOWLDataFactory();

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -186,8 +186,11 @@ public class TestCommand implements Command {
     TapProducer tapProducer = TapProducerFactory.makeTap13Producer();
     TestSet testSet = new TestSet();
     testSet.setPlan(new Plan(phylorefs.size()));
-    testSet.addComment(new Comment("Using reasoner: " +
-      ReasonerHelper.getReasonerNameAndVersion(ReasonerHelper.getReasonerFactoryFromCmdLine(cmdLine))));
+    testSet.addComment(
+        new Comment(
+            "Using reasoner: "
+                + ReasonerHelper.getReasonerNameAndVersion(
+                    ReasonerHelper.getReasonerFactoryFromCmdLine(cmdLine))));
 
     // Preload some terms we need to use in the following code.
     OWLDataFactory dataFactory = manager.getOWLDataFactory();

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -128,8 +128,13 @@ public class WebserverCommand implements Command {
       start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
       System.out.println(
           "Webserver started with reasoner "
-          + ReasonerHelper.getReasonerNameAndVersion(ReasonerHelper.getReasonerFactoryFromCmdLine(cmdLine))
-          + ". Try accessing it at http://" + hostname + ":" + port + "/");
+              + ReasonerHelper.getReasonerNameAndVersion(
+                  ReasonerHelper.getReasonerFactoryFromCmdLine(cmdLine))
+              + ". Try accessing it at http://"
+              + hostname
+              + ":"
+              + port
+              + "/");
     }
 
     /** Respond to a request for reasoning over a JSON-LD file (/reason). */

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -127,7 +127,9 @@ public class WebserverCommand implements Command {
 
       start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
       System.out.println(
-          "Webserver started. Try accessing it at http://" + hostname + ":" + port + "/");
+          "Webserver started with reasoner "
+          + ReasonerHelper.getReasonerNameAndVersion(ReasonerHelper.getReasonerFactoryFromCmdLine(cmdLine))
+          + ". Try accessing it at http://" + hostname + ":" + port + "/");
     }
 
     /** Respond to a request for reasoning over a JSON-LD file (/reason). */

--- a/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
+++ b/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
@@ -51,7 +51,7 @@ class TestCommandTest {
             "Testing complete:1 successes, 0 failures, 0 failures marked TODO, 0 skipped.\n"),
         "Make sure the testing was successful.");
     assertEquals(
-        "1..1\nok 1 "
+        "1..1\n# Using reasoner: JFact/1.2.0.1\nok 1 "
             + phylorefName
             + "\n# The following nodes were matched and expected this phyloreference: [1]\n\n",
         stdoutStr);


### PR DESCRIPTION
This PR modifies both TestCommand and WebserverCommand to write out which reasoner is being used so we can log the time taken by different reasoners to reason over particular ontologies.