### PR TITLE
Add support for Whelk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,14 @@
       	    <version>4.0.4</version>
       	</dependency>
 
+        <!-- Whelk is the future -->
+        <!-- https://mvnrepository.com/artifact/org.geneontology/whelk -->
+        <dependency>
+          <groupId>org.geneontology</groupId>
+          <artifactId>whelk_2.12</artifactId>
+          <version>0.1.3</version>
+        </dependency>
+
         <!-- Fact++ is a very fast JNI-based reasoner -->
         <dependency>
             <groupId>uk.ac.manchester.cs</groupId>

--- a/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
+import org.geneontology.whelk.owlapi.WhelkOWLReasonerFactory;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
@@ -29,6 +30,7 @@ public class ReasonerHelper {
     reasonerFactories.put("null", null);
     reasonerFactories.put("jfact", new JFactFactory());
     reasonerFactories.put("fact++", new FaCTPlusPlusReasonerFactory());
+    reasonerFactories.put("whelk", new WhelkOWLReasonerFactory());
   }
 
   /** Get reasoner factory by name. */


### PR DESCRIPTION
Whelk (https://github.com/balhoff/whelk/) is an OWL EL/RL reasoner. This PR allows users to choose this reasoner (by using `--reasoner whelk`).

**Incomplete**: I'll wait until we get Whelk fully working before I complete and submit this PR, which includes:
 - Whelk can't currently determine which individuals belong to class `phyloref:Phyloreference`. We can get around this by only selecting instances that were explicitly included in this class.
 - Whelk can't reason over our current class expressions, as we use `owl:unionOf`. I've set up an issue to remove these at phyloref/curation-tool#119.

WIP