### PR TITLE
Allow TestCommand to read ontologies from STDIN

### DIFF
--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -1,7 +1,8 @@
 package org.phyloref.jphyloref.commands;
 
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -102,26 +103,32 @@ public class TestCommand implements Command {
   @Override
   public int execute(CommandLine cmdLine) throws RuntimeException {
     // Extract command-line options
-    String str_input = cmdLine.getOptionValue("input");
+    String inputFilename = cmdLine.getOptionValue("input");
 
-    if (str_input == null && cmdLine.getArgList().size() > 1) {
+    if (inputFilename == null && cmdLine.getArgList().size() > 1) {
       // No 'input'? Maybe it's just provided as a left-over option?
-      str_input = cmdLine.getArgList().get(1);
+      inputFilename = cmdLine.getArgList().get(1);
     }
 
-    if (str_input == null) {
+    if (inputFilename == null) {
       throw new IllegalArgumentException("Error: no input ontology specified (use '-i input.owl')");
     }
 
     // If the input filename is '-', we should read the ontology from STDIN instead.
     InputStream inputStreamToReadFrom = null;
-    if (str_input.equals("-")) {
+    if (inputFilename.equals("-")) {
       inputStreamToReadFrom = System.in;
+    } else {
+      try {
+        inputStreamToReadFrom = new FileInputStream(inputFilename);
+      } catch (FileNotFoundException ex) {
+        System.err.println("Could not open input file '" + inputFilename + "': " + ex);
+        return 1;
+      }
     }
 
-    // Create File object to load
-    File inputFile = new File(str_input);
-    System.err.println("Input: " + inputFile);
+    // Report the name of the file being tested.
+    System.err.println("Input: " + inputFilename);
 
     // Set up an OWL Ontology Manager to work with.
     OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
@@ -134,7 +141,7 @@ public class TestCommand implements Command {
 
     // Is this a JSON or JSON-LD file?
     OWLOntology ontology;
-    String inputFileLowercase = str_input.toLowerCase();
+    String inputFileLowercase = inputFilename.toLowerCase();
     try {
       if (cmdLine.hasOption("jsonld")
           || inputFileLowercase.endsWith(".json")
@@ -143,28 +150,20 @@ public class TestCommand implements Command {
         String DEFAULT_URI_PREFIX = "http://example.org/jphyloref";
         ontology = manager.createOntology();
         RDFParser parser = JSONLDHelper.createRDFParserForOntology(ontology);
-        if (inputStreamToReadFrom != null) {
-          // Read from the provided input stream (probably STDIN).
-          parser.parse(inputStreamToReadFrom, DEFAULT_URI_PREFIX);
-        } else {
-          // Read from the provided input file.
-          parser.parse(new FileReader(inputFile), DEFAULT_URI_PREFIX);
-        }
+
+        // Read from the provided input stream (either STDIN or a file).
+        parser.parse(inputStreamToReadFrom, DEFAULT_URI_PREFIX);
+
       } else {
-        // Load the ontology using OWLManager.
-        if (inputStreamToReadFrom != null) {
-          // Read from the provided input stream (probably STDIN).
-          ontology = manager.loadOntologyFromOntologyDocument(inputStreamToReadFrom);
-        } else {
-          // Read from the provided input file.
-          ontology = manager.loadOntologyFromOntologyDocument(inputFile);
-        }
+        // Load the ontology using OWLManager, by reading from the provided
+        // input stream (either STDIN or a file).
+        ontology = manager.loadOntologyFromOntologyDocument(inputStreamToReadFrom);
       }
     } catch (OWLOntologyCreationException ex) {
-      System.err.println("Could not create ontology '" + inputFile + "': " + ex);
+      System.err.println("Could not create ontology '" + inputFilename + "': " + ex);
       return 1;
     } catch (IOException ex) {
-      System.err.println("Could not read and load ontology '" + inputFile + "': " + ex);
+      System.err.println("Could not read and load ontology '" + inputFilename + "': " + ex);
       return 1;
     }
 

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -3,6 +3,7 @@ package org.phyloref.jphyloref.commands;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -112,6 +113,12 @@ public class TestCommand implements Command {
       throw new IllegalArgumentException("Error: no input ontology specified (use '-i input.owl')");
     }
 
+    // If the input filename is '-', we should read the ontology from STDIN instead.
+    InputStream inputStreamToReadFrom = null;
+    if (str_input.equals("-")) {
+      inputStreamToReadFrom = System.in;
+    }
+
     // Create File object to load
     File inputFile = new File(str_input);
     System.err.println("Input: " + inputFile);
@@ -136,10 +143,22 @@ public class TestCommand implements Command {
         String DEFAULT_URI_PREFIX = "http://example.org/jphyloref";
         ontology = manager.createOntology();
         RDFParser parser = JSONLDHelper.createRDFParserForOntology(ontology);
-        parser.parse(new FileReader(inputFile), DEFAULT_URI_PREFIX);
+        if (inputStreamToReadFrom != null) {
+          // Read from the provided input stream (probably STDIN).
+          parser.parse(inputStreamToReadFrom, DEFAULT_URI_PREFIX);
+        } else {
+          // Read from the provided input file.
+          parser.parse(new FileReader(inputFile), DEFAULT_URI_PREFIX);
+        }
       } else {
         // Load the ontology using OWLManager.
-        ontology = manager.loadOntologyFromOntologyDocument(inputFile);
+        if (inputStreamToReadFrom != null) {
+          // Read from the provided input stream (probably STDIN).
+          ontology = manager.loadOntologyFromOntologyDocument(inputStreamToReadFrom);
+        } else {
+          // Read from the provided input file.
+          ontology = manager.loadOntologyFromOntologyDocument(inputFile);
+        }
       }
     } catch (OWLOntologyCreationException ex) {
       System.err.println("Could not create ontology '" + inputFile + "': " + ex);

--- a/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
+++ b/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
@@ -37,6 +37,26 @@ class TestCommandTest {
     error.reset();
   }
 
+  /**
+   * Helper method for testing whether analysing a single phyloreference with a particular name
+   * succeeded.
+   */
+  private void expectSinglePhylorefResolvingCorrectly(
+      String filename, String phylorefName, String stdoutStr, String stderrStr) {
+    assertTrue(
+        stderrStr.contains("Input: " + filename),
+        "Make sure JPhyloRef reports the name of the file being processed");
+    assertTrue(
+        stderrStr.endsWith(
+            "Testing complete:1 successes, 0 failures, 0 failures marked TODO, 0 skipped.\n"),
+        "Make sure the testing was successful.");
+    assertEquals(
+        "1..1\nok 1 "
+            + phylorefName
+            + "\n# The following nodes were matched and expected this phyloreference: [1]\n\n",
+        stdoutStr);
+  }
+
   @Nested
   @DisplayName("can test OWL files")
   class TestingOWLFile {
@@ -56,16 +76,8 @@ class TestCommandTest {
       }
 
       assertEquals(0, exitCode);
-      assertTrue(
-          errorStr.contains("Input: src/test/resources/phylorefs/dummy1.owl"),
-          "Make sure JPhyloRef reports the name of the file being processed");
-      assertTrue(
-          errorStr.endsWith(
-              "Testing complete:1 successes, 0 failures, 0 failures marked TODO, 0 skipped.\n"),
-          "Make sure the testing was successful.");
-      assertEquals(
-          "1..1\nok 1 Phyloreference '1'\n# The following nodes were matched and expected this phyloreference: [1]\n\n",
-          outputStr);
+      expectSinglePhylorefResolvingCorrectly(
+          "src/test/resources/phylorefs/dummy1.owl", "Phyloreference '1'", outputStr, errorStr);
     }
   }
 
@@ -88,16 +100,8 @@ class TestCommandTest {
       }
 
       assertEquals(0, exitCode);
-      assertTrue(
-          errorStr.contains("Input: src/test/resources/phylorefs/dummy1.jsonld"),
-          "Make sure JPhyloRef reports the name of the file being processed");
-      assertTrue(
-          errorStr.endsWith(
-              "Testing complete:1 successes, 0 failures, 0 failures marked TODO, 0 skipped.\n"),
-          "Make sure the testing was successful.");
-      assertEquals(
-          "1..1\nok 1 Phyloreference '1'\n# The following nodes were matched and expected this phyloreference: [1]\n\n",
-          outputStr);
+      expectSinglePhylorefResolvingCorrectly(
+          "src/test/resources/phylorefs/dummy1.jsonld", "Phyloreference '1'", outputStr, errorStr);
       resetIO();
 
       // Run 'test dummy1.txt' with the '--jsonld' option and see if we get the correct response.
@@ -113,16 +117,8 @@ class TestCommandTest {
       }
 
       assertEquals(0, exitCode);
-      assertTrue(
-          errorStr.contains("Input: src/test/resources/phylorefs/dummy1.txt"),
-          "Make sure JPhyloRef reports the name of the file being processed");
-      assertTrue(
-          errorStr.endsWith(
-              "Testing complete:1 successes, 0 failures, 0 failures marked TODO, 0 skipped.\n"),
-          "Make sure the testing was successful.");
-      assertEquals(
-          "1..1\nok 1 Phyloreference '1'\n# The following nodes were matched and expected this phyloreference: [1]\n\n",
-          outputStr);
+      expectSinglePhylorefResolvingCorrectly(
+          "src/test/resources/phylorefs/dummy1.txt", "Phyloreference '1'", outputStr, errorStr);
       resetIO();
     }
 
@@ -155,16 +151,7 @@ class TestCommandTest {
 
         // Test whether the exit code, STDERR and STDOUT is as expected.
         assertEquals(0, exitCode);
-        assertTrue(
-            errorStr.contains("Input: -"),
-            "Make sure JPhyloRef reports the name of the file being processed");
-        assertTrue(
-            errorStr.endsWith(
-                "Testing complete:1 successes, 0 failures, 0 failures marked TODO, 0 skipped.\n"),
-            "Make sure the testing was successful.");
-        assertEquals(
-            "1..1\nok 1 Phyloreference '1'\n# The following nodes were matched and expected this phyloreference: [1]\n\n",
-            outputStr);
+        expectSinglePhylorefResolvingCorrectly("-", "Phyloreference '1'", outputStr, errorStr);
       } catch (UnsupportedEncodingException ex) {
         // Could be thrown when converting STDOUT/STDERR to String as UTF-8.
         throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);


### PR DESCRIPTION
The special filename '-' can be used to indicate that input should be read from STDIN instead. This PR also adds a new test for this feature in TestCommandTest. Since this added to the code duplication in TestCommandTest, this PR adds a new method to remove some duplicated code and thus make the tests clearer.

I was in two minds about whether to keep 0248dc8 in this PR or to separate it into its own PR. Let me know if you'd prefer me to separate it!