### PR TITLE
 Eliminated getReasonerNameAndVersion() crash when a JNI is not linked

### DIFF
--- a/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
@@ -1,5 +1,6 @@
 package org.phyloref.jphyloref.helpers;
 
+import java.lang.UnsatisfiedLinkError;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -63,10 +64,12 @@ public class ReasonerHelper {
 			Version version = reasoner.getReasonerVersion();
 			versionString = version.getMajor() + "." + version.getMinor() + "." + version.getBuild() + "." + version.getPatch();
 		} catch (OWLOntologyCreationException e) {
-			versionString = "(undefined)"; 
-		}		
-		
-		return factory.getReasonerName() + "/" + versionString; 
+			versionString = "(undefined)";
+		} catch (UnsatisfiedLinkError err) {
+			versionString = "(JNI library not linked)";
+		}
+
+		return factory.getReasonerName() + "/" + versionString;
 	}
 		
 	/**

--- a/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
@@ -64,8 +64,13 @@ public class ReasonerHelper {
 			Version version = reasoner.getReasonerVersion();
 			versionString = version.getMajor() + "." + version.getMinor() + "." + version.getBuild() + "." + version.getPatch();
 		} catch (OWLOntologyCreationException e) {
-			versionString = "(undefined)";
+                        // There was an error creating the OWL Ontology.
+			versionString = "(error: " + e + ")";
 		} catch (UnsatisfiedLinkError err) {
+                        // Reasoners that use Java Native Interface (JNI) libraries
+                        // will throw this exception if a native method could not be
+                        // found. Trapping it here allows us to display the entire
+                        // list of reasoners without disruption.
 			versionString = "(JNI library not linked)";
 		}
 


### PR DESCRIPTION
getReasonerNameAndVersion() currently crashes when a JNI is not linked, which occurs when `jphyloref help` has been executed without providing the path to the FaCT++ library. This PR will instead display the reasoner name and version as e.g. `FaCT++/(JNI library not linked)`.