### PR TITLE
Added Spotless as a code style enforcer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,31 @@
 
     <build>
         <plugins>
+            <!-- Use Spotless to check and fix style: https://github.com/diffplug/spotless/tree/master/plugin-maven -->
+            <plugin>
+              <groupId>com.diffplug.spotless</groupId>
+              <artifactId>spotless-maven-plugin</artifactId>
+              <version>1.15.0</version>
+              <configuration>
+                <java>
+                  <googleJavaFormat>
+                    <version>1.6</version>
+                    <style>GOOGLE</style>
+                  </googleJavaFormat>
+                  <removeUnusedImports/>
+                </java>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>test</id>
+                  <phase>test</phase>
+                  <goals>
+                    <goal>check</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -3,7 +3,6 @@ package org.phyloref.jphyloref;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
@@ -14,155 +13,149 @@ import org.phyloref.jphyloref.commands.ReasonCommand;
 import org.phyloref.jphyloref.commands.TestCommand;
 import org.phyloref.jphyloref.commands.WebserverCommand;
 import org.phyloref.jphyloref.helpers.ReasonerHelper;
-import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
-import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
-import org.semanticweb.owlapi.util.Version;
 import org.semanticweb.owlapi.util.VersionInfo;
 
 /**
- * Main class for JPhyloRef. Contains a list of Commands,
- * as well as the code for determining which Command to
- * execute.
- *
+ * Main class for JPhyloRef. Contains a list of Commands, as well as the code for determining which
+ * Command to execute.
  */
 public class JPhyloRef {
-    /** Version of JPhyloRef. */
-    public static final String VERSION = "0.2-SNAPSHOT";
+  /** Version of JPhyloRef. */
+  public static final String VERSION = "0.2-SNAPSHOT";
 
-    /** List of all commands included in JPhyloRef. */
-    private List<Command> commands = Arrays.asList(
-        new HelpCommand(),
-        new TestCommand(),
-        new WebserverCommand(),
-        new ReasonCommand()
-    );
+  /** List of all commands included in JPhyloRef. */
+  private List<Command> commands =
+      Arrays.asList(
+          new HelpCommand(), new TestCommand(), new WebserverCommand(), new ReasonCommand());
 
-    /**
-     * Interpret the command line arguments to determine which command
-     * to execute.
-     *
-     * @param args Command line arguments
-     */
-    public void execute(String[] args) {
-        // Prepare to parse command line arguments.
+  /**
+   * Interpret the command line arguments to determine which command to execute.
+   *
+   * @param args Command line arguments
+   */
+  public void execute(String[] args) {
+    // Prepare to parse command line arguments.
+    Options opts = new Options();
+
+    // Add global options.
+    ReasonerHelper.addCommandLineOptions(opts);
+
+    // Add per-command options.
+    for (Command cmd : commands) {
+      cmd.addCommandLineOptions(opts);
+    }
+
+    // Parse command line arguments.
+    CommandLine cmdLine;
+    try {
+      cmdLine = new DefaultParser().parse(opts, args);
+    } catch (ParseException ex) {
+      System.err.println("Could not parse command line options: " + ex);
+      System.exit(1);
+      return;
+    }
+
+    // Are there any command line arguments?
+    if (cmdLine.getArgList().isEmpty()) {
+      // No command line arguments -- display help!
+      HelpCommand help = new HelpCommand();
+      help.execute(cmdLine);
+    } else {
+      // Look for global options:
+      //	--reasoner: Set the reasoner.
+
+      // The first unprocessed argument should be the command.
+      String command = cmdLine.getArgList().get(0);
+
+      // Look for a Command with the name specified.
+      for (Command cmd : commands) {
+        if (cmd.getName().equalsIgnoreCase(command)) {
+          // Found a match!
+          cmd.execute(cmdLine);
+          System.exit(0);
+        }
+      }
+
+      // Could not find any command.
+      System.err.println("Error: command '" + command + "' has not been implemented.");
+      System.exit(1);
+    }
+  }
+
+  /**
+   * Main method for JPhyloRef. Creates the JPhyloRef instance and tells it to start processing the
+   * command line arguments.
+   *
+   * @param args Command line arguments
+   */
+  public static void main(String[] args) {
+    JPhyloRef jphyloref = new JPhyloRef();
+    jphyloref.execute(args);
+  }
+
+  /**
+   * HelpCommand is a special command that lists help information on all currently implemented
+   * Commands. You can activate it by running "jphyloref help" or by just entering "jphyloref"
+   * without any command.
+   */
+  private class HelpCommand implements Command {
+    /** This command is named "help", and so can be executed as "jphyloref help". */
+    public String getName() {
+      return "help";
+    }
+
+    /** Returns a description of the Help command. */
+    public String getDescription() {
+      return "Provides help on all jphyloref commands";
+    }
+
+    /** There are no command line options for the Help command. */
+    public void addCommandLineOptions(Options opts) {}
+
+    /** Display a list of Commands that can be executed on the command line. */
+    public void execute(CommandLine cmdLine) {
+      // Display version number.
+      System.out.println(
+          "JPhyloRef/"
+              + JPhyloRef.VERSION
+              + " OWLAPI/"
+              + VersionInfo.getVersionInfo().getVersion());
+
+      // Display a synopsis.
+      System.out.println("Synopsis: jphyloref <command> <options>\n");
+
+      // Display a list of currently included Commands.
+      System.out.println("Where command is one of:");
+      for (Command cmd : commands) {
+        // Display the description of the command.
+        System.out.println(" - " + cmd.getName() + ": " + cmd.getDescription());
+
+        // Display all the command line options supported by that command.
         Options opts = new Options();
-        
-        // Add global options.
-        ReasonerHelper.addCommandLineOptions(opts);
-        
-        // Add per-command options.
-        for(Command cmd: commands) {
-            cmd.addCommandLineOptions(opts);
+        cmd.addCommandLineOptions(opts);
+
+        for (Option opt : opts.getOptions()) {
+          String longOpt = "";
+          if (opt.getLongOpt() != null) longOpt = ", " + opt.getLongOpt();
+
+          System.out.println("    - " + opt.getOpt() + longOpt + ": " + opt.getDescription());
         }
+      }
 
-        // Parse command line arguments.
-        CommandLine cmdLine;
-        try {
-            cmdLine = new DefaultParser().parse(opts, args);
-        } catch(ParseException ex) {
-            System.err.println("Could not parse command line options: " + ex);
-            System.exit(1);
-            return;
-        }
+      // Display global options, including the list of possible reasoners.
+      System.out.println("\nWe also accept some global options, including:");
+      System.out.println(
+          " --reasoner <reasonerName>: sets the reasoner name, which should be one of:");
+      Map<String, OWLReasonerFactory> reasonerList = ReasonerHelper.getReasonerFactories();
+      for (String name : reasonerList.keySet()) {
+        OWLReasonerFactory factory = reasonerList.get(name);
+        System.out.println(
+            "    '" + name + "': " + ReasonerHelper.getReasonerNameAndVersion(factory));
+      }
 
-        // Are there any command line arguments?
-        if(cmdLine.getArgList().isEmpty()) {
-            // No command line arguments -- display help!
-            HelpCommand help = new HelpCommand();
-            help.execute(cmdLine);
-        } else {
-        	// Look for global options:
-        	//	--reasoner: Set the reasoner.
-        	
-            // The first unprocessed argument should be the command.
-            String command = cmdLine.getArgList().get(0);
-
-            // Look for a Command with the name specified.
-            for(Command cmd: commands) {
-                if(cmd.getName().equalsIgnoreCase(command)) {
-                    // Found a match!
-                    cmd.execute(cmdLine);
-                    System.exit(0);
-                }
-            }
-
-            // Could not find any command.
-            System.err.println("Error: command '" + command + "' has not been implemented.");
-            System.exit(1);
-        }
+      // One final blank line, please.
+      System.out.println("");
     }
-
-    /**
-     * Main method for JPhyloRef. Creates the JPhyloRef instance
-     * and tells it to start processing the command line arguments.
-     *
-     * @param args Command line arguments
-     */
-    public static void main( String[] args )
-    {
-        JPhyloRef jphyloref = new JPhyloRef();
-        jphyloref.execute(args);
-    }
-
-    /**
-     * HelpCommand is a special command that lists help information on all currently
-     * implemented Commands. You can activate it by running "jphyloref help" or by
-     * just entering "jphyloref" without any command.
-     */
-    private class HelpCommand implements Command {
-        /** This command is named "help", and so can be executed as "jphyloref help". */
-        public String getName() { return "help"; }
-
-        /** Returns a description of the Help command. */
-        public String getDescription() { return "Provides help on all jphyloref commands"; }
-
-        /** There are no command line options for the Help command. */
-        public void addCommandLineOptions(Options opts) { }
-
-        /** Display a list of Commands that can be executed on the command line. */
-        public void execute(CommandLine cmdLine) {
-			// Display version number.
-			System.out.println("JPhyloRef/" + JPhyloRef.VERSION + " OWLAPI/" + VersionInfo.getVersionInfo().getVersion());
-
-            // Display a synopsis.
-            System.out.println("Synopsis: jphyloref <command> <options>\n");
-
-            // Display a list of currently included Commands.
-            System.out.println("Where command is one of:");
-            for(Command cmd: commands) {
-                // Display the description of the command.
-                System.out.println(" - " + cmd.getName() + ": " + cmd.getDescription());
-
-                // Display all the command line options supported by that command.
-                Options opts = new Options();
-                cmd.addCommandLineOptions(opts);
-
-                for(Option opt: opts.getOptions()) {
-                    String longOpt = "";
-                    if(opt.getLongOpt() != null)
-                        longOpt = ", " + opt.getLongOpt();
-
-                    System.out.println("    - "
-                        + opt.getOpt() + longOpt + ": "
-                        + opt.getDescription()
-                    );
-                }
-            }
-            
-            // Display global options, including the list of possible reasoners.
-            System.out.println("\nWe also accept some global options, including:");
-            System.out.println(" --reasoner <reasonerName>: sets the reasoner name, which should be one of:");
-            Map<String, OWLReasonerFactory> reasonerList = ReasonerHelper.getReasonerFactories();
-            for(String name: reasonerList.keySet()) {
-            	OWLReasonerFactory factory = reasonerList.get(name);            	
-            	System.out.println("    '" + name + "': " + ReasonerHelper.getReasonerNameAndVersion(factory));
-            }
-
-            // One final blank line, please.
-            System.out.println("");
-        }
-    }
+  }
 }

--- a/src/main/java/org/phyloref/jphyloref/commands/Command.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/Command.java
@@ -4,36 +4,29 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 
 /**
- * Commands provide commands for jphyloref to run. These are usually
- * in the form 'jphyloref <em>command</em> ...'
- * 
- * @author Gaurav Vaidya <gaurav@ggvaidya.com>
+ * Commands provide commands for jphyloref to run. These are usually in the form 'jphyloref
+ * <em>command</em> ...'
  *
+ * @author Gaurav Vaidya <gaurav@ggvaidya.com>
  */
 public interface Command {
-    /** 
-     * The name of this command. The command is usually 
-     * invoked as "jphyloref command ...".
-     * 
-     * @return The name of this command.
-     */
-    public String getName();
+  /**
+   * The name of this command. The command is usually invoked as "jphyloref command ...".
+   *
+   * @return The name of this command.
+   */
+  public String getName();
 
-    /**
-     * A one-line description of this command.
-     * 
-     * @return
-     */
-    public String getDescription();
+  /**
+   * A one-line description of this command.
+   *
+   * @return
+   */
+  public String getDescription();
 
-    /**
-     * A list of valid command line options. These should
-     * be added to the provided Options object.
-     */
-    public void addCommandLineOptions(Options opts);
+  /** A list of valid command line options. These should be added to the provided Options object. */
+  public void addCommandLineOptions(Options opts);
 
-    /**
-     * Execute this command with the provided command line options. 
-     */
-    public void execute(CommandLine cmdLine);
+  /** Execute this command with the provided command line options. */
+  public void execute(CommandLine cmdLine);
 }

--- a/src/main/java/org/phyloref/jphyloref/commands/ReasonCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/ReasonCommand.java
@@ -2,7 +2,6 @@ package org.phyloref.jphyloref.commands;
 
 import java.io.File;
 import java.util.Set;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.semanticweb.owlapi.apibinding.OWLManager;
@@ -15,89 +14,91 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.reasoner.BufferingMode;
 import org.semanticweb.owlapi.reasoner.InferenceType;
-
 import uk.ac.manchester.cs.jfact.JFactReasoner;
 import uk.ac.manchester.cs.jfact.kernel.options.JFactReasonerConfiguration;
 
 /**
  * Reason over the provided ontology and provide both ABox and TBox.
- * 
- * Eventually, I'd like to set this up to output the complete reasoned ontology,
- * so that we can poke at the result using rdflib in Python. For now, however, 
- * it works as a simple proof-of-concept that phyloreferencing resolution is
- * occuring.
- * 
- * @author Gaurav Vaidya <gaurav@ggvaidya.com>
  *
+ * <p>Eventually, I'd like to set this up to output the complete reasoned ontology, so that we can
+ * poke at the result using rdflib in Python. For now, however, it works as a simple
+ * proof-of-concept that phyloreferencing resolution is occuring.
+ *
+ * @author Gaurav Vaidya <gaurav@ggvaidya.com>
  */
 public class ReasonCommand implements Command {
-	public String getName() { return "reason"; }
-	public String getDescription() { return "Reason over the provided ontology and provide both ABox and TBox."; }
-	
-	public void addCommandLineOptions(Options opts) {
-		opts.addOption("i", "input", true, "The input ontology to read in RDF/XML");
-		opts.addOption("o", "output", true, "Where to write the reasoned ontology in RDF/XML");
-	}
-	
-	/**
-	 * Execute this command with the provided command line options. 
-	 */
-	public void execute(CommandLine cmdLine) {
-		String str_input = cmdLine.getOptionValue("input");
-		String str_output = cmdLine.getOptionValue("output");
-		
-		if(str_input == null) {
-			System.err.println("Error: no input ontology specified (use '-i input.owl')");
-			return;
-		}
-		
-		File inputFile = new File(str_input);
-		if(!inputFile.exists() || !inputFile.canRead()) {
-			System.err.println("Error: cannot read from input ontology '" + str_input + "'");
-			return;
-		}
-		
-		System.err.println("Input: " + str_input);
-		System.err.println("Output: " + str_output);
-		
-		// Load the ontology into inputOntology.
-		OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
-		OWLOntology ontology;
-		try {
-			ontology = manager.loadOntologyFromOntologyDocument(inputFile);
-		} catch (OWLOntologyCreationException ex) {
-			System.err.println("Could not load ontology '" + inputFile + "': " + ex);
-			return;
-		}
-		
-		// Ontology loaded.
-		System.err.println("Loaded ontology: " + ontology);
-		
-		// Now to reason.
-		JFactReasonerConfiguration config = new JFactReasonerConfiguration();
-		JFactReasoner reasoner = new JFactReasoner(ontology, config, BufferingMode.BUFFERING);
-		
-		reasoner.precomputeInferences(InferenceType.CLASS_ASSERTIONS);
-		
-		System.err.println("Precomputing complete.");
-		
-		// Finally, tell us how each node was characterized.
-		IRI iri_Node = IRI.create("http://purl.obolibrary.org/obo/CDAO_0000140");
-		Set<OWLEntity> optClassNode = ontology.getEntitiesInSignature(iri_Node);
-		if(optClassNode.isEmpty()) throw new RuntimeException("No Nodes found in ontology '" + ontology + "'");
-		OWLEntity class_Node = optClassNode.iterator().next();
-		
-		// Get all nodes belonging to class Node.
-		Set<OWLNamedIndividual> individuals = reasoner.getInstances(class_Node.asOWLClass(), false).getFlattened();
-		
-		System.out.println(individuals.size() + " nodes found:");
-		for(OWLNamedIndividual node: individuals) {
-			System.out.print(" - " + node.getIRI().getFragment() + ": ");
-			
-			for(OWLClass cl: reasoner.getTypes(node, true).getFlattened()) {
-				System.out.print(cl + "; ");
-			}
-			System.out.println("");
-		}
-	}
+  public String getName() {
+    return "reason";
+  }
+
+  public String getDescription() {
+    return "Reason over the provided ontology and provide both ABox and TBox.";
+  }
+
+  public void addCommandLineOptions(Options opts) {
+    opts.addOption("i", "input", true, "The input ontology to read in RDF/XML");
+    opts.addOption("o", "output", true, "Where to write the reasoned ontology in RDF/XML");
+  }
+
+  /** Execute this command with the provided command line options. */
+  public void execute(CommandLine cmdLine) {
+    String str_input = cmdLine.getOptionValue("input");
+    String str_output = cmdLine.getOptionValue("output");
+
+    if (str_input == null) {
+      System.err.println("Error: no input ontology specified (use '-i input.owl')");
+      return;
+    }
+
+    File inputFile = new File(str_input);
+    if (!inputFile.exists() || !inputFile.canRead()) {
+      System.err.println("Error: cannot read from input ontology '" + str_input + "'");
+      return;
+    }
+
+    System.err.println("Input: " + str_input);
+    System.err.println("Output: " + str_output);
+
+    // Load the ontology into inputOntology.
+    OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
+    OWLOntology ontology;
+    try {
+      ontology = manager.loadOntologyFromOntologyDocument(inputFile);
+    } catch (OWLOntologyCreationException ex) {
+      System.err.println("Could not load ontology '" + inputFile + "': " + ex);
+      return;
+    }
+
+    // Ontology loaded.
+    System.err.println("Loaded ontology: " + ontology);
+
+    // Now to reason.
+    JFactReasonerConfiguration config = new JFactReasonerConfiguration();
+    JFactReasoner reasoner = new JFactReasoner(ontology, config, BufferingMode.BUFFERING);
+
+    reasoner.precomputeInferences(InferenceType.CLASS_ASSERTIONS);
+
+    System.err.println("Precomputing complete.");
+
+    // Finally, tell us how each node was characterized.
+    IRI iri_Node = IRI.create("http://purl.obolibrary.org/obo/CDAO_0000140");
+    Set<OWLEntity> optClassNode = ontology.getEntitiesInSignature(iri_Node);
+    if (optClassNode.isEmpty())
+      throw new RuntimeException("No Nodes found in ontology '" + ontology + "'");
+    OWLEntity class_Node = optClassNode.iterator().next();
+
+    // Get all nodes belonging to class Node.
+    Set<OWLNamedIndividual> individuals =
+        reasoner.getInstances(class_Node.asOWLClass(), false).getFlattened();
+
+    System.out.println(individuals.size() + " nodes found:");
+    for (OWLNamedIndividual node : individuals) {
+      System.out.print(" - " + node.getIRI().getFragment() + ": ");
+
+      for (OWLClass cl : reasoner.getTypes(node, true).getFlattened()) {
+        System.out.print(cl + "; ");
+      }
+      System.out.println("");
+    }
+  }
 }

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -15,23 +15,17 @@ import org.phyloref.jphyloref.helpers.ReasonerHelper;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.AxiomType;
 import org.semanticweb.owlapi.model.ClassExpressionType;
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLAnnotation;
-import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
-import org.semanticweb.owlapi.model.OWLAnonymousIndividual;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLClassAssertionAxiom;
 import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLDataProperty;
-import org.semanticweb.owlapi.model.OWLDataPropertyAssertionAxiom;
 import org.semanticweb.owlapi.model.OWLNamedIndividual;
 import org.semanticweb.owlapi.model.OWLObjectProperty;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
-import org.semanticweb.owlapi.reasoner.BufferingMode;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 import org.semanticweb.owlapi.search.EntitySearcher;
@@ -46,345 +40,400 @@ import org.tap4j.producer.TapProducer;
 import org.tap4j.producer.TapProducerFactory;
 import org.tap4j.util.DirectiveValues;
 import org.tap4j.util.StatusValues;
-import uk.ac.manchester.cs.jfact.JFactReasoner;
-import uk.ac.manchester.cs.jfact.kernel.options.JFactReasonerConfiguration;
 
 /**
- * Test whether the phyloreferences in the provided ontology resolve correctly.
- * This currently supports RDF/XML input only, but we will eventually modify
- * this to support PHYX files directly.
+ * Test whether the phyloreferences in the provided ontology resolve correctly. This currently
+ * supports RDF/XML input only, but we will eventually modify this to support PHYX files directly.
  *
- * Testing output is produced using the Test Anything Protocol, which has nice
- * libraries in both Python and Java.
+ * <p>Testing output is produced using the Test Anything Protocol, which has nice libraries in both
+ * Python and Java.
  *
  * @author Gaurav Vaidya <gaurav@ggvaidya.com>
- *
  */
 public class TestCommand implements Command {
-    /**
-     * This command is named "test". It should be
-     * invoked as "java -jar jphyloref.jar test ..."
-     */
+  /** This command is named "test". It should be invoked as "java -jar jphyloref.jar test ..." */
+  @Override
+  public String getName() {
+    return "test";
+  }
 
-    @Override
-    public String getName() {
-        return "test";
+  /**
+   * A description of the Test command.
+   *
+   * @return A description of this command.
+   */
+  @Override
+  public String getDescription() {
+    return "Test the phyloreferences in the provided ontology to determine if they resolved correctly.";
+  }
+
+  /**
+   * Add command-line options specific to this command.
+   *
+   * @param opts The command-line options to modify for this command.
+   */
+  @Override
+  public void addCommandLineOptions(Options opts) {
+    opts.addOption(
+        "i",
+        "input",
+        true,
+        "The input ontology to read in RDF/XML (can also be provided without the '-i')");
+  }
+
+  /**
+   * Given an input ontology, reason over it and determine if nodes are identified correctly. It
+   * provides output on System.out using the Test Anything Protocol (TAP:
+   * https://testanything.org/).
+   *
+   * @param cmdLine The command line options provided to this command.
+   */
+  @Override
+  public void execute(CommandLine cmdLine) throws RuntimeException {
+    // Extract command-line options
+    String str_input = cmdLine.getOptionValue("input");
+
+    if (str_input == null && cmdLine.getArgList().size() > 1) {
+      // No 'input'? Maybe it's just provided as a left-over option?
+      str_input = cmdLine.getArgList().get(1);
     }
 
-    /**
-     * A description of the Test command.
-     *
-     * @return A description of this command.
-     */
-    @Override
-    public String getDescription() {
-        return "Test the phyloreferences in the provided ontology to determine if they resolved correctly.";
+    if (str_input == null) {
+      throw new IllegalArgumentException("Error: no input ontology specified (use '-i input.owl')");
     }
 
-    /**
-     * Add command-line options specific to this command.
-     *
-     * @param opts The command-line options to modify for this command.
-     */
-    @Override
-    public void addCommandLineOptions(Options opts) {
-        opts.addOption(
-            "i", "input", true,
-            "The input ontology to read in RDF/XML (can also be provided without the '-i')"
-        );
+    // Create File object to load
+    File inputFile = new File(str_input);
+    System.err.println("Input: " + inputFile);
+
+    // Set up an OWL Ontology Manager to work with.
+    OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
+
+    // Is purl.obolibrary.org down? No worries, you can access local copies
+    // of your ontologies in the 'ontologies/' folder.
+    AutoIRIMapper mapper = new AutoIRIMapper(new File("ontologies"), true);
+    System.err.println("Found local ontologies: " + mapper.getOntologyIRIs());
+    manager.addIRIMapper(mapper);
+
+    // Load the ontology using OWLManager.
+    OWLOntology ontology;
+    try {
+      ontology = manager.loadOntologyFromOntologyDocument(inputFile);
+    } catch (OWLOntologyCreationException ex) {
+      throw new RuntimeException("Could not load ontology '" + inputFile + "': " + ex);
     }
 
-    /**
-     * Given an input ontology, reason over it and determine if nodes are
-     * identified correctly. It provides output on System.out using the
-     * Test Anything Protocol (TAP: https://testanything.org/).
-     *
-     * @param cmdLine The command line options provided to this command.
-     */
-    @Override
-    public void execute(CommandLine cmdLine) throws RuntimeException {
-        // Extract command-line options
-        String str_input = cmdLine.getOptionValue("input");
+    // Ontology loaded.
+    System.err.println("Loaded ontology: " + ontology);
 
-        if(str_input == null && cmdLine.getArgList().size() > 1) {
-            // No 'input'? Maybe it's just provided as a left-over option?
-            str_input = cmdLine.getArgList().get(1);
+    // Reason over the loaded ontology -- but only if the user wants that!
+    // Set up an OWLReasoner to work with.
+    OWLReasonerFactory reasonerFactory = ReasonerHelper.getReasonerFactoryFromCmdLine(cmdLine);
+    OWLReasoner reasoner = null;
+    if (reasonerFactory != null) reasoner = reasonerFactory.createReasoner(ontology);
+    Set<OWLNamedIndividual> phylorefs;
+
+    // Get a list of all phyloreferences.
+    phylorefs = PhylorefHelper.getPhyloreferences(ontology, reasoner);
+
+    // Okay, time to start testing! Each phyloreference counts as one test.
+    // TAP (https://testanything.org/) can be read by downstream software
+    // to determine which phyloreferences resolved correctly and which did not.
+    TapProducer tapProducer = TapProducerFactory.makeTap13Producer();
+    TestSet testSet = new TestSet();
+    testSet.setPlan(new Plan(phylorefs.size()));
+
+    // Preload some terms we need to use in the following code.
+    OWLDataFactory dataFactory = manager.getOWLDataFactory();
+
+    // Some classes we will use.
+    OWLClass classCDAONode = dataFactory.getOWLClass(PhylorefHelper.IRI_CDAO_NODE);
+
+    // Terms associated with phyloreferences
+    OWLAnnotationProperty labelAnnotationProperty =
+        dataFactory.getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI());
+    OWLDataProperty expectedPhyloreferenceNamedProperty =
+        dataFactory.getOWLDataProperty(PhylorefHelper.IRI_NAME_OF_EXPECTED_PHYLOREF);
+    OWLObjectProperty unmatchedSpecifierProperty =
+        dataFactory.getOWLObjectProperty(PhylorefHelper.IRI_PHYLOREF_UNMATCHED_SPECIFIER);
+    // OWLDataProperty specifierDefinitionProperty =
+    // dataFactory.getOWLDataProperty(PhylorefHelper.IRI_CLADE_DEFINITION);
+
+    // Count the number of test results.
+    int testNumber = 0;
+    int countSuccess = 0;
+    int countFailure = 0;
+    int countTODO = 0;
+    int countSkipped = 0;
+
+    // Test each phyloreference individually.
+    for (OWLNamedIndividual phyloref : phylorefs) {
+      // Prepare a TestResult object in which we can store the results of
+      // testing this particular phyloreference.
+      testNumber++;
+      TestResult result = new TestResult();
+      result.setTestNumber(testNumber);
+      boolean testFailed = false;
+
+      // Collect English labels for the phyloreference.
+      Optional<String> opt_phylorefLabel =
+          OWLHelper.getAnnotationLiteralsForEntity(
+                  ontology, phyloref, labelAnnotationProperty, Arrays.asList("en"))
+              .stream()
+              .findFirst();
+
+      String phylorefLabel;
+      if (opt_phylorefLabel.isPresent()) phylorefLabel = opt_phylorefLabel.get();
+      else phylorefLabel = phyloref.getIRI().toString();
+      result.setDescription("Phyloreference '" + phylorefLabel + "'");
+
+      // Which nodes did this phyloreference resolved to?
+      OWLClass phylorefAsClass = manager.getOWLDataFactory().getOWLClass(phyloref.getIRI());
+      Set<OWLNamedIndividual> nodes;
+      if (reasoner != null) {
+        // Use the reasoner to determine which nodes are members of this phyloref as a class
+        nodes =
+            reasoner
+                .getInstances(phylorefAsClass, false)
+                .getFlattened()
+                .stream()
+                // This includes the phyloreference itself. We only want to
+                // look at phylogeny nodes here. So, let's filter down to named
+                // individuals that are asserted to be cdao:Nodes.
+                .filter(
+                    indiv ->
+                        EntitySearcher.getTypes(indiv, ontology)
+                            .stream()
+                            .anyMatch(
+                                type ->
+                                    (!type.getClassExpressionType()
+                                            .equals(ClassExpressionType.OWL_CLASS))
+                                        || type.asOWLClass()
+                                            .getIRI()
+                                            .equals(PhylorefHelper.IRI_CDAO_NODE)))
+                .collect(Collectors.toSet());
+        ;
+      } else {
+        // No reasoner? We can also determine which nodes have been directly stated to
+        // be members of this phyloref as a class. This allows us to read a pre-reasoned
+        // OWL file and test whether phyloreferences resolved as expected.
+        nodes = new HashSet<>();
+        Set<OWLClassAssertionAxiom> classAssertions = ontology.getAxioms(AxiomType.CLASS_ASSERTION);
+
+        for (OWLClassAssertionAxiom classAssertion : classAssertions) {
+          // Does this assertion involve this phyloreference as a class and a named individual?
+          if (classAssertion.getIndividual().isNamed()
+              && classAssertion.getClassesInSignature().contains(phylorefAsClass)) {
+            // If so, then the individual is a phyloreferences!
+            nodes.add(classAssertion.getIndividual().asOWLNamedIndividual());
+          }
+        }
+      }
+
+      if (nodes.isEmpty()) {
+        // Phyloref resolved to no nodes at all.
+        result.setStatus(StatusValues.NOT_OK);
+        result.addComment(new Comment("No nodes matched."));
+        testFailed = true;
+      } else {
+        // Look for nodes where either its label or its expected phyloreference label
+        // is equal to the phyloreference we are currently processing.
+        Set<String> nodeLabelsWithExpectedPhylorefs = new HashSet<>();
+        Set<String> nodeLabelsWithoutExpectedPhylorefs = new HashSet<>();
+
+        for (OWLNamedIndividual node : nodes) {
+          // Get a list of all expected phyloreference labels from the OWL file.
+          Set<String> expectedPhylorefsNamed =
+              EntitySearcher.getDataPropertyValues(
+                      node, expectedPhyloreferenceNamedProperty, ontology)
+                  .stream()
+                  .map(literal -> literal.getLiteral()) // We ignore languages for now.
+                  .collect(Collectors.toSet());
+
+          // Add the label of the node as well.
+          Set<String> nodeLabels = OWLHelper.getLabelsInEnglish(node, ontology);
+          expectedPhylorefsNamed.addAll(nodeLabels);
+
+          // Build a new node label that describes this node.
+          String nodeLabel =
+              new StringBuilder()
+                  .append("[")
+                  .append(String.join(", ", expectedPhylorefsNamed))
+                  .append("]")
+                  .toString();
+
+          // Is this blank? If so, let's use the node's IRI as its label so we can debug issues with
+          // resolution.
+          if (expectedPhylorefsNamed.isEmpty()) {
+            nodeLabel = node.getIRI().toString();
+          }
+
+          // Does this node have an expected phyloreference identical to the phyloref being tested?
+          if (expectedPhylorefsNamed.contains(phylorefLabel)) {
+            nodeLabelsWithExpectedPhylorefs.add(nodeLabel);
+          } else {
+            nodeLabelsWithoutExpectedPhylorefs.add(nodeLabel);
+          }
         }
 
-        if(str_input == null) {
-            throw new IllegalArgumentException("Error: no input ontology specified (use '-i input.owl')");
+        // What happened?
+        if (!nodeLabelsWithExpectedPhylorefs.isEmpty()
+            && !nodeLabelsWithoutExpectedPhylorefs.isEmpty()) {
+          // We found nodes that expected this phyloref, as well as nodes that did not -- success!
+          result.addComment(
+              new Comment(
+                  "The following nodes were matched and expected this phyloreference: "
+                      + String.join("; ", nodeLabelsWithExpectedPhylorefs)));
+          result.addComment(
+              new Comment(
+                  "Also, the following nodes were matched but did not expect this phyloreference: "
+                      + String.join("; ", nodeLabelsWithoutExpectedPhylorefs)));
+        } else if (!nodeLabelsWithExpectedPhylorefs.isEmpty()) {
+          // We only found nodes that expected this phyloref -- success!
+          result.addComment(
+              new Comment(
+                  "The following nodes were matched and expected this phyloreference: "
+                      + String.join("; ", nodeLabelsWithExpectedPhylorefs)));
+        } else if (!nodeLabelsWithoutExpectedPhylorefs.isEmpty()) {
+          // We only have nodes that did not expect this phyloref -- failure!
+          result.addComment(
+              new Comment(
+                  "The following nodes were matched but did not expect this phyloreference: "
+                      + String.join("; ", nodeLabelsWithoutExpectedPhylorefs)));
+          testFailed = true;
+        } else {
+          // No nodes matched. This should have been caught earlier, but just in case.
+          throw new RuntimeException(
+              "No nodes were matched, which should have been caught earlier. Programmer error!");
         }
+      }
 
-        // Create File object to load
-        File inputFile = new File(str_input);
-        System.err.println("Input: " + inputFile);
-
-        // Set up an OWL Ontology Manager to work with.
-        OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
-
-        // Is purl.obolibrary.org down? No worries, you can access local copies
-        // of your ontologies in the 'ontologies/' folder.
-        AutoIRIMapper mapper = new AutoIRIMapper(new File("ontologies"), true);
-        System.err.println("Found local ontologies: " + mapper.getOntologyIRIs());
-        manager.addIRIMapper(mapper);
-
-        // Load the ontology using OWLManager.
-        OWLOntology ontology;
-        try {
-            ontology = manager.loadOntologyFromOntologyDocument(inputFile);
-        } catch (OWLOntologyCreationException ex) {
-            throw new RuntimeException("Could not load ontology '" + inputFile + "': " + ex);
+      // Look for all unmatched specifiers reported for this phyloreference
+      Set<OWLAxiom> axioms = new HashSet<>(EntitySearcher.getReferencingAxioms(phyloref, ontology));
+      Set<OWLNamedIndividual> unmatched_specifiers = new HashSet<>();
+      for (OWLAxiom axiom : axioms) {
+        if (axiom.containsEntityInSignature(unmatchedSpecifierProperty)) {
+          // This axiom references this phyloreference AND the unmatched specifier property!
+          // Therefore, any NamedIndividuals that are not phyloref should be added to
+          // unmatched_specifiers!
+          for (OWLNamedIndividual ni : axiom.getIndividualsInSignature()) {
+            if (ni != phyloref) unmatched_specifiers.add(ni);
+          }
         }
+      }
 
-        // Ontology loaded.
-        System.err.println("Loaded ontology: " + ontology);
+      // Report all unmatched specifiers
+      for (OWLNamedIndividual unmatched_specifier : unmatched_specifiers) {
+        Set<String> unmatched_specifier_label =
+            OWLHelper.getAnnotationLiteralsForEntity(
+                ontology, unmatched_specifier, labelAnnotationProperty, Arrays.asList("en"));
+        if (!unmatched_specifier_label.isEmpty()) {
+          result.addComment(
+              new Comment("Specifier '" + unmatched_specifier_label + "' is marked as unmatched."));
+        } else {
+          result.addComment(
+              new Comment(
+                  "Specifier '"
+                      + unmatched_specifier.getIRI().getShortForm()
+                      + "' is marked as unmatched."));
+        }
+      }
 
-        // Reason over the loaded ontology -- but only if the user wants that!
-        // Set up an OWLReasoner to work with.
-        OWLReasonerFactory reasonerFactory = ReasonerHelper.getReasonerFactoryFromCmdLine(cmdLine);
-        OWLReasoner reasoner = null;
-        if(reasonerFactory != null) reasoner = reasonerFactory.createReasoner(ontology);
-        Set<OWLNamedIndividual> phylorefs;
+      // Get a list of phyloref statuses for this phyloreference.
+      List<PhylorefHelper.PhylorefStatus> statuses =
+          PhylorefHelper.getCurrentStatusesForPhyloref(phyloref, ontology);
 
-        // Get a list of all phyloreferences.
-        phylorefs = PhylorefHelper.getPhyloreferences(ontology, reasoner);
+      // Instead of checking which time interval we are currently in, we take a simpler approach:
+      // we look for all statuses asserted to be "active", i.e. those with a start time but no end
+      // time.
+      boolean flag_expected_to_resolve = false;
 
-        // Okay, time to start testing! Each phyloreference counts as one test.
-        // TAP (https://testanything.org/) can be read by downstream software
-        // to determine which phyloreferences resolved correctly and which did not.
-        TapProducer tapProducer = TapProducerFactory.makeTap13Producer();
-        TestSet testSet = new TestSet();
-        testSet.setPlan(new Plan(phylorefs.size()));
-
-        // Preload some terms we need to use in the following code.
-        OWLDataFactory dataFactory = manager.getOWLDataFactory();
-
-        // Some classes we will use.
-        OWLClass classCDAONode = dataFactory.getOWLClass(PhylorefHelper.IRI_CDAO_NODE);
-
-        // Terms associated with phyloreferences
-        OWLAnnotationProperty labelAnnotationProperty = dataFactory.getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI());
-        OWLDataProperty expectedPhyloreferenceNamedProperty = dataFactory.getOWLDataProperty(PhylorefHelper.IRI_NAME_OF_EXPECTED_PHYLOREF);
-        OWLObjectProperty unmatchedSpecifierProperty = dataFactory.getOWLObjectProperty(PhylorefHelper.IRI_PHYLOREF_UNMATCHED_SPECIFIER);
-        // OWLDataProperty specifierDefinitionProperty = dataFactory.getOWLDataProperty(PhylorefHelper.IRI_CLADE_DEFINITION);
-
-        // Count the number of test results.
-        int testNumber = 0;
-        int countSuccess = 0;
-        int countFailure = 0;
-        int countTODO = 0;
-        int countSkipped = 0;
-
-        // Test each phyloreference individually.
-        for(OWLNamedIndividual phyloref: phylorefs) {
-            // Prepare a TestResult object in which we can store the results of
-            // testing this particular phyloreference.
-            testNumber++;
-            TestResult result = new TestResult();
-            result.setTestNumber(testNumber);
-            boolean testFailed = false;
-
-            // Collect English labels for the phyloreference.
-            Optional<String> opt_phylorefLabel = OWLHelper.getAnnotationLiteralsForEntity(
-                ontology,
-                phyloref,
-                labelAnnotationProperty,
-                Arrays.asList("en")
-            ).stream().findFirst();
-
-            String phylorefLabel;
-            if(opt_phylorefLabel.isPresent())
-                phylorefLabel = opt_phylorefLabel.get();
-            else
-                phylorefLabel = phyloref.getIRI().toString();
-            result.setDescription("Phyloreference '" + phylorefLabel + "'");
-
-            // Which nodes did this phyloreference resolved to?
-            OWLClass phylorefAsClass = manager.getOWLDataFactory().getOWLClass(phyloref.getIRI());
-            Set<OWLNamedIndividual> nodes;
-            if(reasoner != null) {
-            	// Use the reasoner to determine which nodes are members of this phyloref as a class
-            	nodes = reasoner.getInstances(phylorefAsClass, false).getFlattened().stream()
-	                // This includes the phyloreference itself. We only want to
-	                // look at phylogeny nodes here. So, let's filter down to named
-	                // individuals that are asserted to be cdao:Nodes.
-	                .filter(indiv -> EntitySearcher.getTypes(indiv, ontology).stream().anyMatch(
-	                    type -> (!type.getClassExpressionType().equals(ClassExpressionType.OWL_CLASS)) ||
-	                			type.asOWLClass().getIRI().equals(PhylorefHelper.IRI_CDAO_NODE)
-	                ))
-	                .collect(Collectors.toSet());
-                ;
-            } else {
-                // No reasoner? We can also determine which nodes have been directly stated to
-                // be members of this phyloref as a class. This allows us to read a pre-reasoned
-                // OWL file and test whether phyloreferences resolved as expected.
-                nodes = new HashSet<>();
-                Set<OWLClassAssertionAxiom> classAssertions = ontology.getAxioms(AxiomType.CLASS_ASSERTION);
-
-                for(OWLClassAssertionAxiom classAssertion: classAssertions) {
-                    // Does this assertion involve this phyloreference as a class and a named individual?
-                    if(
-                        classAssertion.getIndividual().isNamed() &&
-                        classAssertion.getClassesInSignature().contains(phylorefAsClass)
-                    ) {
-                        // If so, then the individual is a phyloreferences!
-                        nodes.add(classAssertion.getIndividual().asOWLNamedIndividual());
-                    }
-                }
-            }
-
-            if(nodes.isEmpty()) {
-                // Phyloref resolved to no nodes at all.
-                result.setStatus(StatusValues.NOT_OK);
-                result.addComment(new Comment("No nodes matched."));
-                testFailed = true;
-            } else {
-                // Look for nodes where either its label or its expected phyloreference label
-                // is equal to the phyloreference we are currently processing.
-            	Set<String> nodeLabelsWithExpectedPhylorefs = new HashSet<>();
-            	Set<String> nodeLabelsWithoutExpectedPhylorefs = new HashSet<>();
-
-                for(OWLNamedIndividual node: nodes) {
-                    // Get a list of all expected phyloreference labels from the OWL file.
-                    Set<String> expectedPhylorefsNamed = EntitySearcher.getDataPropertyValues(node, expectedPhyloreferenceNamedProperty, ontology).stream()
-                        .map(literal -> literal.getLiteral()) // We ignore languages for now.
-                        .collect(Collectors.toSet());
-
-                    // Add the label of the node as well.
-                    Set<String> nodeLabels = OWLHelper.getLabelsInEnglish(node, ontology);
-                    expectedPhylorefsNamed.addAll(nodeLabels);
-
-                    // Build a new node label that describes this node.
-                    String nodeLabel = new StringBuilder()
-                        .append("[")
-                        .append(String.join(", ", expectedPhylorefsNamed))
-                        .append("]")
-                        .toString();
-
-                    // Is this blank? If so, let's use the node's IRI as its label so we can debug issues with resolution.
-                    if(expectedPhylorefsNamed.isEmpty()) {
-                        nodeLabel = node.getIRI().toString();
-                    }
-
-                    // Does this node have an expected phyloreference identical to the phyloref being tested?
-                    if(expectedPhylorefsNamed.contains(phylorefLabel)) {
-                        nodeLabelsWithExpectedPhylorefs.add(nodeLabel);
-                    } else {
-                        nodeLabelsWithoutExpectedPhylorefs.add(nodeLabel);
-                    }
-                }
-
-                // What happened?
-                if(!nodeLabelsWithExpectedPhylorefs.isEmpty() && !nodeLabelsWithoutExpectedPhylorefs.isEmpty()) {
-                    // We found nodes that expected this phyloref, as well as nodes that did not -- success!
-                    result.addComment(new Comment("The following nodes were matched and expected this phyloreference: " + String.join("; ", nodeLabelsWithExpectedPhylorefs)));
-                    result.addComment(new Comment("Also, the following nodes were matched but did not expect this phyloreference: " + String.join("; ", nodeLabelsWithoutExpectedPhylorefs)));
-                } else if(!nodeLabelsWithExpectedPhylorefs.isEmpty()) {
-                    // We only found nodes that expected this phyloref -- success!
-                    result.addComment(new Comment("The following nodes were matched and expected this phyloreference: " + String.join("; ", nodeLabelsWithExpectedPhylorefs)));
-                } else if(!nodeLabelsWithoutExpectedPhylorefs.isEmpty()) {
-                    // We only have nodes that did not expect this phyloref -- failure!
-                    result.addComment(new Comment("The following nodes were matched but did not expect this phyloreference: " + String.join("; ", nodeLabelsWithoutExpectedPhylorefs)));
-                    testFailed = true;
-                } else {
-                    // No nodes matched. This should have been caught earlier, but just in case.
-                    throw new RuntimeException("No nodes were matched, which should have been caught earlier. Programmer error!");
-                }
-            }
-
-            // Look for all unmatched specifiers reported for this phyloreference
-            Set<OWLAxiom> axioms = new HashSet<>(EntitySearcher.getReferencingAxioms(phyloref, ontology));
-            Set<OWLNamedIndividual> unmatched_specifiers = new HashSet<>();
-            for(OWLAxiom axiom: axioms) {
-            	if(axiom.containsEntityInSignature(unmatchedSpecifierProperty)) {
-                    // This axiom references this phyloreference AND the unmatched specifier property!
-                    // Therefore, any NamedIndividuals that are not phyloref should be added to
-                    // unmatched_specifiers!
-                    for(OWLNamedIndividual ni: axiom.getIndividualsInSignature()) {
-                        if(ni != phyloref) unmatched_specifiers.add(ni);
-                    }
-            	}
-            }
-
-            // Report all unmatched specifiers
-            for(OWLNamedIndividual unmatched_specifier: unmatched_specifiers) {
-                Set<String> unmatched_specifier_label = OWLHelper.getAnnotationLiteralsForEntity(ontology, unmatched_specifier, labelAnnotationProperty, Arrays.asList("en"));
-                if(!unmatched_specifier_label.isEmpty()) {
-                    result.addComment(new Comment("Specifier '" + unmatched_specifier_label + "' is marked as unmatched."));
-                } else {
-                    result.addComment(new Comment("Specifier '" + unmatched_specifier.getIRI().getShortForm() + "' is marked as unmatched."));
-                }
-            }
-
-            // Get a list of phyloref statuses for this phyloreference.
-            List<PhylorefHelper.PhylorefStatus> statuses = PhylorefHelper.getCurrentStatusesForPhyloref(phyloref, ontology);
-
-            // Instead of checking which time interval we are currently in, we take a simpler approach:
-            // we look for all statuses asserted to be "active", i.e. those with a start time but no end time.
-            boolean flag_expected_to_resolve = false;
-
-            List<PhylorefHelper.PhylorefStatus> activeStatuses = statuses.stream()
+      List<PhylorefHelper.PhylorefStatus> activeStatuses =
+          statuses
+              .stream()
               .filter(ps -> ps.getIntervalStart() != null && ps.getIntervalEnd() == null)
               .collect(Collectors.toList());
 
-            // If there are no active statuses, we default to assuming that we expect phyloreferences to resolve.
-            if(activeStatuses.isEmpty())
-              flag_expected_to_resolve = true;
-            else
-            	// If there are active statuses, we default to assuming that we expect phyloreferences NOT to resolve,
-            	// unless they are actively in the "submitted" or "published" statuses.
-            	flag_expected_to_resolve = activeStatuses.stream()
-            	  .anyMatch(ps ->
-            		  ps.getStatus().equals(PhylorefHelper.IRI_PSO_SUBMITTED) ||
-            		  ps.getStatus().equals(PhylorefHelper.IRI_PSO_PUBLISHED)
-            	  );
+      // If there are no active statuses, we default to assuming that we expect phyloreferences to
+      // resolve.
+      if (activeStatuses.isEmpty()) flag_expected_to_resolve = true;
+      else
+        // If there are active statuses, we default to assuming that we expect phyloreferences NOT
+        // to resolve,
+        // unless they are actively in the "submitted" or "published" statuses.
+        flag_expected_to_resolve =
+            activeStatuses
+                .stream()
+                .anyMatch(
+                    ps ->
+                        ps.getStatus().equals(PhylorefHelper.IRI_PSO_SUBMITTED)
+                            || ps.getStatus().equals(PhylorefHelper.IRI_PSO_PUBLISHED));
 
-            // Determine if this phyloreference has failed or succeeded.
-            if(testFailed) {
-            	if(unmatched_specifiers.isEmpty()) {
-                    if(flag_expected_to_resolve) {
-                        // We expect this phyloreference to resolve. Report a failure.
-                        countFailure++;
-                        result.setStatus(StatusValues.NOT_OK);
-                        testSet.addTapLine(result);
-                    } else {
-                        // No, we do not expect this phyloreference to resolve. Report a TODO.
-                        countTODO++;
-                        result.setStatus(StatusValues.NOT_OK);
-                        result.setDirective(new Directive(DirectiveValues.TODO, "Phyloreference did not resolve, but has status " + statuses));
-                        testSet.addTapLine(result);
-                    }
-            	} else {
-                    // Okay, it's a failure, but we do know that there are unmatched specifiers.
-                    // So mark it as a to-do.
-                    countTODO++;
-                    result.setStatus(StatusValues.NOT_OK);
-                    result.setDirective(new Directive(DirectiveValues.TODO, "Phyloreference could not be tested, as one or more specifiers did not match."));
-                    if(!activeStatuses.stream().anyMatch(st -> st.getStatus().equals(PhylorefHelper.IRI_PSO_DRAFT))) {
-                        result.addComment(new Comment(
-                            "Since specifiers remain unmatched, this phyloreference should have a status of 'pso:draft' but instead its status is " + activeStatuses
-                        ));
-                    }
-                    testSet.addTapLine(result);
-            	}
-            } else {
-                // Oh no, success!
-                countSuccess++;
-                result.setStatus(StatusValues.OK);
-                if(!flag_expected_to_resolve) {
-                    result.addComment(new Comment(
-                        "Phyloreference resolved correctly but was not expected to resolve; status should be changed to 'pso:submitted' from " + statuses
-                    ));
-                }
-                testSet.addTapLine(result);
-            }
+      // Determine if this phyloreference has failed or succeeded.
+      if (testFailed) {
+        if (unmatched_specifiers.isEmpty()) {
+          if (flag_expected_to_resolve) {
+            // We expect this phyloreference to resolve. Report a failure.
+            countFailure++;
+            result.setStatus(StatusValues.NOT_OK);
+            testSet.addTapLine(result);
+          } else {
+            // No, we do not expect this phyloreference to resolve. Report a TODO.
+            countTODO++;
+            result.setStatus(StatusValues.NOT_OK);
+            result.setDirective(
+                new Directive(
+                    DirectiveValues.TODO,
+                    "Phyloreference did not resolve, but has status " + statuses));
+            testSet.addTapLine(result);
+          }
+        } else {
+          // Okay, it's a failure, but we do know that there are unmatched specifiers.
+          // So mark it as a to-do.
+          countTODO++;
+          result.setStatus(StatusValues.NOT_OK);
+          result.setDirective(
+              new Directive(
+                  DirectiveValues.TODO,
+                  "Phyloreference could not be tested, as one or more specifiers did not match."));
+          if (!activeStatuses
+              .stream()
+              .anyMatch(st -> st.getStatus().equals(PhylorefHelper.IRI_PSO_DRAFT))) {
+            result.addComment(
+                new Comment(
+                    "Since specifiers remain unmatched, this phyloreference should have a status of 'pso:draft' but instead its status is "
+                        + activeStatuses));
+          }
+          testSet.addTapLine(result);
         }
-
-        System.out.println(tapProducer.dump(testSet));
-        System.err.println("Testing complete:" + countSuccess + " successes, " + countFailure + " failures, " + countTODO + " failures marked TODO, " + countSkipped + " skipped.");
-
-        // Exit with error unless we have zero failures.
-        if(countSuccess == 0) System.exit(-1);
-        System.exit(countFailure);
+      } else {
+        // Oh no, success!
+        countSuccess++;
+        result.setStatus(StatusValues.OK);
+        if (!flag_expected_to_resolve) {
+          result.addComment(
+              new Comment(
+                  "Phyloreference resolved correctly but was not expected to resolve; status should be changed to 'pso:submitted' from "
+                      + statuses));
+        }
+        testSet.addTapLine(result);
+      }
     }
+
+    System.out.println(tapProducer.dump(testSet));
+    System.err.println(
+        "Testing complete:"
+            + countSuccess
+            + " successes, "
+            + countFailure
+            + " failures, "
+            + countTODO
+            + " failures marked TODO, "
+            + countSkipped
+            + " skipped.");
+
+    // Exit with error unless we have zero failures.
+    if (countSuccess == 0) System.exit(-1);
+    System.exit(countFailure);
+  }
 }

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -1,5 +1,8 @@
 package org.phyloref.jphyloref.commands;
 
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.Response.IStatus;
+import fi.iki.elonen.NanoHTTPD.Response.Status;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
@@ -9,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -18,7 +20,6 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
 import org.json.JSONObject;
-
 import org.openrdf.model.Resource;
 import org.openrdf.model.Value;
 import org.openrdf.model.impl.ValueFactoryImpl;
@@ -43,31 +44,22 @@ import org.semanticweb.owlapi.util.AnonymousNodeChecker;
 import org.semanticweb.owlapi.util.AutoIRIMapper;
 import org.semanticweb.owlapi.util.VersionInfo;
 
-import fi.iki.elonen.NanoHTTPD;
-import fi.iki.elonen.NanoHTTPD.Response.IStatus;
-import fi.iki.elonen.NanoHTTPD.Response.Status;
-
 /**
- * Sets up a webserver that allows reasoning over phyloreferences
- * over HTTP.
+ * Sets up a webserver that allows reasoning over phyloreferences over HTTP.
  *
- * At the moment, we implement a simple API, in which:
- *  /version:   returns a JSON object with information on the version of
- *              JPhyloRef and the reasoner being used.
- *  /reason:    expects a form upload with a 'jsonld' element containing a file
- *              upload of a JSON-LD file representing an ontology to test.
- *              This command will reason over the ontology and return a JSON
- *              dictionary, in which the keys are the IRIs for each phyloreference,
- *              and the values are lists of the IRIs of each node matched by that
- *              phyloreference.
+ * <p>At the moment, we implement a simple API, in which: /version: returns a JSON object with
+ * information on the version of JPhyloRef and the reasoner being used. /reason: expects a form
+ * upload with a 'jsonld' element containing a file upload of a JSON-LD file representing an
+ * ontology to test. This command will reason over the ontology and return a JSON dictionary, in
+ * which the keys are the IRIs for each phyloreference, and the values are lists of the IRIs of each
+ * node matched by that phyloreference.
  *
  * @author Gaurav Vaidya <gaurav@ggvaidya.com>
- *
  */
 public class WebserverCommand implements Command {
   /**
-   * This command is named "webserver". It should be
-   * invoked as "java -jar jphyloref.jar webserver ..."
+   * This command is named "webserver". It should be invoked as "java -jar jphyloref.jar webserver
+   * ..."
    */
   @Override
   public String getName() {
@@ -92,13 +84,9 @@ public class WebserverCommand implements Command {
   @Override
   public void addCommandLineOptions(Options opts) {
     opts.addOption(
-      "h", "host", true,
-      "The hostname to listen to HTTP connections on (default: 'localhost')"
-    );
+        "h", "host", true, "The hostname to listen to HTTP connections on (default: 'localhost')");
     opts.addOption(
-      "p", "port", true,
-      "The TCP port to listen to HTTP connections on (default: 34214)"
-    );
+        "p", "port", true, "The TCP port to listen to HTTP connections on (default: 34214)");
   }
 
   /**
@@ -108,55 +96,50 @@ public class WebserverCommand implements Command {
    */
   @Override
   public void execute(CommandLine cmdLine) throws RuntimeException {
-      String hostname = cmdLine.getOptionValue("host", "localhost");
-      String portString = cmdLine.getOptionValue("port", "34214");
-      int port = Integer.parseInt(portString);
+    String hostname = cmdLine.getOptionValue("host", "localhost");
+    String portString = cmdLine.getOptionValue("port", "34214");
+    int port = Integer.parseInt(portString);
 
-      try {
-          Webserver webserver = new Webserver(this, hostname, port, cmdLine);
-          while(webserver.isAlive()) {}
-      } catch(IOException ex) {
-          System.err.println("An error occurred while running webserver: " + ex);
-      }
+    try {
+      Webserver webserver = new Webserver(this, hostname, port, cmdLine);
+      while (webserver.isAlive()) {}
+    } catch (IOException ex) {
+      System.err.println("An error occurred while running webserver: " + ex);
+    }
   }
 
-  /**
-   * The webserver we set up.
-   */
+  /** The webserver we set up. */
   class Webserver extends fi.iki.elonen.NanoHTTPD {
     /**
-     * We keep a copy of the WebserverCommand that invoked us, although we
-     * don't use this for now.
+     * We keep a copy of the WebserverCommand that invoked us, although we don't use this for now.
      */
     private final WebserverCommand cmd;
-    
-    /**
-     * The CommandLine used to invoke this webserver.
-     */
+
+    /** The CommandLine used to invoke this webserver. */
     private final CommandLine cmdLine;
-    
+
     /**
-     * Create and start the webserver. It starts in another thread, so
-     * execution will not stop.
+     * Create and start the webserver. It starts in another thread, so execution will not stop.
      *
      * @param cmd The WebserverCommand that created this Webserver.
      * @param hostname The hostname under which this webserver should listen.
      * @param port The port this webserver should listen to.
      */
-    public Webserver(WebserverCommand cmd, String hostname, int port, CommandLine cmdLine) throws IOException {
+    public Webserver(WebserverCommand cmd, String hostname, int port, CommandLine cmdLine)
+        throws IOException {
       super(hostname, port);
 
       this.cmd = cmd;
       this.cmdLine = cmdLine;
 
       start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
-      System.out.println("Webserver started. Try accessing it at http://" + hostname + ":" + port + "/");
+      System.out.println(
+          "Webserver started. Try accessing it at http://" + hostname + ":" + port + "/");
     }
 
-    /**
-     * Respond to a request for reasoning over a JSON-LD file (/reason).
-     */
-    public JSONObject serveReason(File jsonldFile) throws OWLOntologyCreationException, RDFParseException, IOException {
+    /** Respond to a request for reasoning over a JSON-LD file (/reason). */
+    public JSONObject serveReason(File jsonldFile)
+        throws OWLOntologyCreationException, RDFParseException, IOException {
       JSONObject response = new JSONObject("{'status': 'ok'}");
 
       // Prepare an ontology to fill with the provided JSON-LD file.
@@ -173,30 +156,32 @@ public class WebserverCommand implements Command {
 
       // Set up a RioOWLRDFConsumerAdapter that will take in RDF and will
       // produce OWL to store in an ontology.
-      AnonymousNodeChecker anonymousNodeChecker = new AnonymousNodeChecker() {
-        /* Copied from https://github.com/owlcs/owlapi/blob/master/rio/src/main/java/org/semanticweb/owlapi/rio/RioParserImpl.java */
+      AnonymousNodeChecker anonymousNodeChecker =
+          new AnonymousNodeChecker() {
+            /* Copied from https://github.com/owlcs/owlapi/blob/master/rio/src/main/java/org/semanticweb/owlapi/rio/RioParserImpl.java */
 
-        private boolean isAnonymous(String iri) {
-          return iri.startsWith("_:");
-        }
+            private boolean isAnonymous(String iri) {
+              return iri.startsWith("_:");
+            }
 
-        @Override
-        public boolean isAnonymousSharedNode(String iri) {
-          return isAnonymous(iri);
-        }
+            @Override
+            public boolean isAnonymousSharedNode(String iri) {
+              return isAnonymous(iri);
+            }
 
-        @Override
-        public boolean isAnonymousNode(String iri) {
-          return isAnonymous(iri);
-        }
+            @Override
+            public boolean isAnonymousNode(String iri) {
+              return isAnonymous(iri);
+            }
 
-        @Override
-        public boolean isAnonymousNode(IRI iri) {
-          return isAnonymous(iri.toString());
-        }
-      };
+            @Override
+            public boolean isAnonymousNode(IRI iri) {
+              return isAnonymous(iri.toString());
+            }
+          };
 
-      RioOWLRDFConsumerAdapter rdfHandler = new RioOWLRDFConsumerAdapter(ontology, anonymousNodeChecker, config);
+      RioOWLRDFConsumerAdapter rdfHandler =
+          new RioOWLRDFConsumerAdapter(ontology, anonymousNodeChecker, config);
       rdfHandler.setOntologyFormat(new RDFJsonLDDocumentFormat());
 
       // Set up an RDF parser to read the JSON-LD file.
@@ -219,103 +204,108 @@ public class WebserverCommand implements Command {
       // an org.openrdf.rio.RDFHandler to an org.eclipse.rdf4j.rio.RDFHandler.
       // (Tracked at https://github.com/phyloref/jphyloref/issues/11)
       //
-      parser.setRDFHandler(new org.eclipse.rdf4j.rio.RDFHandler() {
-        // Most of these methods just call the corresponding method on the
-        // other rdfHandler.
+      parser.setRDFHandler(
+          new org.eclipse.rdf4j.rio.RDFHandler() {
+            // Most of these methods just call the corresponding method on the
+            // other rdfHandler.
 
-        @Override
-        public void startRDF() throws RDFHandlerException {
-          rdfHandler.startRDF();
-        }
+            @Override
+            public void startRDF() throws RDFHandlerException {
+              rdfHandler.startRDF();
+            }
 
-        @Override
-        public void endRDF() throws RDFHandlerException {
-          rdfHandler.endRDF();
-        }
+            @Override
+            public void endRDF() throws RDFHandlerException {
+              rdfHandler.endRDF();
+            }
 
-        @Override
-        public void handleNamespace(String prefix, String uri) throws RDFHandlerException {
-          rdfHandler.handleNamespace(prefix, uri);
-        }
+            @Override
+            public void handleNamespace(String prefix, String uri) throws RDFHandlerException {
+              rdfHandler.handleNamespace(prefix, uri);
+            }
 
-        @Override
-        public void handleComment(String comment) throws RDFHandlerException {
-          rdfHandler.handleComment(comment);
-        }
+            @Override
+            public void handleComment(String comment) throws RDFHandlerException {
+              rdfHandler.handleComment(comment);
+            }
 
-        // The only exception to this are handleStatement(Statement), where we
-        // need to translate from one Statement to the other. We do this by
-        // translating subject, object and property using translateResource()
-        // (to translate Resources) and translateValue() (to translate Values).
+            // The only exception to this are handleStatement(Statement), where we
+            // need to translate from one Statement to the other. We do this by
+            // translating subject, object and property using translateResource()
+            // (to translate Resources) and translateValue() (to translate Values).
 
-        @Override
-        public void handleStatement(org.eclipse.rdf4j.model.Statement st) throws RDFHandlerException {
-          ValueFactoryImpl svf = ValueFactoryImpl.getInstance();
+            @Override
+            public void handleStatement(org.eclipse.rdf4j.model.Statement st)
+                throws RDFHandlerException {
+              ValueFactoryImpl svf = ValueFactoryImpl.getInstance();
 
-          // System.out.println("Translating statement " + st);
+              // System.out.println("Translating statement " + st);
 
-          rdfHandler.handleStatement(svf.createStatement(
-            translateResource(st.getSubject()),
-            svf.createURI(st.getPredicate().stringValue()),
-            translateValue(st.getObject())
-          ));
-        }
+              rdfHandler.handleStatement(
+                  svf.createStatement(
+                      translateResource(st.getSubject()),
+                      svf.createURI(st.getPredicate().stringValue()),
+                      translateValue(st.getObject())));
+            }
 
-        /**
-         * Translate a Resource from org.eclipse.rdf4j.model.Resource to
-         * org.openrdf.model.Resource. We support two kinds of resources:
-         * blank nodes (BNodes) and IRIs.
-         */
-        private org.openrdf.model.Resource translateResource(org.eclipse.rdf4j.model.Resource res) {
-          ValueFactoryImpl svf = ValueFactoryImpl.getInstance();
+            /**
+             * Translate a Resource from org.eclipse.rdf4j.model.Resource to
+             * org.openrdf.model.Resource. We support two kinds of resources: blank nodes (BNodes)
+             * and IRIs.
+             */
+            private org.openrdf.model.Resource translateResource(
+                org.eclipse.rdf4j.model.Resource res) {
+              ValueFactoryImpl svf = ValueFactoryImpl.getInstance();
 
-          if(res instanceof org.eclipse.rdf4j.model.BNode) {
-            org.eclipse.rdf4j.model.BNode bnode = (org.eclipse.rdf4j.model.BNode) res;
+              if (res instanceof org.eclipse.rdf4j.model.BNode) {
+                org.eclipse.rdf4j.model.BNode bnode = (org.eclipse.rdf4j.model.BNode) res;
 
-            return (Resource) svf.createBNode(bnode.getID());
-          }
+                return (Resource) svf.createBNode(bnode.getID());
+              }
 
-          if(res instanceof org.eclipse.rdf4j.model.IRI) {
-            org.eclipse.rdf4j.model.IRI iri = (org.eclipse.rdf4j.model.IRI) res;
+              if (res instanceof org.eclipse.rdf4j.model.IRI) {
+                org.eclipse.rdf4j.model.IRI iri = (org.eclipse.rdf4j.model.IRI) res;
 
-            return (Resource) svf.createURI(iri.stringValue());
-          }
+                return (Resource) svf.createURI(iri.stringValue());
+              }
 
-          throw new RuntimeException("Unknown resource type: " + res);
-        }
+              throw new RuntimeException("Unknown resource type: " + res);
+            }
 
-        /**
-         * Translate a Value from org.eclipse.rdf4j.model.Value to org.openrdf.model.Value.
-         * We support three kinds of Values: blank nodes (BNodes), IRIs and
-         * Literals. The first two are handled correctly, but literals are
-         * always converted into strings, regardless of their actual data type.
-         */
-        private org.openrdf.model.Value translateValue(org.eclipse.rdf4j.model.Value value) {
-          ValueFactoryImpl svf = ValueFactoryImpl.getInstance();
+            /**
+             * Translate a Value from org.eclipse.rdf4j.model.Value to org.openrdf.model.Value. We
+             * support three kinds of Values: blank nodes (BNodes), IRIs and Literals. The first two
+             * are handled correctly, but literals are always converted into strings, regardless of
+             * their actual data type.
+             */
+            private org.openrdf.model.Value translateValue(org.eclipse.rdf4j.model.Value value) {
+              ValueFactoryImpl svf = ValueFactoryImpl.getInstance();
 
-          if(value instanceof org.eclipse.rdf4j.model.BNode) {
-            org.eclipse.rdf4j.model.BNode bnode = (org.eclipse.rdf4j.model.BNode) value;
+              if (value instanceof org.eclipse.rdf4j.model.BNode) {
+                org.eclipse.rdf4j.model.BNode bnode = (org.eclipse.rdf4j.model.BNode) value;
 
-            return (Value) svf.createBNode(bnode.getID());
-          }
+                return (Value) svf.createBNode(bnode.getID());
+              }
 
-          if(value instanceof org.eclipse.rdf4j.model.IRI) {
-            org.eclipse.rdf4j.model.IRI iri = (org.eclipse.rdf4j.model.IRI) value;
+              if (value instanceof org.eclipse.rdf4j.model.IRI) {
+                org.eclipse.rdf4j.model.IRI iri = (org.eclipse.rdf4j.model.IRI) value;
 
-            return (Value) svf.createURI(iri.stringValue());
-          }
+                return (Value) svf.createURI(iri.stringValue());
+              }
 
-          if(value instanceof org.eclipse.rdf4j.model.Literal) {
-            org.eclipse.rdf4j.model.Literal literal = (org.eclipse.rdf4j.model.Literal) value;
+              if (value instanceof org.eclipse.rdf4j.model.Literal) {
+                org.eclipse.rdf4j.model.Literal literal = (org.eclipse.rdf4j.model.Literal) value;
 
-            // Note that this converts literals that should be treated as integers,
-            // doubles and so on will be converted into strings here.
-            return (Value) svf.createLiteral(literal.stringValue(), svf.createURI(literal.getDatatype().stringValue()));
-          }
+                // Note that this converts literals that should be treated as integers,
+                // doubles and so on will be converted into strings here.
+                return (Value)
+                    svf.createLiteral(
+                        literal.stringValue(), svf.createURI(literal.getDatatype().stringValue()));
+              }
 
-          throw new RuntimeException("Unknown value type: " + value);
-        }
-      });
+              throw new RuntimeException("Unknown value type: " + value);
+            }
+          });
 
       // Setup ready; parse the file!
       // We could jsonldFile.toURI().toString() as the file IRI, but this points
@@ -342,7 +332,7 @@ public class WebserverCommand implements Command {
 
       // Go through all the phyloreferences, identifying all the nodes that have
       // matched to that phyloreference.
-      for(OWLNamedIndividual phyloref: PhylorefHelper.getPhyloreferences(ontology, reasoner)) {
+      for (OWLNamedIndividual phyloref : PhylorefHelper.getPhyloreferences(ontology, reasoner)) {
         IRI phylorefIRI = phyloref.getIRI();
 
         // Pun from the named individual phyloref to the class with the same IRI.
@@ -350,18 +340,29 @@ public class WebserverCommand implements Command {
 
         // Identify all individuals contained in the class, but filter out everything that
         // is not an IRI_CDAO_NODE.
-        Set<String> nodes = reasoner.getInstances(phylorefAsClass, false).getFlattened().stream()
-          // This includes the phyloreference itself. We only want to
-          // look at phylogeny nodes here. So, let's filter down to named
-          // individuals that are asserted to be cdao:Nodes.
-          .filter(indiv -> EntitySearcher.getTypes(indiv, ontology).stream().anyMatch(
-            type -> (!type.getClassExpressionType().equals(ClassExpressionType.OWL_CLASS)) ||
-              type.asOWLClass().getIRI().equals(PhylorefHelper.IRI_CDAO_NODE)
-          ))
-          .map(indiv -> indiv.getIRI().toString())
-          // Strip the default prefix on the node URI if present.
-          .map(iri -> iri.replaceFirst("^" + DEFAULT_URI_PREFIX, ""))
-          .collect(Collectors.toSet());
+        Set<String> nodes =
+            reasoner
+                .getInstances(phylorefAsClass, false)
+                .getFlattened()
+                .stream()
+                // This includes the phyloreference itself. We only want to
+                // look at phylogeny nodes here. So, let's filter down to named
+                // individuals that are asserted to be cdao:Nodes.
+                .filter(
+                    indiv ->
+                        EntitySearcher.getTypes(indiv, ontology)
+                            .stream()
+                            .anyMatch(
+                                type ->
+                                    (!type.getClassExpressionType()
+                                            .equals(ClassExpressionType.OWL_CLASS))
+                                        || type.asOWLClass()
+                                            .getIRI()
+                                            .equals(PhylorefHelper.IRI_CDAO_NODE)))
+                .map(indiv -> indiv.getIRI().toString())
+                // Strip the default prefix on the node URI if present.
+                .map(iri -> iri.replaceFirst("^" + DEFAULT_URI_PREFIX, ""))
+                .collect(Collectors.toSet());
 
         // Strip the default prefix on the phyloref URI if present.
         String nodeURI = phylorefIRI.toString();
@@ -378,9 +379,7 @@ public class WebserverCommand implements Command {
       return response;
     }
 
-    /**
-     * Respond to a request for the version (GET /version).
-     */
+    /** Respond to a request for the version (GET /version). */
     public JSONObject serveVersion() {
       JSONObject response = new JSONObject("{'status': 'ok'}");
 
@@ -389,23 +388,21 @@ public class WebserverCommand implements Command {
       response.put("owlapiVersion", owlapiVersion);
 
       // Report reasoner version.
-      String reasonerVersion = ReasonerHelper.getReasonerNameAndVersion(ReasonerHelper.getReasonerFactoryFromCmdLine(cmdLine));
+      String reasonerVersion =
+          ReasonerHelper.getReasonerNameAndVersion(
+              ReasonerHelper.getReasonerFactoryFromCmdLine(cmdLine));
       response.put("reasonerVersion", reasonerVersion);
 
       // Report JPhyloRef version.
-      response.put("name",
-        "JPhyloRef/" + JPhyloRef.VERSION +
-        " OWLAPI/" + owlapiVersion + " " +
-        reasonerVersion
-      );
+      response.put(
+          "name",
+          "JPhyloRef/" + JPhyloRef.VERSION + " OWLAPI/" + owlapiVersion + " " + reasonerVersion);
       response.put("version", JPhyloRef.VERSION);
 
       return response;
     }
 
-    /**
-     * Set up some common items when communicating with a browser.
-     */
+    /** Set up some common items when communicating with a browser. */
     public Response createResponse(IStatus status, JSONObject result) {
       Response response = newFixedLengthResponse(status, "application/json", result.toString());
 
@@ -415,19 +412,18 @@ public class WebserverCommand implements Command {
       return response;
     }
 
-    /**
-     * Respond to a request sent to this webserver.
-     */
+    /** Respond to a request sent to this webserver. */
     @Override
     public Response serve(IHTTPSession session) {
       // Look for web forms in the body of the HTTP request.
       Map<String, String> files = new HashMap<>();
-      if(session.getMethod().equals(Method.PUT) || session.getMethod().equals(Method.POST)) {
+      if (session.getMethod().equals(Method.PUT) || session.getMethod().equals(Method.POST)) {
         try {
           session.parseBody(files);
-        } catch(IOException ex) {
-          return newFixedLengthResponse(Response.Status.INTERNAL_ERROR, MIME_PLAINTEXT, "Server threw IOException: " + ex);
-        } catch(ResponseException re) {
+        } catch (IOException ex) {
+          return newFixedLengthResponse(
+              Response.Status.INTERNAL_ERROR, MIME_PLAINTEXT, "Server threw IOException: " + ex);
+        } catch (ResponseException re) {
           return newFixedLengthResponse(re.getStatus(), MIME_PLAINTEXT, re.getMessage());
         }
       }
@@ -441,7 +437,7 @@ public class WebserverCommand implements Command {
 
       System.out.println(">> Request received to '" + path + "': " + params);
 
-      if(path.equals("/reason")) {
+      if (path.equals("/reason")) {
         // We accept two kinds of inputs:
         //  1. A form containing 'jsonld' as a JSON-LD string to process.
         //  2. A form containing 'jsonldFile' as a JSON-LD file to read.
@@ -449,10 +445,10 @@ public class WebserverCommand implements Command {
         File jsonldFile;
 
         try {
-          if(params.containsKey("jsonldFile")) {
+          if (params.containsKey("jsonldFile")) {
             filename = String.join("; ", params.get("jsonldFile"));
             jsonldFile = new File(files.get("jsonldFile"));
-          } else if(params.containsKey("jsonld")) {
+          } else if (params.containsKey("jsonld")) {
             jsonldFile = File.createTempFile("jphyloref", null);
 
             FileWriter writer = new FileWriter(jsonldFile);
@@ -461,7 +457,9 @@ public class WebserverCommand implements Command {
 
           } else {
             response.put("status", "error");
-            response.put("error", "Expected a form with a file upload in the 'jsonldFile' field or a JSON-LD string in the 'jsonld' field, but no such field was found");
+            response.put(
+                "error",
+                "Expected a form with a file upload in the 'jsonldFile' field or a JSON-LD string in the 'jsonld' field, but no such field was found");
             return createResponse(Status.BAD_REQUEST, response);
           }
 
@@ -473,7 +471,7 @@ public class WebserverCommand implements Command {
           return createResponse(Status.INTERNAL_ERROR, response);
         }
 
-      } else if(path.equals("/version")) {
+      } else if (path.equals("/version")) {
         return createResponse(Status.OK, serveVersion());
       } else {
         response.put("status", "error");

--- a/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
@@ -16,93 +16,109 @@ import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
 
 /**
  * OWLHelper contains methods simplify accessing information from the OWL API.
- * 
- * @author Gaurav Vaidya <gaurav@ggvaidya.com>
  *
+ * @author Gaurav Vaidya <gaurav@ggvaidya.com>
  */
 public final class OWLHelper {
-    /** A variable we use to cache rdfs:label */ 
-    private static OWLAnnotationProperty cache_labelProperty = null;
-    
-    /** 
-     * Returns OWL property rdfs:label, using a cache so we don't 
-     * need to load the property using the data property. 
-     */ 
-    public static OWLAnnotationProperty getLabelProperty(OWLOntology ontology) {
-        if(cache_labelProperty != null) return cache_labelProperty;
-        cache_labelProperty = ontology.getOWLOntologyManager().getOWLDataFactory().getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI());
-        return cache_labelProperty;
+  /** A variable we use to cache rdfs:label */
+  private static OWLAnnotationProperty cache_labelProperty = null;
+
+  /**
+   * Returns OWL property rdfs:label, using a cache so we don't need to load the property using the
+   * data property.
+   */
+  public static OWLAnnotationProperty getLabelProperty(OWLOntology ontology) {
+    if (cache_labelProperty != null) return cache_labelProperty;
+    cache_labelProperty =
+        ontology
+            .getOWLOntologyManager()
+            .getOWLDataFactory()
+            .getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI());
+    return cache_labelProperty;
+  }
+
+  /**
+   * Return a list of labels for an OWLNamedIndividual with either no language provided or in
+   * English.
+   *
+   * @param individual The OWLNamedIndividual whose labels need to be retrieved.
+   * @param ontology The ontology within which this individual is defined.
+   * @return A list of labels as Java Strings.
+   */
+  public static Set<String> getLabelsInEnglish(
+      OWLNamedIndividual individual, OWLOntology ontology) {
+    OWLAnnotationProperty labelProperty = getLabelProperty(ontology);
+    return OWLHelper.getAnnotationLiteralsForEntity(
+        ontology, individual, labelProperty, Arrays.asList("en"));
+  }
+
+  /**
+   * Extract values for an annotation property applied to an OWL entity in an ontology for a
+   * particular set of languages.
+   *
+   * @param ontology The ontology containing the entity and the annotation property to extract
+   * @param entity The entity to extract annotations for
+   * @param annotationProperty The annotation property to extract (usually rdfs:label)
+   * @param langs Languages to extract annotation literals for, in order of importance
+   * @return Set of annotation property values for the first matched language, or those associated
+   *     with no languages
+   */
+  public static Set<String> getAnnotationLiteralsForEntity(
+      OWLOntology ontology,
+      OWLEntity entity,
+      OWLAnnotationProperty annotationProperty,
+      List<String> langs) {
+    // Get the map of all strings for all languages for this annotation property
+    Map<String, Set<String>> valuesByLanguage =
+        getAnnotationLiteralsForEntity(ontology, entity, annotationProperty);
+
+    // Look for the languages requested. Note that we return the annotation property
+    // values for the first language we can find, NOT the union of all the annotation
+    // properties.
+    for (String lang : langs) {
+      if (valuesByLanguage.containsKey(lang)) {
+        return valuesByLanguage.get(lang);
+      }
     }
-    
-    /**
-     * Return a list of labels for an OWLNamedIndividual with either no language provided or in English. 
-     * 
-     * @param individual The OWLNamedIndividual whose labels need to be retrieved.
-     * @param ontology The ontology within which this individual is defined.
-     * @return A list of labels as Java Strings.
-     */
-    public static Set<String> getLabelsInEnglish(OWLNamedIndividual individual, OWLOntology ontology) {
-        OWLAnnotationProperty labelProperty = getLabelProperty(ontology);
-        return OWLHelper.getAnnotationLiteralsForEntity(ontology, individual, labelProperty, Arrays.asList("en"));
+
+    // Didn't find the lang? Use "".
+    if (valuesByLanguage.containsKey("")) {
+      return valuesByLanguage.get("");
+    } else {
+      return new HashSet<>();
     }
-    
-    /**
-     * Extract values for an annotation property applied to an OWL entity in an ontology for a particular set of languages.
-     * 
-     * @param ontology The ontology containing the entity and the annotation property to extract
-     * @param entity The entity to extract annotations for
-     * @param annotationProperty The annotation property to extract (usually rdfs:label)
-     * @param langs Languages to extract annotation literals for, in order of importance  
-     * @return Set of annotation property values for the first matched language, or those associated with no languages
-     */
-    public static Set<String> getAnnotationLiteralsForEntity(OWLOntology ontology, OWLEntity entity, OWLAnnotationProperty annotationProperty, List<String> langs) {
-    	// Get the map of all strings for all languages for this annotation property
-        Map<String, Set<String>> valuesByLanguage = getAnnotationLiteralsForEntity(ontology, entity, annotationProperty);
+  }
 
-        // Look for the languages requested. Note that we return the annotation property
-        // values for the first language we can find, NOT the union of all the annotation
-        // properties.
-        for (String lang : langs) {
-            if (valuesByLanguage.containsKey(lang)) {
-                return valuesByLanguage.get(lang);
-            }
-        }
+  /**
+   * Return a Map that contains all known values for a given annotation property for a given OWL
+   * entity, organized by language.
+   *
+   * @param ontology The ontology containing the OWL entity and the annotation property to query
+   * @param entity The OWL entity to query
+   * @param annotationProperty The annotation property to query
+   * @return A Map of annotation values organized into Sets by language.
+   */
+  public static Map<String, Set<String>> getAnnotationLiteralsForEntity(
+      OWLOntology ontology, OWLEntity entity, OWLAnnotationProperty annotationProperty) {
+    Map<String, Set<String>> valuesByLanguage = new HashMap<>();
 
-        // Didn't find the lang? Use "".
-        if (valuesByLanguage.containsKey("")) {
-            return valuesByLanguage.get("");
-        } else {
-            return new HashSet<>();
-        }
-    }
+    // Go through all known annotations, looking for OWLLiterals.
+    EntitySearcher.getAnnotations(entity, ontology, annotationProperty)
+        .stream()
+        .filter(annotation -> annotation.getValue() instanceof OWLLiteral)
+        .forEach(
+            annotation -> {
+              OWLLiteral val = (OWLLiteral) annotation.getValue();
+              String lang = val.getLang();
 
-    /**
-     * Return a Map that contains all known values for a given annotation property for a given OWL entity, 
-     * organized by language. 
-     * 
-     * @param ontology The ontology containing the OWL entity and the annotation property to query 
-     * @param entity The OWL entity to query
-     * @param annotationProperty The annotation property to query
-     * @return A Map of annotation values organized into Sets by language.  
-     */
-    public static Map<String, Set<String>> getAnnotationLiteralsForEntity(OWLOntology ontology, OWLEntity entity, OWLAnnotationProperty annotationProperty) {
-        Map<String, Set<String>> valuesByLanguage = new HashMap<>();
+              // Organize values by language.
+              if (!valuesByLanguage.containsKey(lang)) {
+                valuesByLanguage.put(lang, new HashSet<>());
+              }
 
-        // Go through all known annotations, looking for OWLLiterals.
-        EntitySearcher.getAnnotations(entity, ontology, annotationProperty).stream()
-            .filter(annotation -> annotation.getValue() instanceof OWLLiteral)
-            .forEach(annotation -> {
-                OWLLiteral val = (OWLLiteral) annotation.getValue();
-                String lang = val.getLang();
-
-                // Organize values by language.
-                if (!valuesByLanguage.containsKey(lang)) {
-                    valuesByLanguage.put(lang, new HashSet<>());
-                }
-
-                valuesByLanguage.get(lang).add(val.getLiteral());
+              valuesByLanguage.get(lang).add(val.getLiteral());
             });
 
-        return valuesByLanguage;
-    }
+    return valuesByLanguage;
+  }
 }

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -8,8 +8,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.semanticweb.owlapi.model.AxiomType;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAnnotation;
@@ -26,264 +24,299 @@ import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.search.EntitySearcher;
 
 /**
- * A Phyloreference helper class. It consists of common terms and helper
- * functions to make writing about Phyloreferences easier.
+ * A Phyloreference helper class. It consists of common terms and helper functions to make writing
+ * about Phyloreferences easier.
  *
- * Eventually, this will be reorganized into a Phyloreferencing Java library,
- * but we don't need that level of sophistication just yet.
+ * <p>Eventually, this will be reorganized into a Phyloreferencing Java library, but we don't need
+ * that level of sophistication just yet.
  *
  * @author Gaurav Vaidya <gaurav@ggvaidya.com>
  */
 public class PhylorefHelper {
-    // IRIs used in this package.
+  // IRIs used in this package.
 
-    /** IRI for OWL class Phylogeny */
-    public static final IRI IRI_CDAO_NODE = IRI.create("http://purl.obolibrary.org/obo/CDAO_0000140");
+  /** IRI for OWL class Phylogeny */
+  public static final IRI IRI_CDAO_NODE = IRI.create("http://purl.obolibrary.org/obo/CDAO_0000140");
 
-    /** IRI for OWL class Phyloreference */
-    public static final IRI IRI_PHYLOREFERENCE = IRI.create("http://ontology.phyloref.org/phyloref.owl#Phyloreference");
+  /** IRI for OWL class Phyloreference */
+  public static final IRI IRI_PHYLOREFERENCE =
+      IRI.create("http://ontology.phyloref.org/phyloref.owl#Phyloreference");
 
-    /** IRI for the OWL object property indicating which phylogeny a node belongs to */
-    public static final IRI IRI_PHYLOGENY_CONTAINING_NODE = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#in_phylogeny");
+  /** IRI for the OWL object property indicating which phylogeny a node belongs to */
+  public static final IRI IRI_PHYLOGENY_CONTAINING_NODE =
+      IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#in_phylogeny");
 
-    /** IRI for the OWL data property indicating the label of the expected phyloreference */
-    public static final IRI IRI_NAME_OF_EXPECTED_PHYLOREF = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#expected_phyloreference_named");
+  /** IRI for the OWL data property indicating the label of the expected phyloreference */
+  public static final IRI IRI_NAME_OF_EXPECTED_PHYLOREF =
+      IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#expected_phyloreference_named");
 
-    /** IRI for the OWL object property indicating which specifiers had not been matched */
-    public static final IRI IRI_PHYLOREF_UNMATCHED_SPECIFIER = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#has_unmatched_specifier");
+  /** IRI for the OWL object property indicating which specifiers had not been matched */
+  public static final IRI IRI_PHYLOREF_UNMATCHED_SPECIFIER =
+      IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#has_unmatched_specifier");
 
-    /** IRI for the OWL data property with the verbatim clade definition */
-    public static final IRI IRI_CLADE_DEFINITION = IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#clade_definition");
+  /** IRI for the OWL data property with the verbatim clade definition */
+  public static final IRI IRI_CLADE_DEFINITION =
+      IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#clade_definition");
 
-    /** IRI for the OWL object property that associates a publication with its publication status at a particular time. */
-    public static final IRI IRI_PSO_HOLDS_STATUS_IN_TIME = IRI.create("http://purl.org/spar/pso/holdsStatusInTime");
+  /**
+   * IRI for the OWL object property that associates a publication with its publication status at a
+   * particular time.
+   */
+  public static final IRI IRI_PSO_HOLDS_STATUS_IN_TIME =
+      IRI.create("http://purl.org/spar/pso/holdsStatusInTime");
 
-    /** IRI for the OWL object property that indicates the publication status of a publication status at a particular time. */
-    public static final IRI IRI_PSO_WITH_STATUS = IRI.create("http://purl.org/spar/pso/withStatus");
+  /**
+   * IRI for the OWL object property that indicates the publication status of a publication status
+   * at a particular time.
+   */
+  public static final IRI IRI_PSO_WITH_STATUS = IRI.create("http://purl.org/spar/pso/withStatus");
 
-    /** IRI for the OWL object property that associates a publication status at a particular time with a particular time. */
-    public static final IRI IRI_TVC_AT_TIME = IRI.create("http://www.essepuntato.it/2012/04/tvc/atTime");
+  /**
+   * IRI for the OWL object property that associates a publication status at a particular time with
+   * a particular time.
+   */
+  public static final IRI IRI_TVC_AT_TIME =
+      IRI.create("http://www.essepuntato.it/2012/04/tvc/atTime");
 
-    /** IRI for the OWL data property that indicates when a publication status time begins */
-    public static final IRI IRI_TIMEINT_HAS_INTERVAL_START_DATE = IRI.create("http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#hasIntervalStartDate");
+  /** IRI for the OWL data property that indicates when a publication status time begins */
+  public static final IRI IRI_TIMEINT_HAS_INTERVAL_START_DATE =
+      IRI.create(
+          "http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#hasIntervalStartDate");
 
-    /** IRI for the OWL data property that indicates when a publication status time ends */
-    public static final IRI IRI_TIMEINT_HAS_INTERVAL_END_DATE = IRI.create("http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#hasIntervalEndDate");
+  /** IRI for the OWL data property that indicates when a publication status time ends */
+  public static final IRI IRI_TIMEINT_HAS_INTERVAL_END_DATE =
+      IRI.create(
+          "http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#hasIntervalEndDate");
 
-    /** IRI for the publication status of "Draft" */
-    public static final IRI IRI_PSO_DRAFT = IRI.create("http://purl.org/spar/pso/draft");
+  /** IRI for the publication status of "Draft" */
+  public static final IRI IRI_PSO_DRAFT = IRI.create("http://purl.org/spar/pso/draft");
 
-    /** IRI for the publication status of "Submitted" */
-    public static final IRI IRI_PSO_SUBMITTED = IRI.create("http://purl.org/spar/pso/submitted");
+  /** IRI for the publication status of "Submitted" */
+  public static final IRI IRI_PSO_SUBMITTED = IRI.create("http://purl.org/spar/pso/submitted");
 
-    /** IRI for the publication status of "Published" */
-    public static final IRI IRI_PSO_PUBLISHED = IRI.create("http://purl.org/spar/pso/published");
+  /** IRI for the publication status of "Published" */
+  public static final IRI IRI_PSO_PUBLISHED = IRI.create("http://purl.org/spar/pso/published");
 
-    /**
-     * Get a list of phyloreferences in this ontology without reasoning. This method does not use
-     * the reasoner, and so will only find individuals asserted to have a type
-     * of phyloref:Phyloreference.
-     */
-    public static Set<OWLNamedIndividual> getPhyloreferencesWithoutReasoning(OWLOntology ontology) {
-        // Get a list of all phyloreferences. First, we need to know what a Phyloreference is.
-        Set<OWLEntity> set_phyloref_Phyloreference = ontology.getEntitiesInSignature(IRI_PHYLOREFERENCE);
-        if (set_phyloref_Phyloreference.isEmpty()) {
-            throw new RuntimeException("Class 'phyloref:Phyloreference' is not defined in ontology.");
-        }
-        if (set_phyloref_Phyloreference.size() > 1) {
-            throw new RuntimeException("Class 'phyloref:Phyloreference' is defined multiple times in ontology.");
-        }
-
-        OWLClass phyloref_Phyloreference = set_phyloref_Phyloreference.iterator().next().asOWLClass();
-        Set<OWLNamedIndividual> phylorefs = new HashSet<>();
-        Set<OWLClassAssertionAxiom> classAssertions = ontology.getAxioms(AxiomType.CLASS_ASSERTION);
-
-        for(OWLClassAssertionAxiom classAssertion: classAssertions) {
-            // Does this assertion involve class:Phyloreference and a named individual?
-            if(
-                classAssertion.getIndividual().isNamed() &&
-                classAssertion.getClassesInSignature().contains(phyloref_Phyloreference)
-            ) {
-                // If so, then the individual is a phyloreferences!
-                phylorefs.add(classAssertion.getIndividual().asOWLNamedIndividual());
-            }
-        }
-
-        return phylorefs;
+  /**
+   * Get a list of phyloreferences in this ontology without reasoning. This method does not use the
+   * reasoner, and so will only find individuals asserted to have a type of phyloref:Phyloreference.
+   */
+  public static Set<OWLNamedIndividual> getPhyloreferencesWithoutReasoning(OWLOntology ontology) {
+    // Get a list of all phyloreferences. First, we need to know what a Phyloreference is.
+    Set<OWLEntity> set_phyloref_Phyloreference =
+        ontology.getEntitiesInSignature(IRI_PHYLOREFERENCE);
+    if (set_phyloref_Phyloreference.isEmpty()) {
+      throw new RuntimeException("Class 'phyloref:Phyloreference' is not defined in ontology.");
+    }
+    if (set_phyloref_Phyloreference.size() > 1) {
+      throw new RuntimeException(
+          "Class 'phyloref:Phyloreference' is defined multiple times in ontology.");
     }
 
+    OWLClass phyloref_Phyloreference = set_phyloref_Phyloreference.iterator().next().asOWLClass();
+    Set<OWLNamedIndividual> phylorefs = new HashSet<>();
+    Set<OWLClassAssertionAxiom> classAssertions = ontology.getAxioms(AxiomType.CLASS_ASSERTION);
+
+    for (OWLClassAssertionAxiom classAssertion : classAssertions) {
+      // Does this assertion involve class:Phyloreference and a named individual?
+      if (classAssertion.getIndividual().isNamed()
+          && classAssertion.getClassesInSignature().contains(phyloref_Phyloreference)) {
+        // If so, then the individual is a phyloreferences!
+        phylorefs.add(classAssertion.getIndividual().asOWLNamedIndividual());
+      }
+    }
+
+    return phylorefs;
+  }
+
+  /**
+   * Get a list of phyloreferences in this ontology. This method uses the reasoner, and so will find
+   * all individuals determined to be of type phyloref:Phyloreference.
+   *
+   * @param ontology The OWL Ontology within with we should look for phylorefs
+   * @param reasoner The reasoner to use. May be null.
+   */
+  public static Set<OWLNamedIndividual> getPhyloreferences(
+      OWLOntology ontology, OWLReasoner reasoner) {
+    // If no reasoner is provided, we can't find all individuals that are
+    // inferred to be phyloref:Phyloreference, but we can still find all
+    // individuals that are stated to be phyloref:Phyloreference. So let's do that!
+    if (reasoner == null) return PhylorefHelper.getPhyloreferencesWithoutReasoning(ontology);
+
+    // Get a list of all phyloreferences. First, we need to know what a Phyloreference is.
+    Set<OWLEntity> set_phyloref_Phyloreference =
+        ontology.getEntitiesInSignature(IRI_PHYLOREFERENCE);
+    if (set_phyloref_Phyloreference.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Class " + IRI_PHYLOREFERENCE + " is not defined in ontology.");
+    }
+    if (set_phyloref_Phyloreference.size() > 1) {
+      throw new IllegalArgumentException(
+          "Class " + IRI_PHYLOREFERENCE + " is defined multiple times in ontology.");
+    }
+
+    OWLClass phyloref_Phyloreference = set_phyloref_Phyloreference.iterator().next().asOWLClass();
+    return reasoner.getInstances(phyloref_Phyloreference, true).getFlattened();
+  }
+
+  /** A wrapper for a phyloref status at a particular point in time. */
+  public static class PhylorefStatus {
+    private OWLNamedIndividual phyloref;
+    private IRI statusIRI;
+    private Instant intervalStart;
+    private Instant intervalEnd;
+
     /**
-     * Get a list of phyloreferences in this ontology. This method uses the
-     * reasoner, and so will find all individuals determined to be of
-     * type phyloref:Phyloreference.
+     * Create a PhylorefStatus. All arguments except status are optional, and may be null.
      *
-     * @param ontology The OWL Ontology within with we should look for phylorefs
-     * @param reasoner The reasoner to use. May be null.
+     * @param phyloref The phyloreference containing this status.
+     * @param status The status of this phyloreference, as an individual in the class
+     *     http://purl.org/spar/pso/PublicationStatus. Required.
+     * @param intervalStart The interval at which this status starts.
+     * @param intervalEnd The interval at which this status ends. May be null if this status hasn't
+     *     ended yet.
      */
-    public static Set<OWLNamedIndividual> getPhyloreferences(OWLOntology ontology, OWLReasoner reasoner) {
-        // If no reasoner is provided, we can't find all individuals that are
-        // inferred to be phyloref:Phyloreference, but we can still find all
-        // individuals that are stated to be phyloref:Phyloreference. So let's do that!
-        if(reasoner == null) return PhylorefHelper.getPhyloreferencesWithoutReasoning(ontology);
+    public PhylorefStatus(
+        OWLNamedIndividual phyloref, IRI status, Instant intervalStart, Instant intervalEnd) {
+      this.phyloref = phyloref;
+      this.statusIRI = status;
+      this.intervalStart = intervalStart;
+      this.intervalEnd = intervalEnd;
 
-        // Get a list of all phyloreferences. First, we need to know what a Phyloreference is.
-        Set<OWLEntity> set_phyloref_Phyloreference = ontology.getEntitiesInSignature(IRI_PHYLOREFERENCE);
-        if (set_phyloref_Phyloreference.isEmpty()) {
-            throw new IllegalArgumentException("Class " + IRI_PHYLOREFERENCE + " is not defined in ontology.");
-        }
-        if (set_phyloref_Phyloreference.size() > 1) {
-            throw new IllegalArgumentException("Class " + IRI_PHYLOREFERENCE + " is defined multiple times in ontology.");
-        }
+      if (status == null)
+        throw new IllegalArgumentException(
+            "No status provided to PhylorefStatus, which is a required argument");
+    }
 
-        OWLClass phyloref_Phyloreference = set_phyloref_Phyloreference.iterator().next().asOWLClass();
-        return reasoner.getInstances(phyloref_Phyloreference, true).getFlattened();
+    /** @return the phyloreference this status is associated with. May be null. */
+    public OWLNamedIndividual getPhyloref() {
+      return phyloref;
     }
 
     /**
-     * A wrapper for a phyloref status at a particular point in time.
+     * @return the status of this phyloreference, as an individual in the class
+     *     http://purl.org/spar/pso/PublicationStatus
      */
-    public static class PhylorefStatus {
-      private OWLNamedIndividual phyloref;
-      private IRI statusIRI;
-      private Instant intervalStart;
-      private Instant intervalEnd;
+    public IRI getStatus() {
+      return statusIRI;
+    }
 
-      /**
-       * Create a PhylorefStatus. All arguments except status are optional, and may be null.
-       *
-       * @param phyloref The phyloreference containing this status.
-       * @param status The status of this phyloreference, as an individual in the class http://purl.org/spar/pso/PublicationStatus. Required.
-       * @param intervalStart The interval at which this status starts.
-       * @param intervalEnd The interval at which this status ends. May be null if this status hasn't ended yet.
-       */
-      public PhylorefStatus(OWLNamedIndividual phyloref, IRI status, Instant intervalStart, Instant intervalEnd) {
-        this.phyloref = phyloref;
-        this.statusIRI = status;
-        this.intervalStart = intervalStart;
-        this.intervalEnd = intervalEnd;
-
-        if(status == null) throw new IllegalArgumentException("No status provided to PhylorefStatus, which is a required argument");
-      }
-
-      /**
-       * @return the phyloreference this status is associated with. May be null.
-       */
-      public OWLNamedIndividual getPhyloref() {
-        return phyloref;
-      }
-
-      /**
-       * @return the status of this phyloreference, as an individual in the class http://purl.org/spar/pso/PublicationStatus
-       */
-      public IRI getStatus() {
-        return statusIRI;
-      }
-
-      /**
-       * @return the interval at which this status starts.
-       */
-      public Instant getIntervalStart() {
-        return intervalStart;
-      }
-
-      /**
-       * @return the interval at which this status ends. May be null if this status hasn't ended yet.
-       */
-      public Instant getIntervalEnd() {
-        return intervalEnd;
-      }
-
-      /**
-       * @return a String representation of this phyloref status
-       */
-      @Override
-      public String toString() {
-        StringBuffer statusString = new StringBuffer("phyloreference status " + statusIRI);
-
-        if(getIntervalStart() != null) statusString.append(" starting at " + getIntervalStart().toString());
-        if(getIntervalEnd() != null) statusString.append(" ending at " + getIntervalEnd().toString());
-
-        return statusString.toString();
-      }
+    /** @return the interval at which this status starts. */
+    public Instant getIntervalStart() {
+      return intervalStart;
     }
 
     /**
-     * Return a list of PhylorefStatuses associated with a particular phyloreference in the provided ontology.
-     *
-     * @param phyloref The phyloreference whose statuses are being queried.
-     * @param ontology The ontology within which this phyloreference is defined.
-     * @return A list of phyloref statuses.
+     * @return the interval at which this status ends. May be null if this status hasn't ended yet.
      */
-    public static List<PhylorefStatus> getCurrentStatusesForPhyloref(OWLNamedIndividual phyloref, OWLOntology ontology) {
-      List<PhylorefStatus> statuses = new ArrayList<>();
+    public Instant getIntervalEnd() {
+      return intervalEnd;
+    }
 
-      // Set up the OWL annotation properties we need to look up the phyloref statuses.
-      OWLDataFactory dataFactory = ontology.getOWLOntologyManager().getOWLDataFactory();
-      OWLClass phylorefAsClass = dataFactory.getOWLClass(phyloref.getIRI());
+    /** @return a String representation of this phyloref status */
+    @Override
+    public String toString() {
+      StringBuffer statusString = new StringBuffer("phyloreference status " + statusIRI);
 
-      OWLAnnotationProperty pso_holdsStatusInTime = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_PSO_HOLDS_STATUS_IN_TIME);
-      OWLAnnotationProperty pso_withStatus = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_PSO_WITH_STATUS);
-      OWLAnnotationProperty tvc_atTime = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TVC_AT_TIME);
-      OWLAnnotationProperty timeinterval_hasIntervalStartDate = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TIMEINT_HAS_INTERVAL_START_DATE);
-      OWLAnnotationProperty timeinterval_hasIntervalEndDate = dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TIMEINT_HAS_INTERVAL_END_DATE);
+      if (getIntervalStart() != null)
+        statusString.append(" starting at " + getIntervalStart().toString());
+      if (getIntervalEnd() != null)
+        statusString.append(" ending at " + getIntervalEnd().toString());
 
-      // Retrieve holdsStatusInTime to determine the active status of this phyloreference.
-      Collection<OWLAnnotation> holdsStatusInTime = EntitySearcher.getAnnotations(phylorefAsClass, ontology, pso_holdsStatusInTime);
+      return statusString.toString();
+    }
+  }
 
-      // Read through the list of OWLAnnotations to create corresponding PhylorefStatus objects.
-      for(OWLAnnotation statusInTime: holdsStatusInTime) {
-        // Each statusInTime entry should have one status (pso:withStatus)
-        // and a number of time intervals (tvc:atTime). We collect all
-        // statusues and test to see if any of those time intervals are
-        // "incomplete", i.e. they have a start date but no end date.
-        IRI phylorefStatusIRI = null;
-        Instant intervalStartDate = null;
-        Instant intervalEndDate = null;
+  /**
+   * Return a list of PhylorefStatuses associated with a particular phyloreference in the provided
+   * ontology.
+   *
+   * @param phyloref The phyloreference whose statuses are being queried.
+   * @param ontology The ontology within which this phyloreference is defined.
+   * @return A list of phyloref statuses.
+   */
+  public static List<PhylorefStatus> getCurrentStatusesForPhyloref(
+      OWLNamedIndividual phyloref, OWLOntology ontology) {
+    List<PhylorefStatus> statuses = new ArrayList<>();
 
-        for(OWLAnonymousIndividual indiv_statusInTime: statusInTime.getAnonymousIndividuals()) {
-          for(OWLAnnotationAssertionAxiom axiom: ontology.getAnnotationAssertionAxioms(indiv_statusInTime)) {
-            if(axiom.getProperty().equals(tvc_atTime)) {
-              for(OWLAnonymousIndividual indiv_atTime: axiom.getValue().getAnonymousIndividuals()) {
-                for(OWLAnnotationAssertionAxiom axiom_interval: ontology.getAnnotationAssertionAxioms(indiv_atTime)) {
-                  // Look for timeinterval:hasIntervalStartDate and timeinterval:hasIntervalEndDate data properties.
-                  if(axiom_interval.getProperty().equals(timeinterval_hasIntervalStartDate)) {
-                    try {
-                      intervalStartDate = ZonedDateTime.parse(
-                        axiom_interval.getValue().asLiteral().get().getLiteral()
-                      ).toInstant();
-                    } catch(DateTimeParseException ex) {
-                      // If we have a start date but can't parse it, record it as the earliest possible time.
-                      intervalStartDate = Instant.MIN;
-                    }
+    // Set up the OWL annotation properties we need to look up the phyloref statuses.
+    OWLDataFactory dataFactory = ontology.getOWLOntologyManager().getOWLDataFactory();
+    OWLClass phylorefAsClass = dataFactory.getOWLClass(phyloref.getIRI());
+
+    OWLAnnotationProperty pso_holdsStatusInTime =
+        dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_PSO_HOLDS_STATUS_IN_TIME);
+    OWLAnnotationProperty pso_withStatus =
+        dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_PSO_WITH_STATUS);
+    OWLAnnotationProperty tvc_atTime =
+        dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TVC_AT_TIME);
+    OWLAnnotationProperty timeinterval_hasIntervalStartDate =
+        dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TIMEINT_HAS_INTERVAL_START_DATE);
+    OWLAnnotationProperty timeinterval_hasIntervalEndDate =
+        dataFactory.getOWLAnnotationProperty(PhylorefHelper.IRI_TIMEINT_HAS_INTERVAL_END_DATE);
+
+    // Retrieve holdsStatusInTime to determine the active status of this phyloreference.
+    Collection<OWLAnnotation> holdsStatusInTime =
+        EntitySearcher.getAnnotations(phylorefAsClass, ontology, pso_holdsStatusInTime);
+
+    // Read through the list of OWLAnnotations to create corresponding PhylorefStatus objects.
+    for (OWLAnnotation statusInTime : holdsStatusInTime) {
+      // Each statusInTime entry should have one status (pso:withStatus)
+      // and a number of time intervals (tvc:atTime). We collect all
+      // statusues and test to see if any of those time intervals are
+      // "incomplete", i.e. they have a start date but no end date.
+      IRI phylorefStatusIRI = null;
+      Instant intervalStartDate = null;
+      Instant intervalEndDate = null;
+
+      for (OWLAnonymousIndividual indiv_statusInTime : statusInTime.getAnonymousIndividuals()) {
+        for (OWLAnnotationAssertionAxiom axiom :
+            ontology.getAnnotationAssertionAxioms(indiv_statusInTime)) {
+          if (axiom.getProperty().equals(tvc_atTime)) {
+            for (OWLAnonymousIndividual indiv_atTime : axiom.getValue().getAnonymousIndividuals()) {
+              for (OWLAnnotationAssertionAxiom axiom_interval :
+                  ontology.getAnnotationAssertionAxioms(indiv_atTime)) {
+                // Look for timeinterval:hasIntervalStartDate and timeinterval:hasIntervalEndDate
+                // data properties.
+                if (axiom_interval.getProperty().equals(timeinterval_hasIntervalStartDate)) {
+                  try {
+                    intervalStartDate =
+                        ZonedDateTime.parse(
+                                axiom_interval.getValue().asLiteral().get().getLiteral())
+                            .toInstant();
+                  } catch (DateTimeParseException ex) {
+                    // If we have a start date but can't parse it, record it as the earliest
+                    // possible time.
+                    intervalStartDate = Instant.MIN;
                   }
-                  if(axiom_interval.getProperty().equals(timeinterval_hasIntervalEndDate)) {
-                    try {
-                      intervalEndDate = ZonedDateTime.parse(
-                        axiom_interval.getValue().asLiteral().get().getLiteral()
-                      ).toInstant();
-                    } catch(DateTimeParseException ex) {
-                      // If we have an end date but can't parse it, record it at the latest possible time.
-                      intervalEndDate = Instant.MAX;
-                    }
+                }
+                if (axiom_interval.getProperty().equals(timeinterval_hasIntervalEndDate)) {
+                  try {
+                    intervalEndDate =
+                        ZonedDateTime.parse(
+                                axiom_interval.getValue().asLiteral().get().getLiteral())
+                            .toInstant();
+                  } catch (DateTimeParseException ex) {
+                    // If we have an end date but can't parse it, record it at the latest possible
+                    // time.
+                    intervalEndDate = Instant.MAX;
                   }
                 }
               }
-            } else if(axiom.getProperty().equals(pso_withStatus)) {
-              phylorefStatusIRI = (IRI) axiom.getValue();
-            } else {
-              throw new IllegalArgumentException("Phyloreference " + phyloref + " contains an unknown axiom: " + axiom);
             }
+          } else if (axiom.getProperty().equals(pso_withStatus)) {
+            phylorefStatusIRI = (IRI) axiom.getValue();
+          } else {
+            throw new IllegalArgumentException(
+                "Phyloreference " + phyloref + " contains an unknown axiom: " + axiom);
           }
         }
-
-        statuses.add(new PhylorefHelper.PhylorefStatus(
-          phyloref,
-          phylorefStatusIRI,
-          intervalStartDate,
-          intervalEndDate
-        ));
       }
 
-      return statuses;
+      statuses.add(
+          new PhylorefHelper.PhylorefStatus(
+              phyloref, phylorefStatusIRI, intervalStartDate, intervalEndDate));
     }
+
+    return statuses;
+  }
 }

--- a/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
@@ -2,7 +2,6 @@ package org.phyloref.jphyloref.helpers;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.semanticweb.owlapi.apibinding.OWLManager;
@@ -10,82 +9,91 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 import org.semanticweb.owlapi.util.Version;
-
 import uk.ac.manchester.cs.factplusplus.owlapiv3.FaCTPlusPlusReasonerFactory;
 import uk.ac.manchester.cs.jfact.JFactFactory;
 
 /**
- * The ReasonerHelper provides methods to help create and manage
- * OWL Reasoners, and to allow the user to choose a different
- * reasoner to carry out any specified task. 
- * 
+ * The ReasonerHelper provides methods to help create and manage OWL Reasoners, and to allow the
+ * user to choose a different reasoner to carry out any specified task.
+ *
  * @author Gaurav Vaidya <gaurav@ggvaidya.com>
  */
 public class ReasonerHelper {
-	/** A map of reasoner names and the corresponding reasoner factory */
-	private static Map<String, OWLReasonerFactory> reasonerFactories = new HashMap<>();
-	
-	static {
-		/*
-		 * Set up a list of reasoner names and their corresponding reasoner factory.
-		 */
-		reasonerFactories.put("null", null);
-		reasonerFactories.put("jfact", new JFactFactory());
-		reasonerFactories.put("fact++", new FaCTPlusPlusReasonerFactory());
-	}
+  /** A map of reasoner names and the corresponding reasoner factory */
+  private static Map<String, OWLReasonerFactory> reasonerFactories = new HashMap<>();
 
-	/**
-	 * Get reasoner factory by name.
-	 */
-	public static OWLReasonerFactory getReasonerFactory(String name) {
-		// Look it up.
-		if(reasonerFactories.containsKey(name)) {
-			return reasonerFactories.get(name);
-		}
-		
-		// If all else fails, throw an exception.
-		throw new IllegalArgumentException("No reasoner named '" + name + "'; must be one of: " + reasonerFactories.keySet().toString());
-	}
-	
-	/**
-	 * Get all reasoner factories.
-	 */
-	public static Map<String, OWLReasonerFactory> getReasonerFactories() {
-		return reasonerFactories;
-	}
-	
-	public static String getReasonerNameAndVersion(OWLReasonerFactory factory) {
-		if(factory == null) return "No reasoner used";
-		
-		String versionString;
-		try {
-			OWLReasoner reasoner = factory.createNonBufferingReasoner(OWLManager.createOWLOntologyManager().createOntology());
-			Version version = reasoner.getReasonerVersion();
-			versionString = version.getMajor() + "." + version.getMinor() + "." + version.getBuild() + "." + version.getPatch();
-		} catch (OWLOntologyCreationException e) {
-			versionString = "(undefined)"; 
-		}		
-		
-		return factory.getReasonerName() + "/" + versionString; 
-	}
-		
-	/**
-	 * Return an OWLReasoner based on the command-line settings.
-	 * 
-	 * For now, we only look for one setting -- '--reasoner' -- and identify a reasoner based on that,
-	 * but in the future we might support additional options that allow you to configure the reasoner.
-	 */
-	public static OWLReasonerFactory getReasonerFactoryFromCmdLine(CommandLine cmdLine) {
-		if(cmdLine.hasOption("reasoner")) {
-			return getReasonerFactory(cmdLine.getOptionValue("reasoner")); 				
-		} else {
-			// No reasoner provided? Default to JFact.
-			return new JFactFactory();
-		}
-	}
-	
-	/** Add command line options that can be read by getReasonerFromCmdLine() */
-	public static void addCommandLineOptions(Options opts) {
-		opts.addOption("reasoner", "reasoner", true, "The reasoner to be used (use help to see list of options)");
-	}
+  static {
+    /*
+     * Set up a list of reasoner names and their corresponding reasoner factory.
+     */
+    reasonerFactories.put("null", null);
+    reasonerFactories.put("jfact", new JFactFactory());
+    reasonerFactories.put("fact++", new FaCTPlusPlusReasonerFactory());
+  }
+
+  /** Get reasoner factory by name. */
+  public static OWLReasonerFactory getReasonerFactory(String name) {
+    // Look it up.
+    if (reasonerFactories.containsKey(name)) {
+      return reasonerFactories.get(name);
+    }
+
+    // If all else fails, throw an exception.
+    throw new IllegalArgumentException(
+        "No reasoner named '"
+            + name
+            + "'; must be one of: "
+            + reasonerFactories.keySet().toString());
+  }
+
+  /** Get all reasoner factories. */
+  public static Map<String, OWLReasonerFactory> getReasonerFactories() {
+    return reasonerFactories;
+  }
+
+  public static String getReasonerNameAndVersion(OWLReasonerFactory factory) {
+    if (factory == null) return "No reasoner used";
+
+    String versionString;
+    try {
+      OWLReasoner reasoner =
+          factory.createNonBufferingReasoner(
+              OWLManager.createOWLOntologyManager().createOntology());
+      Version version = reasoner.getReasonerVersion();
+      versionString =
+          version.getMajor()
+              + "."
+              + version.getMinor()
+              + "."
+              + version.getBuild()
+              + "."
+              + version.getPatch();
+    } catch (OWLOntologyCreationException e) {
+      versionString = "(undefined)";
+    }
+
+    return factory.getReasonerName() + "/" + versionString;
+  }
+
+  /**
+   * Return an OWLReasoner based on the command-line settings.
+   *
+   * <p>For now, we only look for one setting -- '--reasoner' -- and identify a reasoner based on
+   * that, but in the future we might support additional options that allow you to configure the
+   * reasoner.
+   */
+  public static OWLReasonerFactory getReasonerFactoryFromCmdLine(CommandLine cmdLine) {
+    if (cmdLine.hasOption("reasoner")) {
+      return getReasonerFactory(cmdLine.getOptionValue("reasoner"));
+    } else {
+      // No reasoner provided? Default to JFact.
+      return new JFactFactory();
+    }
+  }
+
+  /** Add command line options that can be read by getReasonerFromCmdLine() */
+  public static void addCommandLineOptions(Options opts) {
+    opts.addOption(
+        "reasoner", "reasoner", true, "The reasoner to be used (use help to see list of options)");
+  }
 }

--- a/src/test/java/org/phyloref/jphyloref/AppTest.java
+++ b/src/test/java/org/phyloref/jphyloref/AppTest.java
@@ -4,35 +4,24 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
-/**
- * Unit test for simple App.
- */
-public class AppTest 
-    extends TestCase
-{
-    /**
-     * Create the test case
-     *
-     * @param testName name of the test case
-     */
-    public AppTest( String testName )
-    {
-        super( testName );
-    }
+/** Unit test for simple App. */
+public class AppTest extends TestCase {
+  /**
+   * Create the test case
+   *
+   * @param testName name of the test case
+   */
+  public AppTest(String testName) {
+    super(testName);
+  }
 
-    /**
-     * @return the suite of tests being tested
-     */
-    public static Test suite()
-    {
-        return new TestSuite( AppTest.class );
-    }
+  /** @return the suite of tests being tested */
+  public static Test suite() {
+    return new TestSuite(AppTest.class);
+  }
 
-    /**
-     * Rigourous Test :-)
-     */
-    public void testApp()
-    {
-        assertTrue( true );
-    }
+  /** Rigourous Test :-) */
+  public void testApp() {
+    assertTrue(true);
+  }
 }


### PR DESCRIPTION
This PR adds [Spotless](https://github.com/diffplug/spotless/tree/master/plugin-maven) as a code style enforcer. Spotless can be run with a goal of either `spotless:check` (which will report violations of the code style) or `spotless:apply` (which will automatically fix code style violations). This PR integrates a `spotless:check` into the `mvn test` command, and activates automatic testing of the code style on Travis CI.