### PR TITLE
Add basic test suite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,28 @@
               </executions>
             </plugin>
 
+            <!-- Use Jacoco to measure test coverage -->
+            <plugin>
+              <groupId>org.jacoco</groupId>
+              <artifactId>jacoco-maven-plugin</artifactId>
+              <version>0.8.2</version>
+              <executions>
+                <execution>
+                  <id>prepare-agent</id>
+                  <goals>
+                    <goal>prepare-agent</goal>
+                  </goals>
+                </execution>
+                <execution>
+                  <id>report</id>
+                  <phase>prepare-package</phase>
+                  <goals>
+                    <goal>report</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,17 @@
               </executions>
             </plugin>
 
+            <!-- maven-compiler-plugin allows us to configure compilations errors -->
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>3.8.0</version>
+              <configuration>
+                <compilerArgument>-Xlint:unchecked</compilerArgument>
+                <showDeprecation>true</showDeprecation>
+              </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -148,61 +148,58 @@
               </executions>
             </plugin>
 
-            <!-- Use Jacoco to measure test coverage -->
-            <plugin>
-              <groupId>org.jacoco</groupId>
-              <artifactId>jacoco-maven-plugin</artifactId>
-              <version>0.8.2</version>
-              <configuration>
-                <!-- These rules are to ensure that CI output records that we still
-                haven't finished testing this code, which is why we don't halt on failure. -->
-                <haltOnFailure>false</haltOnFailure>
-                <rules>
-                  <rule implementation="org.jacoco.maven.RuleConfiguration">
-                    <element>SOURCEFILE</element>
-                    <limits>
-                      <limit implementation="org.jacoco.report.check.Limit">
-                        <counter>INSTRUCTION</counter>
-                        <value>COVEREDRATIO</value>
-                        <minimum>0.80</minimum>
-                      </limit>
-                      <limit implementation="org.jacoco.report.check.Limit">
-                        <counter>BRANCH</counter>
-                        <value>COVEREDRATIO</value>
-                        <minimum>0.80</minimum>
-                      </limit>
-                      <limit implementation="org.jacoco.report.check.Limit">
-                        <counter>CLASS</counter>
-                        <value>MISSEDCOUNT</value>
-                        <maximum>0</maximum>
-                      </limit>
-                    </limits>
-                  </rule>
-                </rules>
-              </configuration>
-              <executions>
-                <execution>
-                  <id>prepare-agent</id>
-                  <goals>
-                    <goal>prepare-agent</goal>
-                  </goals>
-                </execution>
-                <execution>
-                  <id>report</id>
-                  <phase>prepare-package</phase>
-                  <goals>
-                    <goal>report</goal>
-                  </goals>
-                </execution>
-                <execution>
-                  <id>check</id>
-                  <phase>test</phase>
-                  <goals>
-                    <goal>check</goal>
-                  </goals>
-                </execution>
-              </executions>
-            </plugin>
+      <!--
+        The jacoco-maven-plugin uses Jacoco to measure test coverage
+        https://www.eclemma.org/jacoco/trunk/doc/maven.html
+      -->
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.2</version>
+        <configuration>
+          <!-- These rules are to ensure that CI output records that we still
+          haven't finished testing this code, which is why we don't halt on failure. -->
+          <haltOnFailure>false</haltOnFailure>
+          <rules>
+            <rule implementation="org.jacoco.maven.RuleConfiguration">
+              <element>SOURCEFILE</element>
+              <limits>
+                <limit implementation="org.jacoco.report.check.Limit">
+                  <counter>INSTRUCTION</counter>
+                  <value>COVEREDRATIO</value>
+                  <minimum>0.80</minimum>
+                </limit>
+                <limit implementation="org.jacoco.report.check.Limit">
+                  <counter>BRANCH</counter>
+                  <value>COVEREDRATIO</value>
+                  <minimum>0.80</minimum>
+                </limit>
+                <limit implementation="org.jacoco.report.check.Limit">
+                  <counter>CLASS</counter>
+                  <value>MISSEDCOUNT</value>
+                  <maximum>0</maximum>
+                </limit>
+              </limits>
+            </rule>
+          </rules>
+        </configuration>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>check</id>
+            <phase>test</phase>
+            <goals>
+              <goal>check</goal>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
 
             <!-- maven-compiler-plugin allows us to configure compilations errors -->
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,11 @@
                         <minimum>0.80</minimum>
                       </limit>
                       <limit implementation="org.jacoco.report.check.Limit">
+                        <counter>BRANCH</counter>
+                        <value>COVEREDRATIO</value>
+                        <minimum>0.80</minimum>
+                      </limit>
+                      <limit implementation="org.jacoco.report.check.Limit">
                         <counter>CLASS</counter>
                         <value>MISSEDCOUNT</value>
                         <maximum>0</maximum>

--- a/pom.xml
+++ b/pom.xml
@@ -102,11 +102,11 @@
             <version>1.7.25</version>
         </dependency>
 
-        <!-- We use JUnit for testing -->
+        <!-- We use JUnit Jupiter Engine for testing -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>3.8.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.3.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -114,6 +114,15 @@
 
     <build>
         <plugins>
+            <!-- We use Surefire to run testing using JUnit Jupiter Engine -->
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>2.22.1</version>
+              <configuration>
+              </configuration>
+            </plugin>
+
             <!-- Use Spotless to check and fix style: https://github.com/diffplug/spotless/tree/master/plugin-maven -->
             <plugin>
               <groupId>com.diffplug.spotless</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,28 @@
               <groupId>org.jacoco</groupId>
               <artifactId>jacoco-maven-plugin</artifactId>
               <version>0.8.2</version>
+              <configuration>
+                <!-- These rules are to ensure that CI output records that we still
+                haven't finished testing this code, which is why we don't halt on failure. -->
+                <haltOnFailure>false</haltOnFailure>
+                <rules>
+                  <rule implementation="org.jacoco.maven.RuleConfiguration">
+                    <element>SOURCEFILE</element>
+                    <limits>
+                      <limit implementation="org.jacoco.report.check.Limit">
+                        <counter>INSTRUCTION</counter>
+                        <value>COVEREDRATIO</value>
+                        <minimum>0.80</minimum>
+                      </limit>
+                      <limit implementation="org.jacoco.report.check.Limit">
+                        <counter>CLASS</counter>
+                        <value>MISSEDCOUNT</value>
+                        <maximum>0</maximum>
+                      </limit>
+                    </limits>
+                  </rule>
+                </rules>
+              </configuration>
               <executions>
                 <execution>
                   <id>prepare-agent</id>
@@ -165,6 +187,13 @@
                   <phase>prepare-package</phase>
                   <goals>
                     <goal>report</goal>
+                  </goals>
+                </execution>
+                <execution>
+                  <id>check</id>
+                  <phase>test</phase>
+                  <goals>
+                    <goal>check</goal>
                   </goals>
                 </execution>
               </executions>

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -34,7 +34,7 @@ public class JPhyloRef {
    *
    * @param args Command line arguments
    */
-  public void execute(String[] args) {
+  public int execute(String[] args) {
     // Prepare to parse command line arguments.
     Options opts = new Options();
 
@@ -52,15 +52,14 @@ public class JPhyloRef {
       cmdLine = new DefaultParser().parse(opts, args);
     } catch (ParseException ex) {
       System.err.println("Could not parse command line options: " + ex);
-      System.exit(1);
-      return;
+      return 1;
     }
 
     // Are there any command line arguments?
     if (cmdLine.getArgList().isEmpty()) {
       // No command line arguments -- display help!
       HelpCommand help = new HelpCommand();
-      help.execute(cmdLine);
+      return help.execute(cmdLine);
     } else {
       // Look for global options:
       //	--reasoner: Set the reasoner.
@@ -73,13 +72,13 @@ public class JPhyloRef {
         if (cmd.getName().equalsIgnoreCase(command)) {
           // Found a match!
           cmd.execute(cmdLine);
-          System.exit(0);
+          return 0;
         }
       }
 
       // Could not find any command.
       System.err.println("Error: command '" + command + "' has not been implemented.");
-      System.exit(1);
+      return 1;
     }
   }
 
@@ -91,7 +90,7 @@ public class JPhyloRef {
    */
   public static void main(String[] args) {
     JPhyloRef jphyloref = new JPhyloRef();
-    jphyloref.execute(args);
+    System.exit(jphyloref.execute(args));
   }
 
   /**
@@ -114,7 +113,7 @@ public class JPhyloRef {
     public void addCommandLineOptions(Options opts) {}
 
     /** Display a list of Commands that can be executed on the command line. */
-    public void execute(CommandLine cmdLine) {
+    public int execute(CommandLine cmdLine) {
       // Display version number.
       System.out.println(
           "JPhyloRef/"
@@ -156,6 +155,8 @@ public class JPhyloRef {
 
       // One final blank line, please.
       System.out.println("");
+
+      return 0;
     }
   }
 }

--- a/src/main/java/org/phyloref/jphyloref/commands/Command.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/Command.java
@@ -27,6 +27,9 @@ public interface Command {
   /** A list of valid command line options. These should be added to the provided Options object. */
   public void addCommandLineOptions(Options opts);
 
-  /** Execute this command with the provided command line options. */
-  public void execute(CommandLine cmdLine);
+  /**
+   * Execute this command with the provided command line options, and provide an exit value to
+   * return to the operating system.
+   */
+  public int execute(CommandLine cmdLine);
 }

--- a/src/main/java/org/phyloref/jphyloref/commands/ReasonCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/ReasonCommand.java
@@ -41,19 +41,19 @@ public class ReasonCommand implements Command {
   }
 
   /** Execute this command with the provided command line options. */
-  public void execute(CommandLine cmdLine) {
+  public int execute(CommandLine cmdLine) {
     String str_input = cmdLine.getOptionValue("input");
     String str_output = cmdLine.getOptionValue("output");
 
     if (str_input == null) {
       System.err.println("Error: no input ontology specified (use '-i input.owl')");
-      return;
+      return 1;
     }
 
     File inputFile = new File(str_input);
     if (!inputFile.exists() || !inputFile.canRead()) {
       System.err.println("Error: cannot read from input ontology '" + str_input + "'");
-      return;
+      return 1;
     }
 
     System.err.println("Input: " + str_input);
@@ -66,7 +66,7 @@ public class ReasonCommand implements Command {
       ontology = manager.loadOntologyFromOntologyDocument(inputFile);
     } catch (OWLOntologyCreationException ex) {
       System.err.println("Could not load ontology '" + inputFile + "': " + ex);
-      return;
+      return 1;
     }
 
     // Ontology loaded.
@@ -100,5 +100,7 @@ public class ReasonCommand implements Command {
       }
       System.out.println("");
     }
+
+    return 0;
   }
 }

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -341,7 +341,7 @@ public class TestCommand implements Command {
 
       // Get a list of phyloref statuses for this phyloreference.
       List<PhylorefHelper.PhylorefStatus> statuses =
-          PhylorefHelper.getCurrentStatusesForPhyloref(phyloref, ontology);
+          PhylorefHelper.getStatusesForPhyloref(phyloref, ontology);
 
       // Instead of checking which time interval we are currently in, we take a simpler approach:
       // we look for all statuses asserted to be "active", i.e. those with a start time but no end

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -89,7 +89,7 @@ public class TestCommand implements Command {
    * @param cmdLine The command line options provided to this command.
    */
   @Override
-  public void execute(CommandLine cmdLine) throws RuntimeException {
+  public int execute(CommandLine cmdLine) throws RuntimeException {
     // Extract command-line options
     String str_input = cmdLine.getOptionValue("input");
 
@@ -433,7 +433,7 @@ public class TestCommand implements Command {
             + " skipped.");
 
     // Exit with error unless we have zero failures.
-    if (countSuccess == 0) System.exit(-1);
-    System.exit(countFailure);
+    if (countSuccess == 0) return -1;
+    return countFailure;
   }
 }

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -95,7 +95,7 @@ public class WebserverCommand implements Command {
    * @param cmdLine The command line options provided to this command.
    */
   @Override
-  public void execute(CommandLine cmdLine) throws RuntimeException {
+  public int execute(CommandLine cmdLine) throws RuntimeException {
     String hostname = cmdLine.getOptionValue("host", "localhost");
     String portString = cmdLine.getOptionValue("port", "34214");
     int port = Integer.parseInt(portString);
@@ -106,6 +106,8 @@ public class WebserverCommand implements Command {
     } catch (IOException ex) {
       System.err.println("An error occurred while running webserver: " + ex);
     }
+
+    return 0;
   }
 
   /** The webserver we set up. */

--- a/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
@@ -38,8 +38,8 @@ public final class OWLHelper {
   }
 
   /**
-   * Return a list of labels for an OWLNamedIndividual with either no language provided or in
-   * English.
+   * Return a list of labels for an OWLNamedIndividual in English or (if no such label is known)
+   * with no language provided.
    *
    * @param individual The OWLNamedIndividual whose labels need to be retrieved.
    * @param ontology The ontology within which this individual is defined.
@@ -53,8 +53,10 @@ public final class OWLHelper {
   }
 
   /**
-   * Extract values for an annotation property applied to an OWL entity in an ontology for a
-   * particular set of languages.
+   * Extract literal values for an annotation property applied to an OWL entity in an ontology for a
+   * particular set of languages. If no literals are found for any of the specified languages, we
+   * will return literals that don't have an explicit language tag (i.e. an xsd:string instead of an
+   * rdfs:langString). If no such literals are known, we return an empty set.
    *
    * @param ontology The ontology containing the entity and the annotation property to extract
    * @param entity The entity to extract annotations for
@@ -91,7 +93,8 @@ public final class OWLHelper {
 
   /**
    * Return a Map that contains all known values for a given annotation property for a given OWL
-   * entity, organized by language.
+   * entity, grouped by language tags. The special language tag "" is used as the key for literals
+   * without an explicit language tag.
    *
    * @param ontology The ontology containing the OWL entity and the annotation property to query
    * @param entity The OWL entity to query

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -235,7 +235,7 @@ public class PhylorefHelper {
    * @param ontology The ontology within which this phyloreference is defined.
    * @return A list of phyloref statuses.
    */
-  public static List<PhylorefStatus> getCurrentStatusesForPhyloref(
+  public static List<PhylorefStatus> getStatusesForPhyloref(
       OWLNamedIndividual phyloref, OWLOntology ontology) {
     List<PhylorefStatus> statuses = new ArrayList<>();
 

--- a/src/test/java/org/phyloref/jphyloref/AppTest.java
+++ b/src/test/java/org/phyloref/jphyloref/AppTest.java
@@ -39,27 +39,29 @@ class AppTest {
     assertNotEquals(jphyloref.VERSION, "");
   }
 
-  /** Test whether we can run the "help" command. */
+  /** Test whether we get the "help" output if we run JPhyloRef without any command line. */
   @Test
-  @DisplayName("has a working 'help' command")
-  void phylorefCommandLineHelp() {
+  @DisplayName("provides 'help' output with an empty command line.")
+  void phylorefEmptyCommandLine() {
     // Run 'help' and see if we get the correct response.
-    jphyloref.execute(new String[] {"help"});
-
+    jphyloref.execute(new String[] {});
     try {
-      String outputStr = output.toString("UTF-8");
-      assertTrue(
-          outputStr.matches("(?s)^JPhyloRef/[\\w\\-\\.]+ OWLAPI/[\\d\\.\\-]+.*"),
-          "We get the version information in the first line: " + outputStr);
-      assertTrue(
-          outputStr.contains("Synopsis: jphyloref <command> <options>"),
-          "We see the synopsis in the output: " + outputStr);
-      assertTrue(
-          outputStr.contains("'jfact': JFact/"),
-          "We see JFact reported in the output: " + outputStr);
+      checkHelpOutput(output.toString("UTF-8"));
     } catch (UnsupportedEncodingException ex) {
       throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);
     }
+  }
+
+  /** This method checks whether the output of the Help command is sensible */
+  private void checkHelpOutput(String outputStr) {
+    assertTrue(
+        outputStr.matches("(?s)^JPhyloRef/[\\w\\-\\.]+ OWLAPI/[\\d\\.\\-]+.*"),
+        "We get the version information in the first line: " + outputStr);
+    assertTrue(
+        outputStr.contains("Synopsis: jphyloref <command> <options>"),
+        "We see the synopsis in the output: " + outputStr);
+    assertTrue(
+        outputStr.contains("'jfact': JFact/"), "We see JFact reported in the output: " + outputStr);
   }
 
   /** Test how JPhyloRef responds to an unknown command. */
@@ -72,6 +74,23 @@ class AppTest {
     try {
       assertEquals("", output.toString("UTF-8"));
       assertEquals("Error: command 'unknown' has not been implemented.\n", error.toString("UTF-8"));
+    } catch (UnsupportedEncodingException ex) {
+      throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);
+    }
+  }
+
+  /** Test whether JPhyloRef works with a malformed command line. */
+  @Test
+  @DisplayName("fails correctly when given a malformed command line")
+  void phylorefCommandLineMalformed() {
+    // Run '----' and see if we get the correct response.
+    jphyloref.execute(new String[] {"----"});
+
+    try {
+      assertEquals("", output.toString("UTF-8"));
+      assertEquals(
+          "Could not parse command line options: org.apache.commons.cli.UnrecognizedOptionException: Unrecognized option: ----\n",
+          error.toString("UTF-8"));
     } catch (UnsupportedEncodingException ex) {
       throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);
     }

--- a/src/test/java/org/phyloref/jphyloref/AppTest.java
+++ b/src/test/java/org/phyloref/jphyloref/AppTest.java
@@ -1,27 +1,71 @@
 package org.phyloref.jphyloref;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import static org.junit.jupiter.api.Assertions.*;
 
-/** Unit test for simple App. */
-public class AppTest extends TestCase {
-  /**
-   * Create the test case
-   *
-   * @param testName name of the test case
-   */
-  public AppTest(String testName) {
-    super(testName);
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** A unit test for running the JPhyloRef application. */
+public class AppTest {
+  /** Test whether JPhyloRef has a version number. */
+  @Test
+  public void phylorefVersion() {
+    JPhyloRef jphyloref = new JPhyloRef();
+    assertNotEquals(jphyloref.VERSION, "");
   }
 
-  /** @return the suite of tests being tested */
-  public static Test suite() {
-    return new TestSuite(AppTest.class);
+  /** Test whether we can run the "help" command. */
+  @Test
+  @DisplayName("Test 'java -jar jphyloref.jar help'")
+  public void phylorefCommandLineHelp() {
+    final ByteArrayOutputStream output = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(output));
+
+    final ByteArrayOutputStream error = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(error));
+
+    // Run 'help' and see if we get the correct response.
+    JPhyloRef jphyloref = new JPhyloRef();
+    jphyloref.execute(new String[] {"help"});
+
+    try {
+      String outputStr = output.toString("UTF-8");
+      assertTrue(
+          outputStr.matches("(?s)^JPhyloRef/[\\w\\-\\.]+ OWLAPI/[\\d\\.\\-]+.*"),
+          "We get the version information in the first line: " + outputStr);
+      assertTrue(
+          outputStr.contains("Synopsis: jphyloref <command> <options>"),
+          "We see the synopsis in the output: " + outputStr);
+      assertTrue(
+          outputStr.contains("'jfact': JFact/"),
+          "We see JFact reported in the output: " + outputStr);
+    } catch (UnsupportedEncodingException ex) {
+      throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);
+    }
   }
 
-  /** Rigourous Test :-) */
-  public void testApp() {
-    assertTrue(true);
+  /** Test how JPhyloRef responds to an unknown command. */
+  @Test
+  @DisplayName("Test 'java -jar jphyloref.jar unknown', which should fail")
+  public void phylorefCommandLineUnknown() {
+    final ByteArrayOutputStream output = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(output));
+
+    final ByteArrayOutputStream error = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(error));
+
+    // Run 'version' and see if we get the correct response.
+    JPhyloRef jphyloref = new JPhyloRef();
+    jphyloref.execute(new String[] {"unknown"});
+
+    try {
+      assertEquals("", output.toString("UTF-8"));
+      assertEquals("Error: command 'unknown' has not been implemented.\n", error.toString("UTF-8"));
+    } catch (UnsupportedEncodingException ex) {
+      throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);
+    }
   }
 }

--- a/src/test/java/org/phyloref/jphyloref/AppTest.java
+++ b/src/test/java/org/phyloref/jphyloref/AppTest.java
@@ -5,30 +5,45 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /** A unit test for running the JPhyloRef application. */
-public class AppTest {
+@DisplayName("The JPhyloRef application")
+class AppTest {
+  static JPhyloRef jphyloref = new JPhyloRef();
+  static ByteArrayOutputStream output = new ByteArrayOutputStream();
+  static ByteArrayOutputStream error = new ByteArrayOutputStream();
+
+  /** Set up input and output streams */
+  @BeforeAll
+  static void setupIO() {
+    System.setOut(new PrintStream(output));
+    System.setErr(new PrintStream(error));
+  }
+
+  /** Reset input and output streams between test runs */
+  @BeforeEach
+  void resetIO() {
+    output.reset();
+    error.reset();
+  }
+
   /** Test whether JPhyloRef has a version number. */
   @Test
-  public void phylorefVersion() {
+  @DisplayName("includes a version number")
+  void phylorefVersion() {
     JPhyloRef jphyloref = new JPhyloRef();
     assertNotEquals(jphyloref.VERSION, "");
   }
 
   /** Test whether we can run the "help" command. */
   @Test
-  @DisplayName("Test 'java -jar jphyloref.jar help'")
-  public void phylorefCommandLineHelp() {
-    final ByteArrayOutputStream output = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(output));
-
-    final ByteArrayOutputStream error = new ByteArrayOutputStream();
-    System.setErr(new PrintStream(error));
-
+  @DisplayName("has a working 'help' command")
+  void phylorefCommandLineHelp() {
     // Run 'help' and see if we get the correct response.
-    JPhyloRef jphyloref = new JPhyloRef();
     jphyloref.execute(new String[] {"help"});
 
     try {
@@ -49,16 +64,9 @@ public class AppTest {
 
   /** Test how JPhyloRef responds to an unknown command. */
   @Test
-  @DisplayName("Test 'java -jar jphyloref.jar unknown', which should fail")
-  public void phylorefCommandLineUnknown() {
-    final ByteArrayOutputStream output = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(output));
-
-    final ByteArrayOutputStream error = new ByteArrayOutputStream();
-    System.setErr(new PrintStream(error));
-
+  @DisplayName("fails correctly for unknown command line commands")
+  void phylorefCommandLineUnknown() {
     // Run 'version' and see if we get the correct response.
-    JPhyloRef jphyloref = new JPhyloRef();
     jphyloref.execute(new String[] {"unknown"});
 
     try {

--- a/src/test/java/org/phyloref/jphyloref/helpers/OWLHelperTest.java
+++ b/src/test/java/org/phyloref/jphyloref/helpers/OWLHelperTest.java
@@ -102,6 +102,13 @@ class OWLHelperTest {
       assertTrue(
           spanishLabels.contains("Label without a language"),
           "Label 'Label without a language' correctly identified.");
+
+      // Look up an unlabeled entity (e.g. "http://example.org/phyloref2").
+      // This should return an empty set.
+      Set<String> unlabeledLabels =
+          OWLHelper.getLabelsInEnglish(
+              df.getOWLNamedIndividual(IRI.create("http://example.org/phyloref2")), testOntology);
+      assertEquals(0, unlabeledLabels.size());
     }
   }
 }

--- a/src/test/java/org/phyloref/jphyloref/helpers/OWLHelperTest.java
+++ b/src/test/java/org/phyloref/jphyloref/helpers/OWLHelperTest.java
@@ -125,6 +125,19 @@ class OWLHelperTest {
           labelsWithoutALanguageTag.contains("Label without a language tag"),
           "Label 'Label without a language tag' correctly identified.");
 
+      // Does OWLHelper.getAnnotationLiteralsForEntity() fall back to returning the same
+      // list if asked for a language for which we don't have any labels, e.g. Spanish ("es")?
+      Set<String> labelsForUnknownLanguage =
+          OWLHelper.getAnnotationLiteralsForEntity(
+              testOntology,
+              phyloref,
+              df.getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI()),
+              Arrays.asList("es"));
+      assertEquals(1, labelsForUnknownLanguage.size());
+      assertTrue(
+          labelsForUnknownLanguage.contains("Label without a language tag"),
+          "Querying for a language tag for which we don't have a label should return labels without a language tag");
+
       // Look up an unlabeled entity (e.g. "http://example.org/phyloref2").
       // This should return an empty set.
       Set<String> unlabeledLabels =

--- a/src/test/java/org/phyloref/jphyloref/helpers/OWLHelperTest.java
+++ b/src/test/java/org/phyloref/jphyloref/helpers/OWLHelperTest.java
@@ -111,18 +111,18 @@ class OWLHelperTest {
           hindiGermanLabels.contains("अंग्रेजी में लेबल"),
           "Label 'अंग्रेजी में लेबल' correctly identified.");
 
-      // Attempt to look up labels in Spanish. Since no such label exist, the
-      // program will look for labels without an explicit language tag, and will
-      // return that instead.
-      Set<String> spanishLabels =
+      // Look up labels without an explicit language. We can do this by asking for
+      // the language "". Note that OWLHelper will also fall back to this if asked
+      // for a language in which it doesn't have a label, such as Spanish ("es").
+      Set<String> labelsWithoutALanguageTag =
           OWLHelper.getAnnotationLiteralsForEntity(
               testOntology,
               phyloref,
               df.getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI()),
-              Arrays.asList("es"));
-      assertEquals(1, spanishLabels.size());
+              Arrays.asList(""));
+      assertEquals(1, labelsWithoutALanguageTag.size());
       assertTrue(
-          spanishLabels.contains("Label without a language tag"),
+          labelsWithoutALanguageTag.contains("Label without a language tag"),
           "Label 'Label without a language tag' correctly identified.");
 
       // Look up an unlabeled entity (e.g. "http://example.org/phyloref2").

--- a/src/test/java/org/phyloref/jphyloref/helpers/OWLHelperTest.java
+++ b/src/test/java/org/phyloref/jphyloref/helpers/OWLHelperTest.java
@@ -1,0 +1,69 @@
+package org.phyloref.jphyloref.helpers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
+
+/** A unit test for running the JPhyloRef application. */
+@DisplayName("OWLHelper")
+class OWLHelperTest {
+  @Nested
+  @DisplayName("has methods for reading labels that can")
+  class ReadingLabelsTest {
+    OWLOntologyManager ontologyManager;
+    OWLOntology testOntology;
+
+    /** Set up the test ontology with annotations involving labels */
+    @BeforeEach
+    void setupOntology() throws OWLOntologyCreationException {
+      // Set up a set of axioms we will use to run these tests.
+      ontologyManager = OWLManager.createOWLOntologyManager();
+      OWLDataFactory df = ontologyManager.getOWLDataFactory();
+
+      // A property for RDFS_LABEL.
+      OWLAnnotationProperty RDFSLabelProperty =
+          df.getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI());
+
+      // Set up some labels on a named individual.
+      List<OWLAxiom> axioms = new ArrayList<>();
+      IRI phyloref1IRI = IRI.create("http://example.org/phyloref1");
+      OWLNamedIndividual phyloref = df.getOWLNamedIndividual(phyloref1IRI);
+      axioms.add(
+          df.getOWLAnnotationAssertionAxiom(
+              RDFSLabelProperty, phyloref1IRI, df.getOWLLiteral("Label without a language", "")));
+      axioms.add(
+          df.getOWLAnnotationAssertionAxiom(
+              RDFSLabelProperty, phyloref1IRI, df.getOWLLiteral("Label in English", "en")));
+      axioms.add(
+          df.getOWLAnnotationAssertionAxiom(
+              RDFSLabelProperty, phyloref1IRI, df.getOWLLiteral("Etikett auf Englisch", "de")));
+      axioms.add(
+          df.getOWLAnnotationAssertionAxiom(
+              RDFSLabelProperty, phyloref1IRI, df.getOWLLiteral("अंग्रेजी में लेबल", "hi")));
+
+      // Set up the test ontology.
+      testOntology = ontologyManager.createOntology(new HashSet(axioms));
+    }
+
+    @Test
+    @DisplayName("read labels in English")
+    void canReadLabelInEnglish() {
+      OWLDataFactory df = ontologyManager.getOWLDataFactory();
+      OWLNamedIndividual phyloref =
+          df.getOWLNamedIndividual(IRI.create("http://example.org/phyloref1"));
+      Set<String> englishLabels = OWLHelper.getLabelsInEnglish(phyloref, testOntology);
+
+      assertEquals(1, englishLabels.size());
+      assertTrue(
+          englishLabels.contains("Label in English"),
+          "Label 'Label in English' correctly identified.");
+    }
+  }
+}

--- a/src/test/java/org/phyloref/jphyloref/helpers/OWLHelperTest.java
+++ b/src/test/java/org/phyloref/jphyloref/helpers/OWLHelperTest.java
@@ -58,12 +58,39 @@ class OWLHelperTest {
       OWLDataFactory df = ontologyManager.getOWLDataFactory();
       OWLNamedIndividual phyloref =
           df.getOWLNamedIndividual(IRI.create("http://example.org/phyloref1"));
-      Set<String> englishLabels = OWLHelper.getLabelsInEnglish(phyloref, testOntology);
 
+      // Look up labels in English.
+      Set<String> englishLabels = OWLHelper.getLabelsInEnglish(phyloref, testOntology);
       assertEquals(1, englishLabels.size());
       assertTrue(
           englishLabels.contains("Label in English"),
           "Label 'Label in English' correctly identified.");
+
+      // Look up Hindi or German names. Since Hindi is listed first, only the
+      // Hindi label is retrieved.
+      Set<String> hindiGermanLabels =
+          OWLHelper.getAnnotationLiteralsForEntity(
+              testOntology,
+              phyloref,
+              df.getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI()),
+              Arrays.asList("hi", "de"));
+      assertEquals(1, hindiGermanLabels.size());
+      assertTrue(
+          hindiGermanLabels.contains("अंग्रेजी में लेबल"),
+          "Label 'अंग्रेजी में लेबल' correctly identified.");
+
+      // Look up Spanish labels. Without a label, we'll default to the name without
+      // a language.
+      Set<String> spanishLabels =
+          OWLHelper.getAnnotationLiteralsForEntity(
+              testOntology,
+              phyloref,
+              df.getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI()),
+              Arrays.asList("es"));
+      assertEquals(1, spanishLabels.size());
+      assertTrue(
+          spanishLabels.contains("Label without a language"),
+          "Label 'Label without a language' correctly identified.");
     }
   }
 }

--- a/src/test/java/org/phyloref/jphyloref/helpers/OWLHelperTest.java
+++ b/src/test/java/org/phyloref/jphyloref/helpers/OWLHelperTest.java
@@ -2,16 +2,27 @@ package org.phyloref.jphyloref.helpers;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLNamedIndividual;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
 
-/** A unit test for running the JPhyloRef application. */
+/** A unit test for the OWLHelper class. */
 @DisplayName("OWLHelper")
 class OWLHelperTest {
   @Nested

--- a/src/test/java/org/phyloref/jphyloref/helpers/OWLHelperTest.java
+++ b/src/test/java/org/phyloref/jphyloref/helpers/OWLHelperTest.java
@@ -34,7 +34,7 @@ class OWLHelperTest {
       // Set up some labels on a named individual.
       List<OWLAxiom> axioms = new ArrayList<>();
       IRI phyloref1IRI = IRI.create("http://example.org/phyloref1");
-      OWLNamedIndividual phyloref = df.getOWLNamedIndividual(phyloref1IRI);
+
       axioms.add(
           df.getOWLAnnotationAssertionAxiom(
               RDFSLabelProperty, phyloref1IRI, df.getOWLLiteral("Label without a language", "")));
@@ -49,7 +49,7 @@ class OWLHelperTest {
               RDFSLabelProperty, phyloref1IRI, df.getOWLLiteral("अंग्रेजी में लेबल", "hi")));
 
       // Set up the test ontology.
-      testOntology = ontologyManager.createOntology(new HashSet(axioms));
+      testOntology = ontologyManager.createOntology(new HashSet<>(axioms));
     }
 
     @Test

--- a/src/test/java/org/phyloref/jphyloref/helpers/PhylorefHelperTest.java
+++ b/src/test/java/org/phyloref/jphyloref/helpers/PhylorefHelperTest.java
@@ -216,32 +216,34 @@ class PhylorefHelperTest {
       // we have no guarantee as to which order these statuses will appear in.
 
       // Find the first status somewhere in this list.
-      assertEquals(
-          1,
+      PhylorefStatus first =
           statuses
               .stream()
-              .filter(
-                  st ->
-                      st.getPhyloref().equals(phyloref)
-                          && st.getStatus().equals(IRI.create("http://purl.org/spar/pso/draft"))
-                          && st.getIntervalStart().equals(Instant.parse("2018-11-14T01:00:00.00Z"))
-                          && st.getIntervalEnd().equals(Instant.parse("2018-11-14T02:00:00.00Z")))
-              .count(),
-          "Found the first status: 'pso:draft'");
+              .filter(st -> st.getStatus().equals(IRI.create("http://purl.org/spar/pso/draft")))
+              .findAny()
+              .get();
+
+      assertEquals(phyloref, first.getPhyloref());
+      assertEquals(Instant.parse("2018-11-14T01:00:00.00Z"), first.getIntervalStart());
+      assertEquals(Instant.parse("2018-11-14T02:00:00.00Z"), first.getIntervalEnd());
+      assertEquals(
+          "phyloreference status http://purl.org/spar/pso/draft starting at 2018-11-14T01:00:00Z ending at 2018-11-14T02:00:00Z",
+          first.toString());
 
       // Find the final status somewhere in this list.
-      assertEquals(
-          1,
+      PhylorefStatus last =
           statuses
               .stream()
-              .filter(
-                  st ->
-                      st.getPhyloref().equals(phyloref)
-                          && st.getStatus().equals(IRI.create("http://purl.org/spar/pso/published"))
-                          && st.getIntervalStart().equals(Instant.parse("2018-11-14T04:00:00.00Z"))
-                          && st.getIntervalEnd() == null)
-              .count(),
-          "Found the final status: 'pso:published'");
+              .filter(st -> st.getStatus().equals(IRI.create("http://purl.org/spar/pso/published")))
+              .findAny()
+              .get();
+
+      assertEquals(phyloref, last.getPhyloref());
+      assertEquals(Instant.parse("2018-11-14T04:00:00.00Z"), last.getIntervalStart());
+      assertNull(last.getIntervalEnd());
+      assertEquals(
+          "phyloreference status http://purl.org/spar/pso/published starting at 2018-11-14T04:00:00Z",
+          last.toString());
 
       // How many are "current" (i.e. missing an end time)?
       assertEquals(1, statuses.stream().filter(st -> st.getIntervalEnd() == null).count());

--- a/src/test/java/org/phyloref/jphyloref/helpers/PhylorefHelperTest.java
+++ b/src/test/java/org/phyloref/jphyloref/helpers/PhylorefHelperTest.java
@@ -2,6 +2,7 @@ package org.phyloref.jphyloref.helpers;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -10,15 +11,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.phyloref.jphyloref.helpers.PhylorefHelper.PhylorefStatus;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnonymousIndividual;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLNamedIndividual;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.model.OWLOntologyStorageException;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
+import org.semanticweb.owlapi.vocab.OWL2Datatype;
 import uk.ac.manchester.cs.jfact.JFactFactory;
 
 /** A unit test for the PhylorefHelper class. */
@@ -57,10 +62,100 @@ class PhylorefHelperTest {
           df.getOWLAnnotationAssertionAxiom(
               df.getRDFSLabel(), phyloref1IRI, df.getOWLLiteral("Test phyloreference", "en")));
 
-      // TODO: Set up annotation properties for setting statuses.
+      // Set up annotation properties for setting statuses.
+      axioms.addAll(
+          createStatus(
+              df,
+              phyloref1IRI,
+              IRI.create("http://purl.org/spar/pso/draft"),
+              Instant.parse("2018-11-14T01:00:00.00Z"),
+              Instant.parse("2018-11-14T02:00:00.00Z")));
+
+      axioms.addAll(
+          createStatus(
+              df,
+              phyloref1IRI,
+              IRI.create("http://purl.org/spar/pso/final-draft"),
+              Instant.parse("2018-11-14T02:00:00.00Z"),
+              Instant.parse("2018-11-14T03:00:00.00Z")));
+
+      axioms.addAll(
+          createStatus(
+              df,
+              phyloref1IRI,
+              IRI.create("http://purl.org/spar/pso/submitted"),
+              Instant.parse("2018-11-14T03:00:00.00Z"),
+              Instant.parse("2018-11-14T04:00:00.00Z")));
+
+      axioms.addAll(
+          createStatus(
+              df,
+              phyloref1IRI,
+              IRI.create("http://purl.org/spar/pso/published"),
+              Instant.parse("2018-11-14T04:00:00.00Z"),
+              null));
 
       // Set up the test ontology.
       testOntology = ontologyManager.createOntology(new HashSet<>(axioms));
+    }
+
+    /**
+     * Return an OWLAnonymousIndividual (i.e. an OWLAnnotationObject) that can be the target of a
+     * `pso:withStatus`.
+     */
+    private List<OWLAxiom> createStatus(
+        OWLDataFactory df, IRI phylorefIRI, IRI status, Instant startTime, Instant endTime) {
+      // Create list of axioms.
+      List<OWLAxiom> axioms = new ArrayList<>();
+
+      // Add start time interval to a timeInterval anonymous individual.
+      OWLAnonymousIndividual timeInterval = df.getOWLAnonymousIndividual();
+      if (startTime != null) {
+        axioms.add(
+            df.getOWLAnnotationAssertionAxiom(
+                df.getOWLAnnotationProperty(
+                    IRI.create(
+                        "http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#hasIntervalStartDate")),
+                timeInterval,
+                df.getOWLLiteral(startTime.toString(), OWL2Datatype.XSD_DATE_TIME)));
+      }
+
+      // Add end time interval to a timeInterval anonymous individual.
+      if (endTime != null) {
+        axioms.add(
+            df.getOWLAnnotationAssertionAxiom(
+                df.getOWLAnnotationProperty(
+                    IRI.create(
+                        "http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#hasIntervalEndDate")),
+                timeInterval,
+                df.getOWLLiteral(endTime.toString(), OWL2Datatype.XSD_DATE_TIME)));
+      }
+
+      // Add timeInterval to a holdsStatusInTime anonymous individual.
+      OWLAnonymousIndividual holdsStatusInTime = df.getOWLAnonymousIndividual();
+      axioms.add(
+          df.getOWLAnnotationAssertionAxiom(
+              df.getOWLAnnotationProperty(
+                  IRI.create("http://www.essepuntato.it/2012/04/tvc/atTime")),
+              holdsStatusInTime,
+              timeInterval));
+
+      // Add the status to a holdsStatusInTime anonymous individual.
+      axioms.add(
+          df.getOWLAnnotationAssertionAxiom(
+              df.getOWLAnnotationProperty(IRI.create("http://purl.org/spar/pso/withStatus")),
+              holdsStatusInTime,
+              status));
+
+      // Annotate the phyloref with the holdsStatusInTime anonymous individual.
+      axioms.add(
+          df.getOWLAnnotationAssertionAxiom(
+              df.getOWLAnnotationProperty(IRI.create("http://purl.org/spar/pso/holdsStatusInTime")),
+              phylorefIRI,
+              holdsStatusInTime));
+
+      // Return the axioms that need to be added.
+      return axioms;
     }
 
     @Test
@@ -72,6 +167,14 @@ class PhylorefHelperTest {
 
       Set<OWLNamedIndividual> phylorefs =
           PhylorefHelper.getPhyloreferencesWithoutReasoning(testOntology);
+      assertEquals(1, phylorefs.size());
+      assertTrue(
+          phylorefs.contains(phyloref),
+          "Phyloref 'phyloref1' has been retrieved without reasoning");
+
+      // Calling getPhyloreferences() with a null reasoner should also return
+      // the same results.
+      phylorefs = PhylorefHelper.getPhyloreferences(testOntology, null);
       assertEquals(1, phylorefs.size());
       assertTrue(
           phylorefs.contains(phyloref),
@@ -94,6 +197,54 @@ class PhylorefHelperTest {
       assertEquals(1, phylorefs.size());
       assertTrue(
           phylorefs.contains(phyloref), "Phyloref 'phyloref1' has been retrieved with reasoning");
+    }
+
+    @Test
+    @DisplayName("can retrieve current statuses for a particular phyloreference")
+    void canRetrieveStatuses() throws OWLOntologyStorageException {
+      OWLDataFactory df = ontologyManager.getOWLDataFactory();
+      OWLNamedIndividual phyloref =
+          df.getOWLNamedIndividual(IRI.create("http://example.org/phyloref1"));
+
+      // Uncomment the next line to provide a copy of the test ontology for debugging.
+      // testOntology.saveOntology(new FileDocumentTarget(new File("./output.txt")));
+
+      List<PhylorefStatus> statuses = PhylorefHelper.getStatusesForPhyloref(phyloref, testOntology);
+      assertEquals(4, statuses.size());
+
+      // Note that OWL doesn't really have a concept of a list of statuses;
+      // we have no guarantee as to which order these statuses will appear in.
+
+      // Find the first status somewhere in this list.
+      assertEquals(
+          1,
+          statuses
+              .stream()
+              .filter(
+                  st ->
+                      st.getPhyloref().equals(phyloref)
+                          && st.getStatus().equals(IRI.create("http://purl.org/spar/pso/draft"))
+                          && st.getIntervalStart().equals(Instant.parse("2018-11-14T01:00:00.00Z"))
+                          && st.getIntervalEnd().equals(Instant.parse("2018-11-14T02:00:00.00Z")))
+              .count(),
+          "Found the first status: 'pso:draft'");
+
+      // Find the final status somewhere in this list.
+      assertEquals(
+          1,
+          statuses
+              .stream()
+              .filter(
+                  st ->
+                      st.getPhyloref().equals(phyloref)
+                          && st.getStatus().equals(IRI.create("http://purl.org/spar/pso/published"))
+                          && st.getIntervalStart().equals(Instant.parse("2018-11-14T04:00:00.00Z"))
+                          && st.getIntervalEnd() == null)
+              .count(),
+          "Found the final status: 'pso:published'");
+
+      // How many are "current" (i.e. missing an end time)?
+      assertEquals(1, statuses.stream().filter(st -> st.getIntervalEnd() == null).count());
     }
   }
 }

--- a/src/test/java/org/phyloref/jphyloref/helpers/PhylorefHelperTest.java
+++ b/src/test/java/org/phyloref/jphyloref/helpers/PhylorefHelperTest.java
@@ -1,0 +1,99 @@
+package org.phyloref.jphyloref.helpers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLNamedIndividual;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.reasoner.OWLReasoner;
+import uk.ac.manchester.cs.jfact.JFactFactory;
+
+/** A unit test for the PhylorefHelper class. */
+@DisplayName("PhylorefHelper")
+class PhylorefHelperTest {
+  @Nested
+  @DisplayName("has methods for retrieving lists of phylorefs that can")
+  class PhylorefRetrievalTest {
+    OWLOntologyManager ontologyManager;
+    OWLOntology testOntology;
+
+    /** Set up the test ontology with annotations involving labels */
+    @BeforeEach
+    void setupOntology() throws OWLOntologyCreationException {
+      // Set up a set of axioms we will use to run these tests.
+      ontologyManager = OWLManager.createOWLOntologyManager();
+      OWLDataFactory df = ontologyManager.getOWLDataFactory();
+
+      // Set up a phyloreference we can use for testing.
+      List<OWLAxiom> axioms = new ArrayList<>();
+      IRI phyloref1IRI = IRI.create("http://example.org/phyloref1");
+      OWLNamedIndividual phyloref1 = df.getOWLNamedIndividual(phyloref1IRI);
+
+      // Mark it as a phyloreference.
+      // (Eventually we would like to test whether we can infer that an
+      // individual belongs to class phyloref:Phyloreference based on its
+      // properties alone, but so far no property does this.)
+      axioms.add(
+          df.getOWLClassAssertionAxiom(
+              df.getOWLClass(
+                  IRI.create("http://ontology.phyloref.org/phyloref.owl#Phyloreference")),
+              phyloref1));
+
+      // Give the phyloreference a label.
+      axioms.add(
+          df.getOWLAnnotationAssertionAxiom(
+              df.getRDFSLabel(), phyloref1IRI, df.getOWLLiteral("Test phyloreference", "en")));
+
+      // TODO: Set up annotation properties for setting statuses.
+
+      // Set up the test ontology.
+      testOntology = ontologyManager.createOntology(new HashSet<>(axioms));
+    }
+
+    @Test
+    @DisplayName("can retrieve lists of phylorefs without reasoning")
+    void canRetrievePhylorefsWithoutReasoning() {
+      OWLDataFactory df = ontologyManager.getOWLDataFactory();
+      OWLNamedIndividual phyloref =
+          df.getOWLNamedIndividual(IRI.create("http://example.org/phyloref1"));
+
+      Set<OWLNamedIndividual> phylorefs =
+          PhylorefHelper.getPhyloreferencesWithoutReasoning(testOntology);
+      assertEquals(1, phylorefs.size());
+      assertTrue(
+          phylorefs.contains(phyloref),
+          "Phyloref 'phyloref1' has been retrieved without reasoning");
+    }
+
+    @Test
+    @DisplayName("can retrieve lists of phylorefs with reasoning")
+    void canRetrievePhylorefsWithReasoning() {
+      OWLDataFactory df = ontologyManager.getOWLDataFactory();
+      OWLReasoner reasoner = new JFactFactory().createNonBufferingReasoner(testOntology);
+      OWLNamedIndividual phyloref =
+          df.getOWLNamedIndividual(IRI.create("http://example.org/phyloref1"));
+
+      // Note that this should be identical to the "without reasoning" code in
+      // the absence of individuals that are implied to be Phyloreferences but
+      // not explicitly stated to be phylorefs. This is not tested yet!
+
+      Set<OWLNamedIndividual> phylorefs = PhylorefHelper.getPhyloreferences(testOntology, reasoner);
+      assertEquals(1, phylorefs.size());
+      assertTrue(
+          phylorefs.contains(phyloref), "Phyloref 'phyloref1' has been retrieved with reasoning");
+    }
+  }
+}

--- a/src/test/java/org/phyloref/jphyloref/helpers/ReasonerHelperTest.java
+++ b/src/test/java/org/phyloref/jphyloref/helpers/ReasonerHelperTest.java
@@ -45,6 +45,18 @@ class ReasonerHelperTest {
     }
 
     @Test
+    @DisplayName("fails correctly when given an incorrect reasoner name")
+    void failsCorrectly() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> {
+            ReasonerHelper.getReasonerFactory("incorrect");
+          },
+          "No reasoner named 'incorrect'; must be one of: "
+              + ReasonerHelper.getReasonerFactories().keySet().toString());
+    }
+
+    @Test
     @DisplayName("can read the reasoner from the command line")
     void canReadFromCmdLine() {
       Options cmdLineOptions = new Options();

--- a/src/test/java/org/phyloref/jphyloref/helpers/ReasonerHelperTest.java
+++ b/src/test/java/org/phyloref/jphyloref/helpers/ReasonerHelperTest.java
@@ -2,7 +2,7 @@ package org.phyloref.jphyloref.helpers;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.*;
+import java.util.Map;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
@@ -10,10 +10,9 @@ import org.apache.commons.cli.ParseException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 
-/** A unit test for running the JPhyloRef application. */
+/** A unit test for the ReasonerHelper class */
 @DisplayName("ReasonerHelper")
 class ReasonerHelperTest {
   @Nested

--- a/src/test/java/org/phyloref/jphyloref/helpers/ReasonerHelperTest.java
+++ b/src/test/java/org/phyloref/jphyloref/helpers/ReasonerHelperTest.java
@@ -1,0 +1,70 @@
+package org.phyloref.jphyloref.helpers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.*;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
+
+/** A unit test for running the JPhyloRef application. */
+@DisplayName("ReasonerHelper")
+class ReasonerHelperTest {
+  @Nested
+  @DisplayName("has methods for accessing reasoner factories that")
+  class ReasonerFactoriesTest {
+    @Test
+    @DisplayName("can provide a list of reasoner factories")
+    void canAccessList() {
+      Map<String, OWLReasonerFactory> list = ReasonerHelper.getReasonerFactories();
+      assertFalse(list.isEmpty(), "List of reasoner factories should not be empty");
+    }
+
+    @Test
+    @DisplayName("can access a null reasoner")
+    void canAccessNull() {
+      OWLReasonerFactory nullFactory = ReasonerHelper.getReasonerFactory("null");
+      assertNull(nullFactory);
+      assertEquals("No reasoner used", ReasonerHelper.getReasonerNameAndVersion(nullFactory));
+    }
+
+    @Test
+    @DisplayName("can access the JFact reasoner")
+    void canAccessJFact() {
+      OWLReasonerFactory jFactFactory = ReasonerHelper.getReasonerFactory("jfact");
+      assertEquals("uk.ac.manchester.cs.jfact.JFactFactory", jFactFactory.getClass().getName());
+      assertTrue(
+          ReasonerHelper.getReasonerNameAndVersion(jFactFactory).startsWith("JFact/1."),
+          "'jfact' should refer to JFact version 1.x");
+    }
+
+    @Test
+    @DisplayName("can read the reasoner from the command line")
+    void canReadFromCmdLine() {
+      Options cmdLineOptions = new Options();
+      ReasonerHelper.addCommandLineOptions(cmdLineOptions);
+
+      try {
+        CommandLine cmdLine =
+            new DefaultParser().parse(cmdLineOptions, new String[] {"--reasoner", "null"});
+        assertNull(ReasonerHelper.getReasonerFactoryFromCmdLine(cmdLine));
+
+        cmdLine = new DefaultParser().parse(cmdLineOptions, new String[] {"--reasoner", "jfact"});
+        OWLReasonerFactory jFactFactory = ReasonerHelper.getReasonerFactoryFromCmdLine(cmdLine);
+        assertEquals("uk.ac.manchester.cs.jfact.JFactFactory", jFactFactory.getClass().getName());
+        assertTrue(
+            ReasonerHelper.getReasonerNameAndVersion(jFactFactory).startsWith("JFact/1."),
+            "'--reasoner jfact' should load JFact version 1.x");
+
+      } catch (ParseException ex) {
+        throw new RuntimeException("Pre-written command line arguments could not be parsed: " + ex);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR creates a very basic test suite using JUnit 5, including tests for the main program (JPhyloRef) and the three backend classes (OWLHelper, PhylorefHelper and ReasonerHelper), and adds a code coverage tool for highlighting untested code (JaCoCo). This PR upgrades the testing infrastructure from JUnit 3 to JUnit 5 and removes several `System.exit()` calls so that methods can be tested without exiting the test suite.

None of the commands (ReasonCommand, TestCommand and WebserverCommand) have been tested yet, as this code is complicated and should be refactored to facilitate testing first. It therefore only partially closes #3, which will be left open until all the code has been comprehensively tested.