### PR TITLE
Replaced Phyloref Ontology URIs with version URIs in tests

### DIFF
--- a/src/test/resources/phylorefs/dummy1.jsonld
+++ b/src/test/resources/phylorefs/dummy1.jsonld
@@ -499,7 +499,7 @@
     ],
     "owl:imports": [
         "https://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl",
-        "https://ontology.phyloref.org/phyloref.owl",
+        "https://ontology.phyloref.org/2018-12-04/phyloref.owl",
         "http://purl.obolibrary.org/obo/bco.owl"
     ]
 }

--- a/src/test/resources/phylorefs/dummy1.owl
+++ b/src/test/resources/phylorefs/dummy1.owl
@@ -15,7 +15,7 @@
   </rdf:Description>
   <rdf:Description rdf:about="file:///Users/ggvaidya/Development/jphyloref/src/test/resources/phylorefs/dummy1.jsonld">
     <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#PhyloreferenceTestCase"/>
-    <owl:imports rdf:resource="https://ontology.phyloref.org/phyloref.owl"/>
+    <owl:imports rdf:resource="https://ontology.phyloref.org/2018-12-04/phyloref.owl"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
     <owl:imports rdf:resource="https://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl"/>
     <owl:imports rdf:resource="http://purl.obolibrary.org/obo/bco.owl"/>

--- a/src/test/resources/phylorefs/dummy1.txt
+++ b/src/test/resources/phylorefs/dummy1.txt
@@ -499,7 +499,7 @@
     ],
     "owl:imports": [
         "https://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl",
-        "https://ontology.phyloref.org/phyloref.owl",
+        "https://ontology.phyloref.org/2018-12-04/phyloref.owl",
         "http://purl.obolibrary.org/obo/bco.owl"
     ]
 }


### PR DESCRIPTION
While the app itself was using the version URI for the Phyloref Ontology, the testing files still contained the old URI. This PR replaces them with the version URI.