### PR TITLE
Updated .gitignore to ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore .DS_Store files generated on macOS.
+.DS_Store
+
 # JNI libraries
 *.jnilib
 


### PR DESCRIPTION
Since I'd previously been developing this primarily on Windows and Linux, I hadn't noticed that .DS_Store files generated on macOS were not being ignored by .gitignore. Now fixed.