### PR TITLE
Add support for JSON-LD to TestCommand

### DIFF
--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -82,7 +82,13 @@ public class TestCommand implements Command {
         "i",
         "input",
         true,
-        "The input ontology to read in RDF/XML (can also be provided without the '-i')");
+        "The input ontology to read in RDF/XML or JSON-LD (can also be provided without the '-i').");
+
+    opts.addOption(
+        "j",
+        "jsonld",
+        false,
+        "Treat the input file as a JSON-LD file. Files with a '.json' or '.jsonld' extension will automatically be treated as a JSON-LD file.");
   }
 
   /**
@@ -123,7 +129,9 @@ public class TestCommand implements Command {
     OWLOntology ontology;
     String inputFileLowercase = str_input.toLowerCase();
     try {
-      if (inputFileLowercase.endsWith(".json") || inputFileLowercase.endsWith(".jsonld")) {
+      if (cmdLine.hasOption("jsonld")
+          || inputFileLowercase.endsWith(".json")
+          || inputFileLowercase.endsWith(".jsonld")) {
         // Use the JSONLD Helper to load the ontology.
         String DEFAULT_URI_PREFIX = "http://example.org/jphyloref";
         ontology = manager.createOntology();

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -1,6 +1,8 @@
 package org.phyloref.jphyloref.commands;
 
 import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -9,6 +11,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.phyloref.jphyloref.helpers.JSONLDHelper;
 import org.phyloref.jphyloref.helpers.OWLHelper;
 import org.phyloref.jphyloref.helpers.PhylorefHelper;
 import org.phyloref.jphyloref.helpers.ReasonerHelper;
@@ -115,12 +119,26 @@ public class TestCommand implements Command {
     System.err.println("Found local ontologies: " + mapper.getOntologyIRIs());
     manager.addIRIMapper(mapper);
 
-    // Load the ontology using OWLManager.
+    // Is this a JSON or JSON-LD file?
     OWLOntology ontology;
+    String inputFileLowercase = str_input.toLowerCase();
     try {
-      ontology = manager.loadOntologyFromOntologyDocument(inputFile);
+      if (inputFileLowercase.endsWith(".json") || inputFileLowercase.endsWith(".jsonld")) {
+        // Use the JSONLD Helper to load the ontology.
+        String DEFAULT_URI_PREFIX = "http://example.org/jphyloref";
+        ontology = manager.createOntology();
+        RDFParser parser = JSONLDHelper.createRDFParserForOntology(ontology);
+        parser.parse(new FileReader(inputFile), DEFAULT_URI_PREFIX);
+      } else {
+        // Load the ontology using OWLManager.
+        ontology = manager.loadOntologyFromOntologyDocument(inputFile);
+      }
     } catch (OWLOntologyCreationException ex) {
-      throw new RuntimeException("Could not load ontology '" + inputFile + "': " + ex);
+      System.err.println("Could not create ontology '" + inputFile + "': " + ex);
+      return 1;
+    } catch (IOException ex) {
+      System.err.println("Could not read and load ontology '" + inputFile + "': " + ex);
+      return 1;
     }
 
     // Ontology loaded.

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -14,33 +14,24 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
-import org.eclipse.rdf4j.rio.Rio;
 import org.json.JSONObject;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Value;
-import org.openrdf.model.impl.ValueFactoryImpl;
 import org.phyloref.jphyloref.JPhyloRef;
+import org.phyloref.jphyloref.helpers.JSONLDHelper;
 import org.phyloref.jphyloref.helpers.PhylorefHelper;
 import org.phyloref.jphyloref.helpers.ReasonerHelper;
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.formats.RDFJsonLDDocumentFormat;
 import org.semanticweb.owlapi.model.ClassExpressionType;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLNamedIndividual;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
-import org.semanticweb.owlapi.model.OWLOntologyLoaderConfiguration;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
-import org.semanticweb.owlapi.rio.RioOWLRDFConsumerAdapter;
 import org.semanticweb.owlapi.search.EntitySearcher;
-import org.semanticweb.owlapi.util.AnonymousNodeChecker;
 import org.semanticweb.owlapi.util.AutoIRIMapper;
 import org.semanticweb.owlapi.util.VersionInfo;
 
@@ -153,162 +144,6 @@ public class WebserverCommand implements Command {
       System.err.println("Found local ontologies: " + mapper.getOntologyIRIs());
       manager.addIRIMapper(mapper);
 
-      OWLOntology ontology = manager.createOntology();
-      OWLOntologyLoaderConfiguration config = new OWLOntologyLoaderConfiguration();
-
-      // Set up a RioOWLRDFConsumerAdapter that will take in RDF and will
-      // produce OWL to store in an ontology.
-      AnonymousNodeChecker anonymousNodeChecker =
-          new AnonymousNodeChecker() {
-            /* Copied from https://github.com/owlcs/owlapi/blob/master/rio/src/main/java/org/semanticweb/owlapi/rio/RioParserImpl.java */
-
-            private boolean isAnonymous(String iri) {
-              return iri.startsWith("_:");
-            }
-
-            @Override
-            public boolean isAnonymousSharedNode(String iri) {
-              return isAnonymous(iri);
-            }
-
-            @Override
-            public boolean isAnonymousNode(String iri) {
-              return isAnonymous(iri);
-            }
-
-            @Override
-            public boolean isAnonymousNode(IRI iri) {
-              return isAnonymous(iri.toString());
-            }
-          };
-
-      RioOWLRDFConsumerAdapter rdfHandler =
-          new RioOWLRDFConsumerAdapter(ontology, anonymousNodeChecker, config);
-      rdfHandler.setOntologyFormat(new RDFJsonLDDocumentFormat());
-
-      // Set up an RDF parser to read the JSON-LD file.
-      RDFParser parser = Rio.createParser(RDFFormat.JSONLD);
-
-      // We could connect the parser to the RioOWLRDFConsumerAdapter by saying:
-      //  parser.setRDFHandler(rdfHandler);
-      // Or alternatively:
-      //  RioJsonLDParserFactory factory = new RioJsonLDParserFactory();
-      //  factory.createParser().parse(new FileDocumentSource(jsonldFile), ontology, config);
-      //
-      // Unfortunately, RioOWLRDFConsumerAdapter implements org.openrdf.rio.RDFHandler
-      // while the JSON-LD parser expects org.eclipse.rdf4j.rio.RDFHandler. I've tried
-      // adding https://mvnrepository.com/artifact/org.openrdf.sesame/sesame-rio-jsonld,
-      // as version 2.9.0, 4.0.2 and 4.1.2, but neither version registers as a JSON-LD
-      // handler, giving the following error message:
-      //	Caused by: org.openrdf.rio.UnsupportedRDFormatException: Did not recognise RDF
-      //	format object JSON-LD (mimeTypes=application/ld+json; ext=jsonld)
-      // So as to keep moving, I've written a very hacky translator from
-      // an org.openrdf.rio.RDFHandler to an org.eclipse.rdf4j.rio.RDFHandler.
-      // (Tracked at https://github.com/phyloref/jphyloref/issues/11)
-      //
-      parser.setRDFHandler(
-          new org.eclipse.rdf4j.rio.RDFHandler() {
-            // Most of these methods just call the corresponding method on the
-            // other rdfHandler.
-
-            @Override
-            public void startRDF() throws RDFHandlerException {
-              rdfHandler.startRDF();
-            }
-
-            @Override
-            public void endRDF() throws RDFHandlerException {
-              rdfHandler.endRDF();
-            }
-
-            @Override
-            public void handleNamespace(String prefix, String uri) throws RDFHandlerException {
-              rdfHandler.handleNamespace(prefix, uri);
-            }
-
-            @Override
-            public void handleComment(String comment) throws RDFHandlerException {
-              rdfHandler.handleComment(comment);
-            }
-
-            // The only exception to this are handleStatement(Statement), where we
-            // need to translate from one Statement to the other. We do this by
-            // translating subject, object and property using translateResource()
-            // (to translate Resources) and translateValue() (to translate Values).
-
-            @Override
-            public void handleStatement(org.eclipse.rdf4j.model.Statement st)
-                throws RDFHandlerException {
-              ValueFactoryImpl svf = ValueFactoryImpl.getInstance();
-
-              // System.out.println("Translating statement " + st);
-
-              rdfHandler.handleStatement(
-                  svf.createStatement(
-                      translateResource(st.getSubject()),
-                      svf.createURI(st.getPredicate().stringValue()),
-                      translateValue(st.getObject())));
-            }
-
-            /**
-             * Translate a Resource from org.eclipse.rdf4j.model.Resource to
-             * org.openrdf.model.Resource. We support two kinds of resources: blank nodes (BNodes)
-             * and IRIs.
-             */
-            private org.openrdf.model.Resource translateResource(
-                org.eclipse.rdf4j.model.Resource res) {
-              ValueFactoryImpl svf = ValueFactoryImpl.getInstance();
-
-              if (res instanceof org.eclipse.rdf4j.model.BNode) {
-                org.eclipse.rdf4j.model.BNode bnode = (org.eclipse.rdf4j.model.BNode) res;
-
-                return (Resource) svf.createBNode(bnode.getID());
-              }
-
-              if (res instanceof org.eclipse.rdf4j.model.IRI) {
-                org.eclipse.rdf4j.model.IRI iri = (org.eclipse.rdf4j.model.IRI) res;
-
-                return (Resource) svf.createURI(iri.stringValue());
-              }
-
-              throw new RuntimeException("Unknown resource type: " + res);
-            }
-
-            /**
-             * Translate a Value from org.eclipse.rdf4j.model.Value to org.openrdf.model.Value. We
-             * support three kinds of Values: blank nodes (BNodes), IRIs and Literals. The first two
-             * are handled correctly, but literals are always converted into strings, regardless of
-             * their actual data type.
-             */
-            private org.openrdf.model.Value translateValue(org.eclipse.rdf4j.model.Value value) {
-              ValueFactoryImpl svf = ValueFactoryImpl.getInstance();
-
-              if (value instanceof org.eclipse.rdf4j.model.BNode) {
-                org.eclipse.rdf4j.model.BNode bnode = (org.eclipse.rdf4j.model.BNode) value;
-
-                return (Value) svf.createBNode(bnode.getID());
-              }
-
-              if (value instanceof org.eclipse.rdf4j.model.IRI) {
-                org.eclipse.rdf4j.model.IRI iri = (org.eclipse.rdf4j.model.IRI) value;
-
-                return (Value) svf.createURI(iri.stringValue());
-              }
-
-              if (value instanceof org.eclipse.rdf4j.model.Literal) {
-                org.eclipse.rdf4j.model.Literal literal = (org.eclipse.rdf4j.model.Literal) value;
-
-                // Note that this converts literals that should be treated as integers,
-                // doubles and so on will be converted into strings here.
-                return (Value)
-                    svf.createLiteral(
-                        literal.stringValue(), svf.createURI(literal.getDatatype().stringValue()));
-              }
-
-              throw new RuntimeException("Unknown value type: " + value);
-            }
-          });
-
       // Setup ready; parse the file!
       // We could jsonldFile.toURI().toString() as the file IRI, but this points
       // to a temporary file on the server where the JSON-LD file was stored by
@@ -321,6 +156,8 @@ public class WebserverCommand implements Command {
       // (i.e. all of whose URIs are local to the document itself) will produce
       // results with local URIs as well.
       String DEFAULT_URI_PREFIX = "http://example.org/jphyloref";
+      OWLOntology ontology = manager.createOntology();
+      RDFParser parser = JSONLDHelper.createRDFParserForOntology(ontology);
       parser.parse(new FileReader(jsonldFile), DEFAULT_URI_PREFIX);
       response.put("ontology", ontology.toString());
 

--- a/src/main/java/org/phyloref/jphyloref/helpers/JSONLDHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/JSONLDHelper.java
@@ -1,0 +1,185 @@
+package org.phyloref.jphyloref.helpers;
+
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.Rio;
+import org.openrdf.model.Resource;
+import org.openrdf.model.Value;
+import org.openrdf.model.impl.ValueFactoryImpl;
+import org.semanticweb.owlapi.formats.RDFJsonLDDocumentFormat;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyLoaderConfiguration;
+import org.semanticweb.owlapi.rio.RioOWLRDFConsumerAdapter;
+import org.semanticweb.owlapi.util.AnonymousNodeChecker;
+
+/**
+ * JSONLDHelper provides methods to help read and process JSON-LD files.
+ *
+ * @author Gaurav Vaidya <gaurav@ggvaidya.com>
+ */
+public class JSONLDHelper {
+  /**
+   * Create an RDFParser for JSON-LD files. When the parser's <tt>parse()</tt> method is called, its
+   * contents will be added to the OWLOntology passed to this method.
+   */
+  public static RDFParser createRDFParserForOntology(OWLOntology ontology) {
+    // Set up a RioOWLRDFConsumerAdapter that will take in RDF and will
+    // produce OWL to store in an ontology. This requires an anonymous node
+    // checker, which has been copied from:
+    // https://github.com/owlcs/owlapi/blob/master/rio/src/main/java/org/semanticweb/owlapi/rio/RioParserImpl.java
+    AnonymousNodeChecker anonymousNodeChecker =
+        new AnonymousNodeChecker() {
+          private boolean isAnonymous(String iri) {
+            return iri.startsWith("_:");
+          }
+
+          @Override
+          public boolean isAnonymousSharedNode(String iri) {
+            return isAnonymous(iri);
+          }
+
+          @Override
+          public boolean isAnonymousNode(String iri) {
+            return isAnonymous(iri);
+          }
+
+          @Override
+          public boolean isAnonymousNode(IRI iri) {
+            return isAnonymous(iri.toString());
+          }
+        };
+
+    // Create a RioOWLRDFConsumerAdapter, and use it as an RDFHandler.
+    OWLOntologyLoaderConfiguration config = new OWLOntologyLoaderConfiguration();
+    RioOWLRDFConsumerAdapter rdfHandler =
+        new RioOWLRDFConsumerAdapter(ontology, anonymousNodeChecker, config);
+    rdfHandler.setOntologyFormat(new RDFJsonLDDocumentFormat());
+
+    // Set up an RDF parser to read the JSON-LD file.
+    RDFParser parser = Rio.createParser(RDFFormat.JSONLD);
+
+    // We could connect the parser to the RioOWLRDFConsumerAdapter by saying:
+    //  parser.setRDFHandler(rdfHandler);
+    // Or alternatively:
+    //  RioJsonLDParserFactory factory = new RioJsonLDParserFactory();
+    //  factory.createParser().parse(new FileDocumentSource(jsonldFile), ontology, config);
+    //
+    // Unfortunately, RioOWLRDFConsumerAdapter implements org.openrdf.rio.RDFHandler
+    // while the JSON-LD parser expects org.eclipse.rdf4j.rio.RDFHandler. I've tried
+    // adding https://mvnrepository.com/artifact/org.openrdf.sesame/sesame-rio-jsonld,
+    // as version 2.9.0, 4.0.2 and 4.1.2, but neither version registers as a JSON-LD
+    // handler, giving the following error message:
+    //	Caused by: org.openrdf.rio.UnsupportedRDFormatException: Did not recognise RDF
+    //	format object JSON-LD (mimeTypes=application/ld+json; ext=jsonld)
+    // So as to keep moving, I've written a very hacky translator from
+    // an org.openrdf.rio.RDFHandler to an org.eclipse.rdf4j.rio.RDFHandler.
+    // (Tracked at https://github.com/phyloref/jphyloref/issues/11)
+    //
+    parser.setRDFHandler(
+        new org.eclipse.rdf4j.rio.RDFHandler() {
+          // Most of these methods just call the corresponding method on the
+          // other rdfHandler.
+
+          @Override
+          public void startRDF() throws RDFHandlerException {
+            rdfHandler.startRDF();
+          }
+
+          @Override
+          public void endRDF() throws RDFHandlerException {
+            rdfHandler.endRDF();
+          }
+
+          @Override
+          public void handleNamespace(String prefix, String uri) throws RDFHandlerException {
+            rdfHandler.handleNamespace(prefix, uri);
+          }
+
+          @Override
+          public void handleComment(String comment) throws RDFHandlerException {
+            rdfHandler.handleComment(comment);
+          }
+
+          // The only exception to this are handleStatement(Statement), where we
+          // need to translate from one Statement to the other. We do this by
+          // translating subject, object and property using translateResource()
+          // (to translate Resources) and translateValue() (to translate Values).
+
+          @Override
+          public void handleStatement(org.eclipse.rdf4j.model.Statement st)
+              throws RDFHandlerException {
+            ValueFactoryImpl svf = ValueFactoryImpl.getInstance();
+
+            // System.out.println("Translating statement " + st);
+
+            rdfHandler.handleStatement(
+                svf.createStatement(
+                    translateResource(st.getSubject()),
+                    svf.createURI(st.getPredicate().stringValue()),
+                    translateValue(st.getObject())));
+          }
+
+          /**
+           * Translate a Resource from org.eclipse.rdf4j.model.Resource to
+           * org.openrdf.model.Resource. We support two kinds of resources: blank nodes (BNodes) and
+           * IRIs.
+           */
+          private org.openrdf.model.Resource translateResource(
+              org.eclipse.rdf4j.model.Resource res) {
+            ValueFactoryImpl svf = ValueFactoryImpl.getInstance();
+
+            if (res instanceof org.eclipse.rdf4j.model.BNode) {
+              org.eclipse.rdf4j.model.BNode bnode = (org.eclipse.rdf4j.model.BNode) res;
+
+              return (Resource) svf.createBNode(bnode.getID());
+            }
+
+            if (res instanceof org.eclipse.rdf4j.model.IRI) {
+              org.eclipse.rdf4j.model.IRI iri = (org.eclipse.rdf4j.model.IRI) res;
+
+              return (Resource) svf.createURI(iri.stringValue());
+            }
+
+            throw new RuntimeException("Unknown resource type: " + res);
+          }
+
+          /**
+           * Translate a Value from org.eclipse.rdf4j.model.Value to org.openrdf.model.Value. We
+           * support three kinds of Values: blank nodes (BNodes), IRIs and Literals. The first two
+           * are handled correctly, but literals are always converted into strings, regardless of
+           * their actual data type.
+           */
+          private org.openrdf.model.Value translateValue(org.eclipse.rdf4j.model.Value value) {
+            ValueFactoryImpl svf = ValueFactoryImpl.getInstance();
+
+            if (value instanceof org.eclipse.rdf4j.model.BNode) {
+              org.eclipse.rdf4j.model.BNode bnode = (org.eclipse.rdf4j.model.BNode) value;
+
+              return (Value) svf.createBNode(bnode.getID());
+            }
+
+            if (value instanceof org.eclipse.rdf4j.model.IRI) {
+              org.eclipse.rdf4j.model.IRI iri = (org.eclipse.rdf4j.model.IRI) value;
+
+              return (Value) svf.createURI(iri.stringValue());
+            }
+
+            if (value instanceof org.eclipse.rdf4j.model.Literal) {
+              org.eclipse.rdf4j.model.Literal literal = (org.eclipse.rdf4j.model.Literal) value;
+
+              // Note that this converts literals that should be treated as integers,
+              // doubles and so on will be converted into strings here.
+              return (Value)
+                  svf.createLiteral(
+                      literal.stringValue(), svf.createURI(literal.getDatatype().stringValue()));
+            }
+
+            throw new RuntimeException("Unknown value type: " + value);
+          }
+        });
+
+    return parser;
+  }
+}

--- a/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
+++ b/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
@@ -1,0 +1,94 @@
+package org.phyloref.jphyloref;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/** A unit test for the TestCommand class */
+@DisplayName("TestCommandTest")
+class TestCommandTest {
+  static JPhyloRef jphyloref = new JPhyloRef();
+  static ByteArrayOutputStream output = new ByteArrayOutputStream();
+  static ByteArrayOutputStream error = new ByteArrayOutputStream();
+
+  /** Set up input and output streams */
+  @BeforeAll
+  static void setupIO() {
+    System.setOut(new PrintStream(output));
+    System.setErr(new PrintStream(error));
+  }
+
+  /** Reset input and output streams between test runs */
+  @BeforeEach
+  void resetIO() {
+    output.reset();
+    error.reset();
+  }
+
+  @Nested
+  @DisplayName("can test OWL files")
+  class TestingOWLFile {
+    @Test
+    @DisplayName("successfully tests simple OWL files")
+    void testSimpleOWLFiles() {
+      // Run 'test dummy1.owl' and see if we get the correct response.
+      jphyloref.execute(new String[] {"test", "src/test/resources/phylorefs/dummy1.owl"});
+
+      String outputStr, errorStr;
+      try {
+        outputStr = output.toString("UTF-8");
+        errorStr = error.toString("UTF-8");
+      } catch (UnsupportedEncodingException ex) {
+        throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);
+      }
+
+      assertTrue(
+          errorStr.contains("Input: src/test/resources/phylorefs/dummy1.owl"),
+          "Make sure JPhyloRef reports the name of the file being processed");
+      assertTrue(
+          errorStr.endsWith(
+              "Testing complete:1 successes, 0 failures, 0 failures marked TODO, 0 skipped.\n"),
+          "Make sure the testing was successful.");
+      assertEquals(
+          "1..1\nok 1 Phyloreference '1'\n# The following nodes were matched and expected this phyloreference: [1]\n\n",
+          outputStr);
+    }
+  }
+
+  @Nested
+  @DisplayName("can test JSON-LD files")
+  class TestingJSONLDFile {
+    @Test
+    @DisplayName("successfully tests simple JSON-LD files")
+    void testSimpleOWLFiles() {
+      // Run 'test dummy1.owl' and see if we get the correct response.
+      jphyloref.execute(new String[] {"test", "src/test/resources/phylorefs/dummy1.jsonld"});
+
+      String outputStr, errorStr;
+      try {
+        outputStr = output.toString("UTF-8");
+        errorStr = error.toString("UTF-8");
+      } catch (UnsupportedEncodingException ex) {
+        throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);
+      }
+
+      assertTrue(
+          errorStr.contains("Input: src/test/resources/phylorefs/dummy1.jsonld"),
+          "Make sure JPhyloRef reports the name of the file being processed");
+      assertTrue(
+          errorStr.endsWith(
+              "Testing complete:1 successes, 0 failures, 0 failures marked TODO, 0 skipped.\n"),
+          "Make sure the testing was successful.");
+      assertEquals(
+          "1..1\nok 1 Phyloreference '1'\n# The following nodes were matched and expected this phyloreference: [1]\n\n",
+          outputStr);
+    }
+  }
+}

--- a/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
+++ b/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
@@ -39,7 +39,8 @@ class TestCommandTest {
     @DisplayName("successfully tests simple OWL files")
     void testSimpleOWLFiles() {
       // Run 'test dummy1.owl' and see if we get the correct response.
-      jphyloref.execute(new String[] {"test", "src/test/resources/phylorefs/dummy1.owl"});
+      int exitCode =
+          jphyloref.execute(new String[] {"test", "src/test/resources/phylorefs/dummy1.owl"});
 
       String outputStr, errorStr;
       try {
@@ -49,6 +50,7 @@ class TestCommandTest {
         throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);
       }
 
+      assertEquals(0, exitCode);
       assertTrue(
           errorStr.contains("Input: src/test/resources/phylorefs/dummy1.owl"),
           "Make sure JPhyloRef reports the name of the file being processed");
@@ -67,9 +69,10 @@ class TestCommandTest {
   class TestingJSONLDFile {
     @Test
     @DisplayName("successfully tests simple JSON-LD files")
-    void testSimpleOWLFiles() {
-      // Run 'test dummy1.owl' and see if we get the correct response.
-      jphyloref.execute(new String[] {"test", "src/test/resources/phylorefs/dummy1.jsonld"});
+    void testSimpleJSONLDFiles() {
+      // Run 'test dummy1.jsonld' and see if we get the correct response.
+      int exitCode =
+          jphyloref.execute(new String[] {"test", "src/test/resources/phylorefs/dummy1.jsonld"});
 
       String outputStr, errorStr;
       try {
@@ -79,6 +82,7 @@ class TestCommandTest {
         throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);
       }
 
+      assertEquals(0, exitCode);
       assertTrue(
           errorStr.contains("Input: src/test/resources/phylorefs/dummy1.jsonld"),
           "Make sure JPhyloRef reports the name of the file being processed");
@@ -89,6 +93,32 @@ class TestCommandTest {
       assertEquals(
           "1..1\nok 1 Phyloreference '1'\n# The following nodes were matched and expected this phyloreference: [1]\n\n",
           outputStr);
+      resetIO();
+
+      // Run 'test dummy1.txt' with the '--jsonld' option and see if we get the correct response.
+      exitCode =
+          jphyloref.execute(
+              new String[] {"test", "src/test/resources/phylorefs/dummy1.txt", "--jsonld"});
+
+      try {
+        outputStr = output.toString("UTF-8");
+        errorStr = error.toString("UTF-8");
+      } catch (UnsupportedEncodingException ex) {
+        throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);
+      }
+
+      assertEquals(0, exitCode);
+      assertTrue(
+          errorStr.contains("Input: src/test/resources/phylorefs/dummy1.txt"),
+          "Make sure JPhyloRef reports the name of the file being processed");
+      assertTrue(
+          errorStr.endsWith(
+              "Testing complete:1 successes, 0 failures, 0 failures marked TODO, 0 skipped.\n"),
+          "Make sure the testing was successful.");
+      assertEquals(
+          "1..1\nok 1 Phyloreference '1'\n# The following nodes were matched and expected this phyloreference: [1]\n\n",
+          outputStr);
+      resetIO();
     }
   }
 }

--- a/src/test/resources/phylorefs/dummy1.json
+++ b/src/test/resources/phylorefs/dummy1.json
@@ -1,0 +1,41 @@
+{
+    "@context": "http://phyloref.org/curation-tool/json/phyx.json",
+    "citation": "Dummy phyloreference for testing",
+    "phylogenies": [
+        {
+            "description": "Dummy phylogeny for testing",
+            "newick": "(Aa_a, (Bb_b, (Cc_c, Dd_d, Ee_e)1)2)3"
+        }
+    ],
+    "phylorefs": [
+        {
+            "label": "1",
+            "cladeDefinition": "Node-based, includes C and E, should resolve to (C, D, E) clade.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Cc c"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Ee e"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
+        }
+    ]
+}

--- a/src/test/resources/phylorefs/dummy1.jsonld
+++ b/src/test/resources/phylorefs/dummy1.jsonld
@@ -1,0 +1,505 @@
+{
+    "@context": "http://phyloref.org/curation-tool/json/phyx.json",
+    "citation": "Dummy phyloreference for testing",
+    "phylogenies": [
+        {
+            "description": "Dummy phylogeny for testing",
+            "newick": "(Aa_a, (Bb_b, (Cc_c, Dd_d, Ee_e)1)2)3",
+            "@id": "#phylogeny0",
+            "@type": "testcase:PhyloreferenceTestPhylogeny",
+            "nodes": [
+                {
+                    "@id": "#phylogeny1_node0",
+                    "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                    "labels": [
+                        "3"
+                    ],
+                    "representsTaxonomicUnits": [],
+                    "children": [
+                        "#phylogeny1_node1",
+                        "#phylogeny1_node2"
+                    ]
+                },
+                {
+                    "@id": "#phylogeny1_node1",
+                    "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                    "labels": [
+                        "Aa_a"
+                    ],
+                    "representsTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Aa a",
+                                    "binomialName": "Aa a",
+                                    "genus": "Aa",
+                                    "specificEpithet": "a"
+                                }
+                            ],
+                            "@id": "#phylogeny1_node1_taxonomicunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "parent": "#phylogeny1_node0",
+                    "siblings": [
+                        "#phylogeny1_node2"
+                    ]
+                },
+                {
+                    "@id": "#phylogeny1_node2",
+                    "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                    "labels": [
+                        "2"
+                    ],
+                    "representsTaxonomicUnits": [],
+                    "parent": "#phylogeny1_node0",
+                    "siblings": [
+                        "#phylogeny1_node1"
+                    ],
+                    "children": [
+                        "#phylogeny1_node3",
+                        "#phylogeny1_node4"
+                    ]
+                },
+                {
+                    "@id": "#phylogeny1_node3",
+                    "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                    "labels": [
+                        "Bb_b"
+                    ],
+                    "representsTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Bb b",
+                                    "binomialName": "Bb b",
+                                    "genus": "Bb",
+                                    "specificEpithet": "b"
+                                }
+                            ],
+                            "@id": "#phylogeny1_node3_taxonomicunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "parent": "#phylogeny1_node2",
+                    "siblings": [
+                        "#phylogeny1_node4"
+                    ]
+                },
+                {
+                    "@id": "#phylogeny1_node4",
+                    "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                    "labels": [
+                        "1"
+                    ],
+                    "representsTaxonomicUnits": [],
+                    "parent": "#phylogeny1_node2",
+                    "siblings": [
+                        "#phylogeny1_node3"
+                    ],
+                    "children": [
+                        "#phylogeny1_node5",
+                        "#phylogeny1_node6",
+                        "#phylogeny1_node7"
+                    ]
+                },
+                {
+                    "@id": "#phylogeny1_node5",
+                    "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                    "labels": [
+                        "Cc_c"
+                    ],
+                    "representsTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Cc c",
+                                    "binomialName": "Cc c",
+                                    "genus": "Cc",
+                                    "specificEpithet": "c"
+                                }
+                            ],
+                            "@id": "#phylogeny1_node5_taxonomicunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "parent": "#phylogeny1_node4",
+                    "siblings": [
+                        "#phylogeny1_node6",
+                        "#phylogeny1_node7"
+                    ]
+                },
+                {
+                    "@id": "#phylogeny1_node6",
+                    "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                    "labels": [
+                        "Dd_d"
+                    ],
+                    "representsTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Dd d",
+                                    "binomialName": "Dd d",
+                                    "genus": "Dd",
+                                    "specificEpithet": "d"
+                                }
+                            ],
+                            "@id": "#phylogeny1_node6_taxonomicunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "parent": "#phylogeny1_node4",
+                    "siblings": [
+                        "#phylogeny1_node5",
+                        "#phylogeny1_node7"
+                    ]
+                },
+                {
+                    "@id": "#phylogeny1_node7",
+                    "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                    "labels": [
+                        "Ee_e"
+                    ],
+                    "representsTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Ee e",
+                                    "binomialName": "Ee e",
+                                    "genus": "Ee",
+                                    "specificEpithet": "e"
+                                }
+                            ],
+                            "@id": "#phylogeny1_node7_taxonomicunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "parent": "#phylogeny1_node4",
+                    "siblings": [
+                        "#phylogeny1_node5",
+                        "#phylogeny1_node6"
+                    ]
+                }
+            ],
+            "hasRootNode": {
+                "@id": "#phylogeny1_node0",
+                "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                "labels": [
+                    "3"
+                ],
+                "representsTaxonomicUnits": [],
+                "children": [
+                    "#phylogeny1_node1",
+                    "#phylogeny1_node2"
+                ]
+            }
+        }
+    ],
+    "phylorefs": [
+        {
+            "label": "1",
+            "cladeDefinition": "Node-based, includes C and E, should resolve to (C, D, E) clade.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Cc c"
+                                }
+                            ],
+                            "@id": "#phyloref1_specifier_internal1_tunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "@id": "#phyloref1_specifier_internal1",
+                    "@type": [
+                        "testcase:Specifier"
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Ee e"
+                                }
+                            ],
+                            "@id": "#phyloref1_specifier_internal2_tunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "@id": "#phyloref1_specifier_internal2",
+                    "@type": [
+                        "testcase:Specifier"
+                    ]
+                }
+            ],
+            "externalSpecifiers": [],
+            "@id": "#phyloref1",
+            "@type": [
+                "phyloref:Phyloreference",
+                "owl:Class"
+            ],
+            "hasInternalSpecifier": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Cc c"
+                                }
+                            ],
+                            "@id": "#phyloref1_specifier_internal1_tunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "@id": "#phyloref1_specifier_internal1",
+                    "@type": [
+                        "testcase:Specifier"
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Ee e"
+                                }
+                            ],
+                            "@id": "#phyloref1_specifier_internal2_tunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "@id": "#phyloref1_specifier_internal2",
+                    "@type": [
+                        "testcase:Specifier"
+                    ]
+                }
+            ],
+            "hasExternalSpecifier": [],
+            "hasAdditionalClass": [
+                {
+                    "@id": "#phyloref1_additional0",
+                    "@type": "owl:Class",
+                    "equivalentClass": {
+                        "@type": "owl:Class",
+                        "unionOf": [
+                            {
+                                "@type": "owl:Class",
+                                "intersectionOf": [
+                                    {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "testcase:matches_specifier",
+                                        "hasValue": {
+                                            "@id": "#phyloref1_specifier_internal1"
+                                        }
+                                    },
+                                    {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "obo:CDAO_0000174",
+                                        "someValuesFrom": {
+                                            "@type": "owl:Restriction",
+                                            "onProperty": "testcase:matches_specifier",
+                                            "hasValue": {
+                                                "@id": "#phyloref1_specifier_internal2"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "@type": "owl:Class",
+                                "intersectionOf": [
+                                    {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "testcase:matches_specifier",
+                                        "hasValue": {
+                                            "@id": "#phyloref1_specifier_internal2"
+                                        }
+                                    },
+                                    {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "obo:CDAO_0000174",
+                                        "someValuesFrom": {
+                                            "@type": "owl:Restriction",
+                                            "onProperty": "testcase:matches_specifier",
+                                            "hasValue": {
+                                                "@id": "#phyloref1_specifier_internal1"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "@type": "owl:Class",
+                                "intersectionOf": [
+                                    {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "obo:CDAO_0000149",
+                                        "someValuesFrom": {
+                                            "@type": "owl:Class",
+                                            "intersectionOf": [
+                                                {
+                                                    "@type": "owl:Restriction",
+                                                    "unionOf": [
+                                                        {
+                                                            "@type": "owl:Restriction",
+                                                            "onProperty": "testcase:matches_specifier",
+                                                            "hasValue": {
+                                                                "@id": "#phyloref1_specifier_internal1"
+                                                            }
+                                                        },
+                                                        {
+                                                            "@type": "owl:Restriction",
+                                                            "onProperty": "obo:CDAO_0000174",
+                                                            "someValuesFrom": {
+                                                                "@type": "owl:Restriction",
+                                                                "onProperty": "testcase:matches_specifier",
+                                                                "hasValue": {
+                                                                    "@id": "#phyloref1_specifier_internal1"
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "@type": "owl:Restriction",
+                                                    "onProperty": "phyloref:has_Sibling",
+                                                    "someValuesFrom": {
+                                                        "@type": "owl:Restriction",
+                                                        "unionOf": [
+                                                            {
+                                                                "@type": "owl:Restriction",
+                                                                "onProperty": "testcase:matches_specifier",
+                                                                "hasValue": {
+                                                                    "@id": "#phyloref1_specifier_internal2"
+                                                                }
+                                                            },
+                                                            {
+                                                                "@type": "owl:Restriction",
+                                                                "onProperty": "obo:CDAO_0000174",
+                                                                "someValuesFrom": {
+                                                                    "@type": "owl:Restriction",
+                                                                    "onProperty": "testcase:matches_specifier",
+                                                                    "hasValue": {
+                                                                        "@id": "#phyloref1_specifier_internal2"
+                                                                    }
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "obo:CDAO_0000149",
+                                        "someValuesFrom": {
+                                            "@type": "owl:Class",
+                                            "intersectionOf": [
+                                                {
+                                                    "@type": "owl:Restriction",
+                                                    "unionOf": [
+                                                        {
+                                                            "@type": "owl:Restriction",
+                                                            "onProperty": "testcase:matches_specifier",
+                                                            "hasValue": {
+                                                                "@id": "#phyloref1_specifier_internal2"
+                                                            }
+                                                        },
+                                                        {
+                                                            "@type": "owl:Restriction",
+                                                            "onProperty": "obo:CDAO_0000174",
+                                                            "someValuesFrom": {
+                                                                "@type": "owl:Restriction",
+                                                                "onProperty": "testcase:matches_specifier",
+                                                                "hasValue": {
+                                                                    "@id": "#phyloref1_specifier_internal2"
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "@type": "owl:Restriction",
+                                                    "onProperty": "phyloref:has_Sibling",
+                                                    "someValuesFrom": {
+                                                        "@type": "owl:Restriction",
+                                                        "unionOf": [
+                                                            {
+                                                                "@type": "owl:Restriction",
+                                                                "onProperty": "testcase:matches_specifier",
+                                                                "hasValue": {
+                                                                    "@id": "#phyloref1_specifier_internal1"
+                                                                }
+                                                            },
+                                                            {
+                                                                "@type": "owl:Restriction",
+                                                                "onProperty": "obo:CDAO_0000174",
+                                                                "someValuesFrom": {
+                                                                    "@type": "owl:Restriction",
+                                                                    "onProperty": "testcase:matches_specifier",
+                                                                    "hasValue": {
+                                                                        "@id": "#phyloref1_specifier_internal1"
+                                                                    }
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ],
+            "equivalentClass": {
+                "@id": "#phyloref1_additional0"
+            }
+        }
+    ],
+    "hasTaxonomicUnitMatches": [
+        {
+            "@id": "#taxonomic_unit_match0",
+            "@type": "testcase:TUMatch",
+            "reason": "Scientific name 'Cc c' and scientific name 'Cc c' share the same binomial name",
+            "matchesTaxonomicUnits": [
+                {
+                    "@id": "#phyloref1_specifier_internal1_tunit0"
+                },
+                {
+                    "@id": "#phylogeny1_node5_taxonomicunit0"
+                }
+            ]
+        },
+        {
+            "@id": "#taxonomic_unit_match1",
+            "@type": "testcase:TUMatch",
+            "reason": "Scientific name 'Ee e' and scientific name 'Ee e' share the same binomial name",
+            "matchesTaxonomicUnits": [
+                {
+                    "@id": "#phyloref1_specifier_internal2_tunit0"
+                },
+                {
+                    "@id": "#phylogeny1_node7_taxonomicunit0"
+                }
+            ]
+        }
+    ],
+    "@id": "",
+    "@type": [
+        "testcase:PhyloreferenceTestCase",
+        "owl:Ontology"
+    ],
+    "owl:imports": [
+        "https://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl",
+        "https://ontology.phyloref.org/phyloref.owl",
+        "http://purl.obolibrary.org/obo/bco.owl"
+    ]
+}

--- a/src/test/resources/phylorefs/dummy1.owl
+++ b/src/test/resources/phylorefs/dummy1.owl
@@ -1,0 +1,423 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+   xmlns:dwc="http://rs.tdwg.org/dwc/terms/"
+   xmlns:obo="http://purl.obolibrary.org/obo/"
+   xmlns:ot="http://purl.org/opentree/nexson#"
+   xmlns:owl="http://www.w3.org/2002/07/owl#"
+   xmlns:phyloref="http://ontology.phyloref.org/phyloref.owl#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+   xmlns:testcase="http://vocab.phyloref.org/phyloref/testcase.owl#"
+>
+  <rdf:Description rdf:nodeID="Nff44733d5cf64cf99b455453eaf618b5">
+    <rdf:rest rdf:nodeID="Na21dafe0d1e74925b3b0ea7c21a216ca"/>
+    <rdf:first rdf:nodeID="Nb18fca210c184efaac91d6b6f98d6a36"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld">
+    <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#PhyloreferenceTestCase"/>
+    <owl:imports rdf:resource="https://ontology.phyloref.org/phyloref.owl"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
+    <owl:imports rdf:resource="https://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl"/>
+    <owl:imports rdf:resource="http://purl.obolibrary.org/obo/bco.owl"/>
+    <testcase:has_phylogeny rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0"/>
+    <testcase:has_taxonomic_unit_match rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#taxonomic_unit_match0"/>
+    <testcase:has_phyloreference rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1"/>
+    <testcase:has_taxonomic_unit_match rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#taxonomic_unit_match1"/>
+    <ot:studyPublicationReference>Dummy phyloreference for testing</ot:studyPublicationReference>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nd510e03ada224d7ab7fb22293073efd4">
+    <dwc:genus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd</dwc:genus>
+    <dwc:scientificName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</dwc:scientificName>
+    <testcase:has_binomial_name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</testcase:has_binomial_name>
+    <dwc:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">d</dwc:specificEpithet>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N3b9c1f826045465e9387b36bf141e57a">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:nodeID="Na7159940e0a14b71be1f747f2d95ce68"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node4">
+    <phyloref:has_Sibling rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node3"/>
+    <obo:CDAO_0000149 rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node6"/>
+    <obo:CDAO_0000149 rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node5"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+    <obo:CDAO_0000149 rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node7"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1">
+    <testcase:clade_definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Node-based, includes C and E, should resolve to (C, D, E) clade.</testcase:clade_definition>
+    <testcase:has_additional_class rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_additional0"/>
+    <testcase:has_internal_specifier rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal1"/>
+    <testcase:has_internal_specifier rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal2"/>
+    <rdf:type rdf:resource="http://ontology.phyloref.org/phyloref.owl#Phyloreference"/>
+    <owl:equivalentClass rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_additional0"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node1_taxonomicunit0">
+    <testcase:has_scientific_name rdf:nodeID="N8d09b7f68fbc4e4181235ac5ee33c697"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000138"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nb18fca210c184efaac91d6b6f98d6a36">
+    <owl:hasValue rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal2"/>
+    <owl:onProperty rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#matches_specifier"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N642e35d6c18e4ab1aacd14e647d5870d">
+    <owl:someValuesFrom rdf:nodeID="N17b943cf0dcc4bda9a549d4cbb27800e"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000174"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N7df3877fc1164d50bcfa54adfe8fb659">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:nodeID="N5f1f97d51e9e4cb483d196bcdd5a29e1"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nb2631a4f87914d59a2bb17ec82c909de">
+    <owl:hasValue rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal2"/>
+    <owl:onProperty rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#matches_specifier"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Na7159940e0a14b71be1f747f2d95ce68">
+    <owl:someValuesFrom rdf:nodeID="Ndf311e16c4f94c2daca6814ea1bcbc79"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000174"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node5">
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc_c</rdfs:label>
+    <obo:CDAO_0000187 rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node5_taxonomicunit0"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+    <phyloref:has_Sibling rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node7"/>
+    <phyloref:has_Sibling rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node6"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nba43ce3ecd1e4d80946032424a8548cc">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <owl:intersectionOf rdf:nodeID="Nf358e2a4894e43c58bd041fe7141acdc"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Naa9b5de6581e44b9be5fe13c405a7171">
+    <rdf:rest rdf:nodeID="Na3d2d606f20f4f53b00510377ce6253f"/>
+    <rdf:first rdf:nodeID="N896bd23533e64469b35a6d2fdc4bbea4"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N0f38a4cd27dd4eddbf79eb5d3fbec038">
+    <rdf:rest rdf:nodeID="N34b20487e3da4c5e9ec7c9941b6fe117"/>
+    <rdf:first rdf:nodeID="N4328ab4246e54d41aea11e7b0b1370c1"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N99ba34150b9a48f981c4ecf262f96b1c">
+    <owl:intersectionOf rdf:nodeID="Ncd9db3d135f1471d9a95a769ec60fe81"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N321adaf55f5345bcb5b16bf0669cf4aa">
+    <rdf:rest rdf:nodeID="N24153587c7e84801b3ab871b5406897b"/>
+    <rdf:first rdf:nodeID="N99ba34150b9a48f981c4ecf262f96b1c"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N8d09b7f68fbc4e4181235ac5ee33c697">
+    <dwc:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a</dwc:specificEpithet>
+    <dwc:scientificName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa a</dwc:scientificName>
+    <dwc:genus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa</dwc:genus>
+    <testcase:has_binomial_name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa a</testcase:has_binomial_name>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node5_taxonomicunit0">
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000138"/>
+    <testcase:has_scientific_name rdf:nodeID="N5bc27150f784435db4ddb7a054612ff8"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N1e71691f817a40eeb07463d2975ce401">
+    <rdf:first rdf:nodeID="Nf910c45a82fe4c59a3893b9cca1d0187"/>
+    <rdf:rest rdf:nodeID="Ne4f4df2c66f24b63b134d3644e415a3b"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N497741a2072b465dbd15dece47736fd3">
+    <dwc:scientificName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</dwc:scientificName>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N106eb20976844743b7a81f3477f8754b">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <owl:intersectionOf rdf:nodeID="N1e71691f817a40eeb07463d2975ce401"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0">
+    <testcase:has_root_node rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node0"/>
+    <testcase:has_node rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node4"/>
+    <testcase:as_newick_string rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(Aa_a, (Bb_b, (Cc_c, Dd_d, Ee_e)1)2)3</testcase:as_newick_string>
+    <testcase:has_node rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node6"/>
+    <testcase:has_node rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node3"/>
+    <testcase:has_node rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node1"/>
+    <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#PhyloreferenceTestPhylogeny"/>
+    <testcase:has_node rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node2"/>
+    <testcase:has_node rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node0"/>
+    <testcase:has_node rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node7"/>
+    <testcase:has_node rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node5"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal2_tunit0">
+    <testcase:has_scientific_name rdf:nodeID="Nd89eeffffd2046f6acd17bf20f7ec7d5"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000138"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N78b663b3fb5041b1921b4fb545204792">
+    <owl:hasValue rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal2"/>
+    <owl:onProperty rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#matches_specifier"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N121d3f504a2c4e14911703dd67c808f5">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <owl:intersectionOf rdf:nodeID="N9193c983e07a498aa0d08b833056c77e"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nb3715e8e05de441ba3c1ef77a2503cfa">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:nodeID="N642e35d6c18e4ab1aacd14e647d5870d"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nafaf4391a37d418baea404e91040858e">
+    <owl:unionOf rdf:nodeID="N4f19d49f623a4ee7a416f2b080f1eddf"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nf47ae7bc01154b2fae111c281a816fbd">
+    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000149"/>
+    <owl:someValuesFrom rdf:nodeID="Nb2291f57f580403f925742080ed63c51"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Ne9f905e0d96f4c5a8138a1f9f14ad75d">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:hasValue rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal1"/>
+    <owl:onProperty rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#matches_specifier"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Na130c6a3dfcb4a9a8c47b939791de7b6">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000174"/>
+    <owl:someValuesFrom rdf:nodeID="Nb2631a4f87914d59a2bb17ec82c909de"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nd89eeffffd2046f6acd17bf20f7ec7d5">
+    <dwc:scientificName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee e</dwc:scientificName>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#taxonomic_unit_match1">
+    <testcase:matches_taxonomic_unit rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node7_taxonomicunit0"/>
+    <testcase:reason_for_match rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Scientific name 'Ee e' and scientific name 'Ee e' share the same binomial name</testcase:reason_for_match>
+    <testcase:matches_taxonomic_unit rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal2_tunit0"/>
+    <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#TUMatch"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nd0ca847eff334a6ca97e0cd709d77c34">
+    <rdf:first rdf:nodeID="N2554d6cabbb349ff92614cae884f05cc"/>
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nb344a18bd9274e139bd793b614eb713f">
+    <owl:onProperty rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#matches_specifier"/>
+    <owl:hasValue rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal1"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Ndf311e16c4f94c2daca6814ea1bcbc79">
+    <owl:hasValue rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal1"/>
+    <owl:onProperty rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#matches_specifier"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N92228e1a9df34ed7906a4555459b245e">
+    <owl:someValuesFrom rdf:nodeID="Ne9f905e0d96f4c5a8138a1f9f14ad75d"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000174"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N5bc27150f784435db4ddb7a054612ff8">
+    <dwc:scientificName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</dwc:scientificName>
+    <dwc:genus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc</dwc:genus>
+    <testcase:has_binomial_name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</testcase:has_binomial_name>
+    <dwc:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">c</dwc:specificEpithet>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N24153587c7e84801b3ab871b5406897b">
+    <rdf:first rdf:nodeID="N106eb20976844743b7a81f3477f8754b"/>
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N34b20487e3da4c5e9ec7c9941b6fe117">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:nodeID="N9496275fedc942b6aee06789d4a780fc"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#taxonomic_unit_match0">
+    <testcase:matches_taxonomic_unit rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal1_tunit0"/>
+    <testcase:matches_taxonomic_unit rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node5_taxonomicunit0"/>
+    <testcase:reason_for_match rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Scientific name 'Cc c' and scientific name 'Cc c' share the same binomial name</testcase:reason_for_match>
+    <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#TUMatch"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node0">
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</rdfs:label>
+    <obo:CDAO_0000149 rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node1"/>
+    <obo:CDAO_0000149 rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node2"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nc0b67b64ec764dbb9a28aafa7ffa9771">
+    <dwc:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">b</dwc:specificEpithet>
+    <dwc:genus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb</dwc:genus>
+    <testcase:has_binomial_name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb b</testcase:has_binomial_name>
+    <dwc:scientificName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb b</dwc:scientificName>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Ndafd076cb42e45e0912aeb371d0db35f">
+    <rdf:first rdf:nodeID="Nfe8ef43303f147f487b5769798aba9aa"/>
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Ne699f871f4354be9b2df88662f0deb2e">
+    <rdf:first rdf:nodeID="N121d3f504a2c4e14911703dd67c808f5"/>
+    <rdf:rest rdf:nodeID="N321adaf55f5345bcb5b16bf0669cf4aa"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Ne4f4df2c66f24b63b134d3644e415a3b">
+    <rdf:first rdf:nodeID="Nf47ae7bc01154b2fae111c281a816fbd"/>
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Na18609394f294cfe881e07e273285a63">
+    <owl:onProperty rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#matches_specifier"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:hasValue rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal1"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nf358e2a4894e43c58bd041fe7141acdc">
+    <rdf:rest rdf:nodeID="Nd0ca847eff334a6ca97e0cd709d77c34"/>
+    <rdf:first rdf:nodeID="Nafaf4391a37d418baea404e91040858e"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N2554d6cabbb349ff92614cae884f05cc">
+    <owl:onProperty rdf:resource="http://ontology.phyloref.org/phyloref.owl#has_Sibling"/>
+    <owl:someValuesFrom rdf:nodeID="N8b594a4c208f402383e5d204a3874164"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal1">
+    <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#Specifier"/>
+    <testcase:references_taxonomic_unit rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal1_tunit0"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N896bd23533e64469b35a6d2fdc4bbea4">
+    <owl:onProperty rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#matches_specifier"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:hasValue rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal1"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node2">
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2</rdfs:label>
+    <obo:CDAO_0000149 rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node4"/>
+    <obo:CDAO_0000149 rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node3"/>
+    <phyloref:has_Sibling rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node1"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node3">
+    <obo:CDAO_0000187 rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node3_taxonomicunit0"/>
+    <phyloref:has_Sibling rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node4"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb_b</rdfs:label>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node7">
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee_e</rdfs:label>
+    <phyloref:has_Sibling rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node6"/>
+    <obo:CDAO_0000187 rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node7_taxonomicunit0"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+    <phyloref:has_Sibling rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node5"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node6">
+    <phyloref:has_Sibling rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node7"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+    <obo:CDAO_0000187 rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node6_taxonomicunit0"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd_d</rdfs:label>
+    <phyloref:has_Sibling rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node5"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N9193c983e07a498aa0d08b833056c77e">
+    <rdf:first rdf:nodeID="Na18609394f294cfe881e07e273285a63"/>
+    <rdf:rest rdf:nodeID="N7df3877fc1164d50bcfa54adfe8fb659"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node7_taxonomicunit0">
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000138"/>
+    <testcase:has_scientific_name rdf:nodeID="N385f45dfbfef4467bf1cfe7b9b62fa17"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_additional0">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <owl:equivalentClass rdf:nodeID="Nb4d0bc5c432144e6a14abfc891b781dc"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N17b943cf0dcc4bda9a549d4cbb27800e">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:hasValue rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal1"/>
+    <owl:onProperty rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#matches_specifier"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Na3d2d606f20f4f53b00510377ce6253f">
+    <rdf:first rdf:nodeID="N92228e1a9df34ed7906a4555459b245e"/>
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N8b594a4c208f402383e5d204a3874164">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:unionOf rdf:nodeID="Nff44733d5cf64cf99b455453eaf618b5"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N62e8bdd53dcc4727bd31ccee7fe88bbe">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:hasValue rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal2"/>
+    <owl:onProperty rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#matches_specifier"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N4328ab4246e54d41aea11e7b0b1370c1">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:unionOf rdf:nodeID="Nf7b239abe8c1415d865420a0fb555a2d"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Na21dafe0d1e74925b3b0ea7c21a216ca">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:nodeID="Na130c6a3dfcb4a9a8c47b939791de7b6"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node3_taxonomicunit0">
+    <testcase:has_scientific_name rdf:nodeID="Nc0b67b64ec764dbb9a28aafa7ffa9771"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000138"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N771caad8388f4b1fbe9393ebe96ad818">
+    <owl:unionOf rdf:nodeID="Naa9b5de6581e44b9be5fe13c405a7171"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Ne0936191703946978b8007aceac7211f">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:hasValue rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal2"/>
+    <owl:onProperty rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#matches_specifier"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nfe8ef43303f147f487b5769798aba9aa">
+    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000174"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:someValuesFrom rdf:nodeID="Ne0936191703946978b8007aceac7211f"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N385f45dfbfef4467bf1cfe7b9b62fa17">
+    <dwc:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">e</dwc:specificEpithet>
+    <dwc:genus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee</dwc:genus>
+    <dwc:scientificName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee e</dwc:scientificName>
+    <testcase:has_binomial_name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee e</testcase:has_binomial_name>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node1">
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+    <phyloref:has_Sibling rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node2"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa_a</rdfs:label>
+    <obo:CDAO_0000187 rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node1_taxonomicunit0"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nb4d0bc5c432144e6a14abfc891b781dc">
+    <owl:unionOf rdf:nodeID="Ne699f871f4354be9b2df88662f0deb2e"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N9496275fedc942b6aee06789d4a780fc">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:someValuesFrom rdf:nodeID="N771caad8388f4b1fbe9393ebe96ad818"/>
+    <owl:onProperty rdf:resource="http://ontology.phyloref.org/phyloref.owl#has_Sibling"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N5f1f97d51e9e4cb483d196bcdd5a29e1">
+    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000174"/>
+    <owl:someValuesFrom rdf:nodeID="N62e8bdd53dcc4727bd31ccee7fe88bbe"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal1_tunit0">
+    <testcase:has_scientific_name rdf:nodeID="N497741a2072b465dbd15dece47736fd3"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000138"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal2">
+    <testcase:references_taxonomic_unit rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal2_tunit0"/>
+    <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#Specifier"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N503c959b6c1a4087a63e7ada1f0d6a7b">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:hasValue rdf:resource="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref1_specifier_internal2"/>
+    <owl:onProperty rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#matches_specifier"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny1_node6_taxonomicunit0">
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000138"/>
+    <testcase:has_scientific_name rdf:nodeID="Nd510e03ada224d7ab7fb22293073efd4"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nb2291f57f580403f925742080ed63c51">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <owl:intersectionOf rdf:nodeID="N0f38a4cd27dd4eddbf79eb5d3fbec038"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N4f19d49f623a4ee7a416f2b080f1eddf">
+    <rdf:first rdf:nodeID="Nb344a18bd9274e139bd793b614eb713f"/>
+    <rdf:rest rdf:nodeID="Nb3715e8e05de441ba3c1ef77a2503cfa"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Ncd9db3d135f1471d9a95a769ec60fe81">
+    <rdf:rest rdf:nodeID="N3b9c1f826045465e9387b36bf141e57a"/>
+    <rdf:first rdf:nodeID="N503c959b6c1a4087a63e7ada1f0d6a7b"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nf7b239abe8c1415d865420a0fb555a2d">
+    <rdf:rest rdf:nodeID="Ndafd076cb42e45e0912aeb371d0db35f"/>
+    <rdf:first rdf:nodeID="N78b663b3fb5041b1921b4fb545204792"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nf910c45a82fe4c59a3893b9cca1d0187">
+    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000149"/>
+    <owl:someValuesFrom rdf:nodeID="Nba43ce3ecd1e4d80946032424a8548cc"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/src/test/resources/phylorefs/dummy1.txt
+++ b/src/test/resources/phylorefs/dummy1.txt
@@ -1,0 +1,505 @@
+{
+    "@context": "http://phyloref.org/curation-tool/json/phyx.json",
+    "citation": "Dummy phyloreference for testing",
+    "phylogenies": [
+        {
+            "description": "Dummy phylogeny for testing",
+            "newick": "(Aa_a, (Bb_b, (Cc_c, Dd_d, Ee_e)1)2)3",
+            "@id": "#phylogeny0",
+            "@type": "testcase:PhyloreferenceTestPhylogeny",
+            "nodes": [
+                {
+                    "@id": "#phylogeny1_node0",
+                    "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                    "labels": [
+                        "3"
+                    ],
+                    "representsTaxonomicUnits": [],
+                    "children": [
+                        "#phylogeny1_node1",
+                        "#phylogeny1_node2"
+                    ]
+                },
+                {
+                    "@id": "#phylogeny1_node1",
+                    "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                    "labels": [
+                        "Aa_a"
+                    ],
+                    "representsTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Aa a",
+                                    "binomialName": "Aa a",
+                                    "genus": "Aa",
+                                    "specificEpithet": "a"
+                                }
+                            ],
+                            "@id": "#phylogeny1_node1_taxonomicunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "parent": "#phylogeny1_node0",
+                    "siblings": [
+                        "#phylogeny1_node2"
+                    ]
+                },
+                {
+                    "@id": "#phylogeny1_node2",
+                    "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                    "labels": [
+                        "2"
+                    ],
+                    "representsTaxonomicUnits": [],
+                    "parent": "#phylogeny1_node0",
+                    "siblings": [
+                        "#phylogeny1_node1"
+                    ],
+                    "children": [
+                        "#phylogeny1_node3",
+                        "#phylogeny1_node4"
+                    ]
+                },
+                {
+                    "@id": "#phylogeny1_node3",
+                    "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                    "labels": [
+                        "Bb_b"
+                    ],
+                    "representsTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Bb b",
+                                    "binomialName": "Bb b",
+                                    "genus": "Bb",
+                                    "specificEpithet": "b"
+                                }
+                            ],
+                            "@id": "#phylogeny1_node3_taxonomicunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "parent": "#phylogeny1_node2",
+                    "siblings": [
+                        "#phylogeny1_node4"
+                    ]
+                },
+                {
+                    "@id": "#phylogeny1_node4",
+                    "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                    "labels": [
+                        "1"
+                    ],
+                    "representsTaxonomicUnits": [],
+                    "parent": "#phylogeny1_node2",
+                    "siblings": [
+                        "#phylogeny1_node3"
+                    ],
+                    "children": [
+                        "#phylogeny1_node5",
+                        "#phylogeny1_node6",
+                        "#phylogeny1_node7"
+                    ]
+                },
+                {
+                    "@id": "#phylogeny1_node5",
+                    "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                    "labels": [
+                        "Cc_c"
+                    ],
+                    "representsTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Cc c",
+                                    "binomialName": "Cc c",
+                                    "genus": "Cc",
+                                    "specificEpithet": "c"
+                                }
+                            ],
+                            "@id": "#phylogeny1_node5_taxonomicunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "parent": "#phylogeny1_node4",
+                    "siblings": [
+                        "#phylogeny1_node6",
+                        "#phylogeny1_node7"
+                    ]
+                },
+                {
+                    "@id": "#phylogeny1_node6",
+                    "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                    "labels": [
+                        "Dd_d"
+                    ],
+                    "representsTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Dd d",
+                                    "binomialName": "Dd d",
+                                    "genus": "Dd",
+                                    "specificEpithet": "d"
+                                }
+                            ],
+                            "@id": "#phylogeny1_node6_taxonomicunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "parent": "#phylogeny1_node4",
+                    "siblings": [
+                        "#phylogeny1_node5",
+                        "#phylogeny1_node7"
+                    ]
+                },
+                {
+                    "@id": "#phylogeny1_node7",
+                    "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                    "labels": [
+                        "Ee_e"
+                    ],
+                    "representsTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Ee e",
+                                    "binomialName": "Ee e",
+                                    "genus": "Ee",
+                                    "specificEpithet": "e"
+                                }
+                            ],
+                            "@id": "#phylogeny1_node7_taxonomicunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "parent": "#phylogeny1_node4",
+                    "siblings": [
+                        "#phylogeny1_node5",
+                        "#phylogeny1_node6"
+                    ]
+                }
+            ],
+            "hasRootNode": {
+                "@id": "#phylogeny1_node0",
+                "@type": "http://purl.obolibrary.org/obo/CDAO_0000140",
+                "labels": [
+                    "3"
+                ],
+                "representsTaxonomicUnits": [],
+                "children": [
+                    "#phylogeny1_node1",
+                    "#phylogeny1_node2"
+                ]
+            }
+        }
+    ],
+    "phylorefs": [
+        {
+            "label": "1",
+            "cladeDefinition": "Node-based, includes C and E, should resolve to (C, D, E) clade.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Cc c"
+                                }
+                            ],
+                            "@id": "#phyloref1_specifier_internal1_tunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "@id": "#phyloref1_specifier_internal1",
+                    "@type": [
+                        "testcase:Specifier"
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Ee e"
+                                }
+                            ],
+                            "@id": "#phyloref1_specifier_internal2_tunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "@id": "#phyloref1_specifier_internal2",
+                    "@type": [
+                        "testcase:Specifier"
+                    ]
+                }
+            ],
+            "externalSpecifiers": [],
+            "@id": "#phyloref1",
+            "@type": [
+                "phyloref:Phyloreference",
+                "owl:Class"
+            ],
+            "hasInternalSpecifier": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Cc c"
+                                }
+                            ],
+                            "@id": "#phyloref1_specifier_internal1_tunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "@id": "#phyloref1_specifier_internal1",
+                    "@type": [
+                        "testcase:Specifier"
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Ee e"
+                                }
+                            ],
+                            "@id": "#phyloref1_specifier_internal2_tunit0",
+                            "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
+                        }
+                    ],
+                    "@id": "#phyloref1_specifier_internal2",
+                    "@type": [
+                        "testcase:Specifier"
+                    ]
+                }
+            ],
+            "hasExternalSpecifier": [],
+            "hasAdditionalClass": [
+                {
+                    "@id": "#phyloref1_additional0",
+                    "@type": "owl:Class",
+                    "equivalentClass": {
+                        "@type": "owl:Class",
+                        "unionOf": [
+                            {
+                                "@type": "owl:Class",
+                                "intersectionOf": [
+                                    {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "testcase:matches_specifier",
+                                        "hasValue": {
+                                            "@id": "#phyloref1_specifier_internal1"
+                                        }
+                                    },
+                                    {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "obo:CDAO_0000174",
+                                        "someValuesFrom": {
+                                            "@type": "owl:Restriction",
+                                            "onProperty": "testcase:matches_specifier",
+                                            "hasValue": {
+                                                "@id": "#phyloref1_specifier_internal2"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "@type": "owl:Class",
+                                "intersectionOf": [
+                                    {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "testcase:matches_specifier",
+                                        "hasValue": {
+                                            "@id": "#phyloref1_specifier_internal2"
+                                        }
+                                    },
+                                    {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "obo:CDAO_0000174",
+                                        "someValuesFrom": {
+                                            "@type": "owl:Restriction",
+                                            "onProperty": "testcase:matches_specifier",
+                                            "hasValue": {
+                                                "@id": "#phyloref1_specifier_internal1"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "@type": "owl:Class",
+                                "intersectionOf": [
+                                    {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "obo:CDAO_0000149",
+                                        "someValuesFrom": {
+                                            "@type": "owl:Class",
+                                            "intersectionOf": [
+                                                {
+                                                    "@type": "owl:Restriction",
+                                                    "unionOf": [
+                                                        {
+                                                            "@type": "owl:Restriction",
+                                                            "onProperty": "testcase:matches_specifier",
+                                                            "hasValue": {
+                                                                "@id": "#phyloref1_specifier_internal1"
+                                                            }
+                                                        },
+                                                        {
+                                                            "@type": "owl:Restriction",
+                                                            "onProperty": "obo:CDAO_0000174",
+                                                            "someValuesFrom": {
+                                                                "@type": "owl:Restriction",
+                                                                "onProperty": "testcase:matches_specifier",
+                                                                "hasValue": {
+                                                                    "@id": "#phyloref1_specifier_internal1"
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "@type": "owl:Restriction",
+                                                    "onProperty": "phyloref:has_Sibling",
+                                                    "someValuesFrom": {
+                                                        "@type": "owl:Restriction",
+                                                        "unionOf": [
+                                                            {
+                                                                "@type": "owl:Restriction",
+                                                                "onProperty": "testcase:matches_specifier",
+                                                                "hasValue": {
+                                                                    "@id": "#phyloref1_specifier_internal2"
+                                                                }
+                                                            },
+                                                            {
+                                                                "@type": "owl:Restriction",
+                                                                "onProperty": "obo:CDAO_0000174",
+                                                                "someValuesFrom": {
+                                                                    "@type": "owl:Restriction",
+                                                                    "onProperty": "testcase:matches_specifier",
+                                                                    "hasValue": {
+                                                                        "@id": "#phyloref1_specifier_internal2"
+                                                                    }
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "obo:CDAO_0000149",
+                                        "someValuesFrom": {
+                                            "@type": "owl:Class",
+                                            "intersectionOf": [
+                                                {
+                                                    "@type": "owl:Restriction",
+                                                    "unionOf": [
+                                                        {
+                                                            "@type": "owl:Restriction",
+                                                            "onProperty": "testcase:matches_specifier",
+                                                            "hasValue": {
+                                                                "@id": "#phyloref1_specifier_internal2"
+                                                            }
+                                                        },
+                                                        {
+                                                            "@type": "owl:Restriction",
+                                                            "onProperty": "obo:CDAO_0000174",
+                                                            "someValuesFrom": {
+                                                                "@type": "owl:Restriction",
+                                                                "onProperty": "testcase:matches_specifier",
+                                                                "hasValue": {
+                                                                    "@id": "#phyloref1_specifier_internal2"
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "@type": "owl:Restriction",
+                                                    "onProperty": "phyloref:has_Sibling",
+                                                    "someValuesFrom": {
+                                                        "@type": "owl:Restriction",
+                                                        "unionOf": [
+                                                            {
+                                                                "@type": "owl:Restriction",
+                                                                "onProperty": "testcase:matches_specifier",
+                                                                "hasValue": {
+                                                                    "@id": "#phyloref1_specifier_internal1"
+                                                                }
+                                                            },
+                                                            {
+                                                                "@type": "owl:Restriction",
+                                                                "onProperty": "obo:CDAO_0000174",
+                                                                "someValuesFrom": {
+                                                                    "@type": "owl:Restriction",
+                                                                    "onProperty": "testcase:matches_specifier",
+                                                                    "hasValue": {
+                                                                        "@id": "#phyloref1_specifier_internal1"
+                                                                    }
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ],
+            "equivalentClass": {
+                "@id": "#phyloref1_additional0"
+            }
+        }
+    ],
+    "hasTaxonomicUnitMatches": [
+        {
+            "@id": "#taxonomic_unit_match0",
+            "@type": "testcase:TUMatch",
+            "reason": "Scientific name 'Cc c' and scientific name 'Cc c' share the same binomial name",
+            "matchesTaxonomicUnits": [
+                {
+                    "@id": "#phyloref1_specifier_internal1_tunit0"
+                },
+                {
+                    "@id": "#phylogeny1_node5_taxonomicunit0"
+                }
+            ]
+        },
+        {
+            "@id": "#taxonomic_unit_match1",
+            "@type": "testcase:TUMatch",
+            "reason": "Scientific name 'Ee e' and scientific name 'Ee e' share the same binomial name",
+            "matchesTaxonomicUnits": [
+                {
+                    "@id": "#phyloref1_specifier_internal2_tunit0"
+                },
+                {
+                    "@id": "#phylogeny1_node7_taxonomicunit0"
+                }
+            ]
+        }
+    ],
+    "@id": "",
+    "@type": [
+        "testcase:PhyloreferenceTestCase",
+        "owl:Ontology"
+    ],
+    "owl:imports": [
+        "https://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl",
+        "https://ontology.phyloref.org/phyloref.owl",
+        "http://purl.obolibrary.org/obo/bco.owl"
+    ]
+}


### PR DESCRIPTION
This PR moves the JSON-LD parsing code from WebserverCommand to a new class, JSONLDHelper, which allows it to be used from both WebserverCommand and TestCommand. Files with a '.json' or '.jsonld' extension will automatically be treated as JSON-LD files, and the '--jsonld' flag can be used to treat any file as a JSON-LD file.

This should be merged after PR #30, as it includes tests written in the new test suite included in that PR.