### PR TITLE
Moved Phyloref resolution code into PhylorefHelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 
 ## [Unreleased]
+- Centralized code for determining nodes in phylorefs (#53, #54).
 - Added support for the Elk reasoner (as "elk") and made it the default reasoner.
 - Phyloreferences were previously identified in input ontologies by looking for
   individuals defined as instances of the class phyloref:Phyloreference. They

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -234,7 +234,7 @@ public class TestCommand implements Command {
       result.setDescription("Phyloreference '" + phylorefLabel + "'");
 
       // Which nodes did this phyloreference resolved to?
-      Set<OWLNamedIndividual> nodes = PhylorefHelper.getResolvedNodes(phyloref, ontology, reasoner);
+      Set<OWLNamedIndividual> nodes = PhylorefHelper.getNodesInClass(phyloref, ontology, reasoner);
       // System.err.println("Phyloreference <" + phyloref + "> has nodes: " + nodes);
 
       if (nodes.isEmpty()) {

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -19,11 +19,9 @@ import org.phyloref.jphyloref.helpers.OWLHelper;
 import org.phyloref.jphyloref.helpers.PhylorefHelper;
 import org.phyloref.jphyloref.helpers.ReasonerHelper;
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.AxiomType;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLClass;
-import org.semanticweb.owlapi.model.OWLClassAssertionAxiom;
 import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLDataProperty;
 import org.semanticweb.owlapi.model.OWLNamedIndividual;
@@ -236,26 +234,7 @@ public class TestCommand implements Command {
       result.setDescription("Phyloreference '" + phylorefLabel + "'");
 
       // Which nodes did this phyloreference resolved to?
-      Set<OWLNamedIndividual> nodes;
-      if (reasoner != null) {
-        // Use the reasoner to determine which nodes are members of this phyloref as a class
-        nodes = reasoner.getInstances(phyloref, false).getFlattened();
-      } else {
-        // No reasoner? We can also determine which nodes have been directly stated to
-        // be members of this phyloref as a class. This allows us to read a pre-reasoned
-        // OWL file and test whether phyloreferences resolved as expected.
-        nodes = new HashSet<>();
-        Set<OWLClassAssertionAxiom> classAssertions = ontology.getAxioms(AxiomType.CLASS_ASSERTION);
-
-        for (OWLClassAssertionAxiom classAssertion : classAssertions) {
-          // Does this assertion involve this phyloreference as a class and a named individual?
-          if (classAssertion.getIndividual().isNamed()
-              && classAssertion.getClassesInSignature().contains(phyloref)) {
-            // If so, then the individual is a node that is included in this phyloreference.
-            nodes.add(classAssertion.getIndividual().asOWLNamedIndividual());
-          }
-        }
-      }
+      Set<OWLNamedIndividual> nodes = PhylorefHelper.getResolvedNodes(phyloref, ontology, reasoner);
       // System.err.println("Phyloreference <" + phyloref + "> has nodes: " + nodes);
 
       if (nodes.isEmpty()) {

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -181,7 +181,7 @@ public class WebserverCommand implements Command {
         // Identify all individuals contained in this phyloref class, but filter out
         // everything that is not an IRI_CDAO_NODE.
         Set<String> nodes =
-            PhylorefHelper.getResolvedNodes(phyloref, ontology, reasoner)
+            PhylorefHelper.getNodesInClass(phyloref, ontology, reasoner)
                 .stream()
                 .map(indiv -> indiv.getIRI().toString())
                 // Strip the default prefix on the node URI if present.

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -22,7 +22,6 @@ import org.phyloref.jphyloref.helpers.JSONLDHelper;
 import org.phyloref.jphyloref.helpers.PhylorefHelper;
 import org.phyloref.jphyloref.helpers.ReasonerHelper;
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.ClassExpressionType;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLOntology;
@@ -30,7 +29,6 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
-import org.semanticweb.owlapi.search.EntitySearcher;
 import org.semanticweb.owlapi.util.AutoIRIMapper;
 import org.semanticweb.owlapi.util.VersionInfo;
 
@@ -183,24 +181,8 @@ public class WebserverCommand implements Command {
         // Identify all individuals contained in this phyloref class, but filter out
         // everything that is not an IRI_CDAO_NODE.
         Set<String> nodes =
-            reasoner
-                .getInstances(phyloref, false)
-                .getFlattened()
+            PhylorefHelper.getResolvedNodes(phyloref, ontology, reasoner)
                 .stream()
-                // This includes the phyloreference itself. We only want to
-                // look at phylogeny nodes here. So, let's filter down to named
-                // individuals that are asserted to be cdao:Nodes.
-                .filter(
-                    indiv ->
-                        EntitySearcher.getTypes(indiv, ontology)
-                            .stream()
-                            .anyMatch(
-                                type ->
-                                    (!type.getClassExpressionType()
-                                            .equals(ClassExpressionType.OWL_CLASS))
-                                        || type.asOWLClass()
-                                            .getIRI()
-                                            .equals(PhylorefHelper.IRI_CDAO_NODE)))
                 .map(indiv -> indiv.getIRI().toString())
                 // Strip the default prefix on the node URI if present.
                 .map(iri -> iri.replaceFirst("^" + DEFAULT_URI_PREFIX, ""))

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -186,23 +186,23 @@ public class PhylorefHelper {
   }
 
   /**
-   * Get the set of resolved nodes for a particular phyloreference. If `reasoner` is set to null,
-   * this will return all individuals asserted as belonging to the provided phyloref class, allowing
+   * Get the set of named individuals in a particular OWL class. If `reasoner` is set to null,
+   * this will return all individuals asserted as belonging to the provided class, allowing
    * it to be used on precomputed OWL ontologies.
    *
-   * @param phyloref The phyloreference to query.
-   * @param ontology The ontology to query.
+   * @param owlClass The OWL class to retrieve instances from.
+   * @param ontology The ontology containing the OWL class and its instances.
    * @param reasoner The reasoner to use. May be set to null if no reasoner if available.
    * @return A set of OWLNamedIndividuals asserted directly or indirectly as belonging to the
-   *     provided phyloreference.
+   *     provided class.
    */
-  public static Set<OWLNamedIndividual> getResolvedNodes(
-      OWLClass phyloref, OWLOntology ontology, OWLReasoner reasoner) {
+  public static Set<OWLNamedIndividual> getNodesInClass(
+      OWLClass owlClass, OWLOntology ontology, OWLReasoner reasoner) {
     if (reasoner != null) {
       // Return nodes that the reasoner has determined are instances of the provided phyloref.
       return reasoner
           .getInstances(
-              phyloref,
+              owlClass,
               false // include both direct and indirectly asserted members of this phyloref class
               )
           .getFlattened();
@@ -217,7 +217,7 @@ public class PhylorefHelper {
     for (OWLClassAssertionAxiom classAssertion : classAssertions) {
       // Does this assertion involve this phyloreference as a class and a named individual?
       if (classAssertion.getIndividual().isNamed()
-          && classAssertion.getClassesInSignature().contains(phyloref)) {
+          && classAssertion.getClassesInSignature().contains(owlClass)) {
         // If so, then the individual is a node that is included in this phyloreference.
         nodes.add(classAssertion.getIndividual().asOWLNamedIndividual());
       }

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -186,9 +186,9 @@ public class PhylorefHelper {
   }
 
   /**
-   * Get the set of named individuals in a particular OWL class. If `reasoner` is set to null,
-   * this will return all individuals asserted as belonging to the provided class, allowing
-   * it to be used on precomputed OWL ontologies.
+   * Get the set of named individuals in a particular OWL class. If `reasoner` is set to null, this
+   * will return all individuals asserted as belonging to the provided class, allowing it to be used
+   * on precomputed OWL ontologies.
    *
    * @param owlClass The OWL class to retrieve instances from.
    * @param ontology The ontology containing the OWL class and its instances.


### PR DESCRIPTION
This PR centralizes how we resolve phyloreferences to nodes rather than doing it in slightly different ways in different parts of the program. Closes #53.