### PR TITLE
Fixed incorrect code merged in #17

### DIFF
--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -227,7 +228,7 @@ public class PhylorefHelper {
       OWLAnnotationProperty timeinterval_hasIntervalEndDate = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TIMEINT_HAS_INTERVAL_END_DATE);
 
       // Retrieve holdsStatusInTime to determine the active status of this phyloreference.
-      List<OWLAnnotation> holdsStatusInTime = EntitySearcher.getAnnotations(phylorefAsClass, ontology, pso_holdsStatusInTime).collect(Collectors.toList());
+      Collection<OWLAnnotation> holdsStatusInTime = EntitySearcher.getAnnotations(phylorefAsClass, ontology, pso_holdsStatusInTime);
 
       // Read through the list of OWLAnnotations to create corresponding PhylorefStatus objects.
       for(OWLAnnotation statusInTime: holdsStatusInTime) {


### PR DESCRIPTION
47f84fb2104 introduced some incorrect code, which was then merged into master in PR #17. Since the subsequent commits appeared to work while I was working on them, I think the error was caused by the incorporation of FaCT++ in a separate pull request and the subsequent merge. I could probably have caught this by repulling from master rather than trusting Github's assertion that the merge did not have any problems. It could definitely have been caught if we ran a test suite in Travis with every pull request -- so all the more reason to incorporate a test suite ASAP (#3)!