### PR TITLE
Created a ResolveCommand to resolve phylorefs from the command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 
 ## [Unreleased]
+- Added a "resolve" command that resolves phylorefs in input ontologies (in OWL
+  or JSON-LD) and returns the result as a JSON string (#52).
 - Centralized code for determining nodes in phylorefs (#53, #54).
 - Added support for the Elk reasoner (as "elk") and made it the default reasoner.
 - Phyloreferences were previously identified in input ontologies by looking for

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -9,6 +9,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.phyloref.jphyloref.commands.Command;
+import org.phyloref.jphyloref.commands.ResolveCommand;
 import org.phyloref.jphyloref.commands.TestCommand;
 import org.phyloref.jphyloref.commands.WebserverCommand;
 import org.phyloref.jphyloref.helpers.ReasonerHelper;
@@ -25,7 +26,8 @@ public class JPhyloRef {
 
   /** List of all commands included in JPhyloRef. */
   private List<Command> commands =
-      Arrays.asList(new HelpCommand(), new TestCommand(), new WebserverCommand());
+      Arrays.asList(
+          new HelpCommand(), new TestCommand(), new WebserverCommand(), new ResolveCommand());
 
   /**
    * Interpret the command line arguments to determine which command to execute.

--- a/src/main/java/org/phyloref/jphyloref/commands/ResolveCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/ResolveCommand.java
@@ -1,0 +1,211 @@
+package org.phyloref.jphyloref.commands;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.json.JSONObject;
+import org.phyloref.jphyloref.helpers.JSONLDHelper;
+import org.phyloref.jphyloref.helpers.PhylorefHelper;
+import org.phyloref.jphyloref.helpers.ReasonerHelper;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.ClassExpressionType;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.reasoner.OWLReasoner;
+import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
+import org.semanticweb.owlapi.search.EntitySearcher;
+import org.semanticweb.owlapi.util.AutoIRIMapper;
+
+/**
+ * Resolve an ontology of phyloreferences provided on the command line, and report on the resolution
+ * of each clade definition. The resulting report or an appropriate error message will be provided
+ * in JSON, and the exit code will be set to non-zero if an error occurred.
+ *
+ * <p>This code was extracted from WebserverCommand so its functionality can be used from the
+ * command line, which is while for now it returns its results in the JSON format. We might
+ * eventually want to switch over to YAML or another more command line friendly format.
+ *
+ * @author Gaurav Vaidya <gaurav@ggvaidya.com>
+ */
+public class ResolveCommand implements Command {
+  /**
+   * This command is named "resolve". It should be invoked as "java -jar jphyloref.jar resolve ..."
+   */
+  @Override
+  public String getName() {
+    return "resolve";
+  }
+
+  /**
+   * A description of the Resolve command.
+   *
+   * @return A description of this command.
+   */
+  @Override
+  public String getDescription() {
+    return "Resolve phyloreferences in the input ontology and report on their resolution in JSON.";
+  }
+
+  /**
+   * Add command-line options specific to this command.
+   *
+   * @param opts The command-line options to modify for this command.
+   */
+  @Override
+  public void addCommandLineOptions(Options opts) {
+    opts.addOption(
+        "i",
+        "input",
+        true,
+        "The input ontology to read in RDF/XML or JSON-LD (can also be provided without the '-i').");
+
+    opts.addOption(
+        "j",
+        "jsonld",
+        false,
+        "Treat the input file as a JSON-LD file. Files with a '.json' or '.jsonld' extension will automatically be treated as a JSON-LD file.");
+  }
+
+  /** Use a default base URI when reading JSON-LD file. */
+  private static final String DEFAULT_URI_PREFIX = "http://example.org/jphyloref";
+
+  /**
+   * Set up a webserver to listen on the provided hostname and port (or their defaults).
+   *
+   * @param cmdLine The command line options provided to this command.
+   */
+  @Override
+  public int execute(CommandLine cmdLine) throws RuntimeException {
+    // Extract command-line options
+    String inputFilename = cmdLine.getOptionValue("input");
+
+    if (inputFilename == null && cmdLine.getArgList().size() > 1) {
+      // No 'input'? Maybe it's just provided as a left-over option?
+      inputFilename = cmdLine.getArgList().get(1);
+    }
+
+    if (inputFilename == null) {
+      throw new IllegalArgumentException("Error: no input ontology specified (use '-i input.owl')");
+    }
+
+    // If the input filename is '-', we should read the ontology from STDIN instead.
+    InputStream inputStreamToReadFrom = null;
+    if (inputFilename.equals("-")) {
+      inputStreamToReadFrom = System.in;
+    } else {
+      try {
+        inputStreamToReadFrom = new FileInputStream(inputFilename);
+      } catch (FileNotFoundException ex) {
+        System.err.println("Could not open input file '" + inputFilename + "': " + ex);
+        return 1;
+      }
+    }
+
+    // Report the name of the file being tested.
+    System.err.println("Input: " + inputFilename);
+
+    // Set up an OWL Ontology Manager to work with.
+    OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
+
+    // Is purl.obolibrary.org down? No worries, you can access local copies
+    // of your ontologies in the 'ontologies/' folder.
+    AutoIRIMapper mapper = new AutoIRIMapper(new File("ontologies"), true);
+    System.err.println("Found local ontologies: " + mapper.getOntologyIRIs());
+    manager.addIRIMapper(mapper);
+
+    // Is this a JSON or JSON-LD file?
+    OWLOntology ontology;
+    String inputFileLowercase = inputFilename.toLowerCase();
+    try {
+      if (cmdLine.hasOption("jsonld")
+          || inputFileLowercase.endsWith(".json")
+          || inputFileLowercase.endsWith(".jsonld")) {
+        // Use the JSONLD Helper to load the ontology.
+        ontology = manager.createOntology();
+        RDFParser parser = JSONLDHelper.createRDFParserForOntology(ontology);
+
+        // Read from the provided input stream (either STDIN or a file).
+        parser.parse(inputStreamToReadFrom, DEFAULT_URI_PREFIX);
+
+      } else {
+        // Load the ontology using OWLManager, by reading from the provided
+        // input stream (either STDIN or a file).
+        ontology = manager.loadOntologyFromOntologyDocument(inputStreamToReadFrom);
+      }
+    } catch (OWLOntologyCreationException ex) {
+      System.err.println("Could not create ontology '" + inputFilename + "': " + ex);
+      return 1;
+    } catch (IOException ex) {
+      System.err.println("Could not read and load ontology '" + inputFilename + "': " + ex);
+      return 1;
+    }
+
+    // Ontology loaded.
+    System.err.println("Loaded ontology: " + ontology);
+
+    // We have an ontology! Let's reason over it, and store the results as
+    // a map of a list of node IRIs matched by each phyloref IRI.
+    Map<String, Set<String>> nodesPerPhylorefAsString = new HashMap<>();
+
+    // Set up and start the reasoner.
+    OWLReasonerFactory factory = ReasonerHelper.getReasonerFactoryFromCmdLine(cmdLine);
+    OWLReasoner reasoner = factory.createReasoner(ontology);
+
+    // Go through all the phyloreferences, identifying all the nodes that have
+    // matched to that phyloreference.
+    for (OWLClass phyloref : PhylorefHelper.getPhyloreferences(ontology, reasoner)) {
+      IRI phylorefIRI = phyloref.getIRI();
+
+      // Identify all individuals contained in this phyloref class, but filter out
+      // everything that is not an IRI_CDAO_NODE.
+      Set<String> nodes =
+          reasoner
+              .getInstances(phyloref, false)
+              .getFlattened()
+              .stream()
+              // This includes the phyloreference itself. We only want to
+              // look at phylogeny nodes here. So, let's filter down to named
+              // individuals that are asserted to be cdao:Nodes.
+              .filter(
+                  indiv ->
+                      EntitySearcher.getTypes(indiv, ontology)
+                          .stream()
+                          .anyMatch(
+                              type ->
+                                  (!type.getClassExpressionType()
+                                          .equals(ClassExpressionType.OWL_CLASS))
+                                      || type.asOWLClass()
+                                          .getIRI()
+                                          .equals(PhylorefHelper.IRI_CDAO_NODE)))
+              .map(indiv -> indiv.getIRI().toString())
+              // Strip the default prefix on the node URI if present.
+              .map(iri -> iri.replaceFirst("^" + DEFAULT_URI_PREFIX, ""))
+              .collect(Collectors.toSet());
+
+      // Strip the default prefix on the phyloref URI if present.
+      String nodeURI = phylorefIRI.toString();
+      nodeURI = nodeURI.replaceFirst("^" + DEFAULT_URI_PREFIX, "");
+
+      nodesPerPhylorefAsString.put(nodeURI, nodes);
+    }
+
+    // Dispose of the reasoner.
+    reasoner.dispose();
+
+    // Write the JSON response to STDOUT.
+    System.out.println(new JSONObject(nodesPerPhylorefAsString).toString());
+    return 0;
+  }
+}

--- a/src/main/java/org/phyloref/jphyloref/commands/ResolveCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/ResolveCommand.java
@@ -17,7 +17,6 @@ import org.phyloref.jphyloref.helpers.JSONLDHelper;
 import org.phyloref.jphyloref.helpers.PhylorefHelper;
 import org.phyloref.jphyloref.helpers.ReasonerHelper;
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.ClassExpressionType;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLOntology;
@@ -25,7 +24,6 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
-import org.semanticweb.owlapi.search.EntitySearcher;
 import org.semanticweb.owlapi.util.AutoIRIMapper;
 
 /**
@@ -171,24 +169,8 @@ public class ResolveCommand implements Command {
       // Identify all individuals contained in this phyloref class, but filter out
       // everything that is not an IRI_CDAO_NODE.
       Set<String> nodes =
-          reasoner
-              .getInstances(phyloref, false)
-              .getFlattened()
+          PhylorefHelper.getNodesInClass(phyloref, ontology, reasoner)
               .stream()
-              // This includes the phyloreference itself. We only want to
-              // look at phylogeny nodes here. So, let's filter down to named
-              // individuals that are asserted to be cdao:Nodes.
-              .filter(
-                  indiv ->
-                      EntitySearcher.getTypes(indiv, ontology)
-                          .stream()
-                          .anyMatch(
-                              type ->
-                                  (!type.getClassExpressionType()
-                                          .equals(ClassExpressionType.OWL_CLASS))
-                                      || type.asOWLClass()
-                                          .getIRI()
-                                          .equals(PhylorefHelper.IRI_CDAO_NODE)))
               .map(indiv -> indiv.getIRI().toString())
               // Strip the default prefix on the node URI if present.
               .map(iri -> iri.replaceFirst("^" + DEFAULT_URI_PREFIX, ""))

--- a/src/test/java/org/phyloref/jphyloref/ResolveCommandTest.java
+++ b/src/test/java/org/phyloref/jphyloref/ResolveCommandTest.java
@@ -1,0 +1,148 @@
+package org.phyloref.jphyloref;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/** A unit test for the ResolveCommand class */
+@DisplayName("ResolveCommandTest")
+class ResolveCommandTest {
+  static JPhyloRef jphyloref = new JPhyloRef();
+  static ByteArrayOutputStream output = new ByteArrayOutputStream();
+  static ByteArrayOutputStream error = new ByteArrayOutputStream();
+
+  /** Set up input and output streams */
+  @BeforeAll
+  static void setupIO() {
+    System.setOut(new PrintStream(output));
+    System.setErr(new PrintStream(error));
+  }
+
+  /** Reset input and output streams between test runs */
+  @BeforeEach
+  void resetIO() {
+    output.reset();
+    error.reset();
+  }
+
+  @Nested
+  @DisplayName("can resolve OWL files")
+  class TestingOWLFile {
+    @Test
+    @DisplayName("successfully resolves phylorefs in OWL files")
+    void resolveOWLFiles() {
+      // Run 'test dummy1.owl' and see if we get the correct response.
+      int exitCode =
+          jphyloref.execute(new String[] {"resolve", "src/test/resources/phylorefs/dummy1.owl"});
+
+      String outputStr, errorStr;
+      try {
+        outputStr = output.toString("UTF-8");
+        errorStr = error.toString("UTF-8");
+      } catch (UnsupportedEncodingException ex) {
+        throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);
+      }
+
+      assertEquals(0, exitCode);
+      assertEquals(outputStr, "{\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001\":[\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2\"]}\n");
+    }
+  }
+
+  @Nested
+  @DisplayName("can resolve phylorefs in JSON-LD files")
+  class TestingJSONLDFile {
+    @Test
+    @DisplayName("successfully resolves phylorefs in JSON-LD files")
+    void resolveJSONLDFiles() {
+      // Run 'resolve dummy1.jsonld' and see if we get the correct response.
+      int exitCode =
+          jphyloref.execute(new String[] {"resolve", "src/test/resources/phylorefs/dummy1.jsonld"});
+
+      String outputStr, errorStr;
+      try {
+        outputStr = output.toString("UTF-8");
+        errorStr = error.toString("UTF-8");
+      } catch (UnsupportedEncodingException ex) {
+        throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);
+      }
+
+      assertEquals(0, exitCode);
+      assertEquals(outputStr, "{\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001\":[\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2\"]}\n");
+      resetIO();
+
+      // Run 'resolve dummy1.txt' with the '--jsonld' option and see if we get the correct response.
+      exitCode =
+          jphyloref.execute(
+              new String[] {"resolve", "src/test/resources/phylorefs/dummy1.txt", "--jsonld"});
+
+      try {
+        outputStr = output.toString("UTF-8");
+        errorStr = error.toString("UTF-8");
+      } catch (UnsupportedEncodingException ex) {
+        throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);
+      }
+
+      assertEquals(0, exitCode);
+      assertEquals(outputStr, "{\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001\":[\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2\"]}\n");
+      resetIO();
+    }
+
+    @Test
+    @DisplayName("can load JSON-LD files from STDIN")
+    void testJSONLDFromStdin() {
+      // The test file we're going to use in this test.
+      String testFilename = "src/test/resources/phylorefs/dummy1.jsonld";
+
+      // We're going to take over STDIN, so let's save the real STDIN so we can
+      // restore it.
+      InputStream actualStdin = System.in;
+
+      try {
+        // Reset STDOUT and STDERR and set STDIN.
+        resetIO();
+
+        // Create an InputStream with the contents of the JSON-LD file we've
+        // already tested, and set the System STDIN to point to that input stream.
+        ByteArrayInputStream input =
+            new ByteArrayInputStream(Files.readAllBytes(Paths.get(testFilename)));
+        System.setIn(input);
+
+        // Test the contents of STDIN.
+        int exitCode = jphyloref.execute(new String[] {"resolve", "--jsonld", "-"});
+
+        // Obtain STDOUT and STDERR.
+        String outputStr = output.toString("UTF-8");
+        String errorStr = error.toString("UTF-8");
+
+        // Test whether the exit code, STDERR and STDOUT is as expected.
+        assertEquals(0, exitCode);
+        assertEquals(outputStr, "{\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001\":[\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2\"]}\n");
+      } catch (UnsupportedEncodingException ex) {
+        // Could be thrown when converting STDOUT/STDERR to String as UTF-8.
+        throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);
+      } catch (IOException ex) {
+        // Could be thrown if there were errors reading the testing file.
+        throw new RuntimeException(
+            "Expected testing file '" + testFilename + "' not found or could not be read: " + ex);
+      } finally {
+        // Reset System.in to the actual STDIN.
+        System.setIn(actualStdin);
+
+        // Reset everything else as well.
+        resetIO();
+      }
+    }
+  }
+}

--- a/src/test/java/org/phyloref/jphyloref/ResolveCommandTest.java
+++ b/src/test/java/org/phyloref/jphyloref/ResolveCommandTest.java
@@ -23,6 +23,9 @@ class ResolveCommandTest {
   static ByteArrayOutputStream output = new ByteArrayOutputStream();
   static ByteArrayOutputStream error = new ByteArrayOutputStream();
 
+  private static final String EXPECTED_DUMMY1_RESOLUTION =
+      "{\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001\":[\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2\"]}\n";
+
   /** Set up input and output streams */
   @BeforeAll
   static void setupIO() {
@@ -56,7 +59,7 @@ class ResolveCommandTest {
       }
 
       assertEquals(0, exitCode);
-      assertEquals(outputStr, "{\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001\":[\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2\"]}\n");
+      assertEquals(outputStr, EXPECTED_DUMMY1_RESOLUTION);
     }
   }
 
@@ -79,7 +82,7 @@ class ResolveCommandTest {
       }
 
       assertEquals(0, exitCode);
-      assertEquals(outputStr, "{\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001\":[\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2\"]}\n");
+      assertEquals(outputStr, EXPECTED_DUMMY1_RESOLUTION);
       resetIO();
 
       // Run 'resolve dummy1.txt' with the '--jsonld' option and see if we get the correct response.
@@ -95,7 +98,7 @@ class ResolveCommandTest {
       }
 
       assertEquals(0, exitCode);
-      assertEquals(outputStr, "{\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001\":[\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2\"]}\n");
+      assertEquals(outputStr, EXPECTED_DUMMY1_RESOLUTION);
       resetIO();
     }
 
@@ -128,7 +131,7 @@ class ResolveCommandTest {
 
         // Test whether the exit code, STDERR and STDOUT is as expected.
         assertEquals(0, exitCode);
-        assertEquals(outputStr, "{\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001\":[\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2\"]}\n");
+        assertEquals(outputStr, EXPECTED_DUMMY1_RESOLUTION);
       } catch (UnsupportedEncodingException ex) {
         // Could be thrown when converting STDOUT/STDERR to String as UTF-8.
         throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);

--- a/src/test/java/org/phyloref/jphyloref/ResolveCommandTest.java
+++ b/src/test/java/org/phyloref/jphyloref/ResolveCommandTest.java
@@ -82,7 +82,7 @@ class ResolveCommandTest {
       }
 
       assertEquals(0, exitCode);
-      assertEquals(outputStr, EXPECTED_DUMMY1_RESOLUTION);
+      assertEquals(EXPECTED_DUMMY1_RESOLUTION, outputStr);
       resetIO();
 
       // Run 'resolve dummy1.txt' with the '--jsonld' option and see if we get the correct response.
@@ -98,7 +98,7 @@ class ResolveCommandTest {
       }
 
       assertEquals(0, exitCode);
-      assertEquals(outputStr, EXPECTED_DUMMY1_RESOLUTION);
+      assertEquals(EXPECTED_DUMMY1_RESOLUTION, outputStr);
       resetIO();
     }
 
@@ -131,7 +131,7 @@ class ResolveCommandTest {
 
         // Test whether the exit code, STDERR and STDOUT is as expected.
         assertEquals(0, exitCode);
-        assertEquals(outputStr, EXPECTED_DUMMY1_RESOLUTION);
+        assertEquals(EXPECTED_DUMMY1_RESOLUTION, outputStr);
       } catch (UnsupportedEncodingException ex) {
         // Could be thrown when converting STDOUT/STDERR to String as UTF-8.
         throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);


### PR DESCRIPTION
Adds a "resolve" command that is identical to the WebserverCommand, but executable from the command line (executed as `java -jar jphyloref.jar resolve input.jsonld`). Resolved nodes are returned as a JSON document using URIs, for example:
```
{
  "#phyloref1" : [ "#phylogeny0_node1", "#phylogeny1_node2" ],
  "#phyloref2": [ "#phylogeny1_node5" ]
}
```

Should be merged after #54 has been merged.