### PR TITLE
Replace System.err with SLF4J calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 
 ## [Unreleased]
+- Replaced `System.err` and `System.out` with calls to SLF4J (#51).
 - Added a "resolve" command that resolves phylorefs in input ontologies (in OWL
   or JSON-LD) and returns the result as a JSON string (#52).
 - Centralized code for determining nodes in phylorefs (#53, #54).

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -15,12 +15,17 @@ import org.phyloref.jphyloref.commands.WebserverCommand;
 import org.phyloref.jphyloref.helpers.ReasonerHelper;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 import org.semanticweb.owlapi.util.VersionInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Main class for JPhyloRef. Contains a list of Commands, as well as the code for determining which
  * Command to execute.
  */
 public class JPhyloRef {
+  /** Set up a logger to use for providing logging. */
+  private static final Logger logger = LoggerFactory.getLogger(JPhyloRef.class);
+
   /** Version of JPhyloRef. */
   public static final String VERSION = "0.2-SNAPSHOT";
 
@@ -51,7 +56,7 @@ public class JPhyloRef {
     try {
       cmdLine = new DefaultParser().parse(opts, args);
     } catch (ParseException ex) {
-      System.err.println("Could not parse command line options: " + ex);
+      logger.error("Could not parse command line options: {}", (Object) ex);
       return 1;
     }
 
@@ -77,7 +82,7 @@ public class JPhyloRef {
       }
 
       // Could not find any command.
-      System.err.println("Error: command '" + command + "' has not been implemented.");
+      logger.error("Command '{}' has not been implemented.", command);
       return 1;
     }
   }

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -56,7 +56,7 @@ public class JPhyloRef {
     try {
       cmdLine = new DefaultParser().parse(opts, args);
     } catch (ParseException ex) {
-      logger.error("Could not parse command line options: {}", (Object) ex);
+      logger.error("Could not parse command line options: {}", ex.toString());
       return 1;
     }
 

--- a/src/main/java/org/phyloref/jphyloref/commands/ResolveCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/ResolveCommand.java
@@ -25,6 +25,8 @@ import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 import org.semanticweb.owlapi.util.AutoIRIMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Resolve an ontology of phyloreferences provided on the command line, and report on the resolution
@@ -38,6 +40,9 @@ import org.semanticweb.owlapi.util.AutoIRIMapper;
  * @author Gaurav Vaidya <gaurav@ggvaidya.com>
  */
 public class ResolveCommand implements Command {
+  /** Set up a logger to use for providing logging. */
+  private static final Logger logger = LoggerFactory.getLogger(ResolveCommand.class);
+
   /**
    * This command is named "resolve". It should be invoked as "java -jar jphyloref.jar resolve ..."
    */
@@ -115,13 +120,13 @@ public class ResolveCommand implements Command {
       try {
         inputStreamToReadFrom = new FileInputStream(inputFilename);
       } catch (FileNotFoundException ex) {
-        System.err.println("Could not open input file '" + inputFilename + "': " + ex);
+        logger.error("Could not open input file '{}': {}", inputFilename, ex);
         return 1;
       }
     }
 
     // Report the name of the file being tested.
-    System.err.println("Input: " + inputFilename);
+    logger.info("Input: {}", inputFilename);
 
     // Set up an OWL Ontology Manager to work with.
     OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
@@ -129,7 +134,7 @@ public class ResolveCommand implements Command {
     // Is purl.obolibrary.org down? No worries, you can access local copies
     // of your ontologies in the 'ontologies/' folder.
     AutoIRIMapper mapper = new AutoIRIMapper(new File("ontologies"), true);
-    System.err.println("Found local ontologies: " + mapper.getOntologyIRIs());
+    logger.info("Found local ontologies: {}", mapper.getOntologyIRIs());
     manager.addIRIMapper(mapper);
 
     // Is this a JSON or JSON-LD file?

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -34,6 +34,8 @@ import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 import org.semanticweb.owlapi.search.EntitySearcher;
 import org.semanticweb.owlapi.util.AutoIRIMapper;
 import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tap4j.model.Comment;
 import org.tap4j.model.Directive;
 import org.tap4j.model.Plan;
@@ -54,6 +56,9 @@ import org.tap4j.util.StatusValues;
  * @author Gaurav Vaidya <gaurav@ggvaidya.com>
  */
 public class TestCommand implements Command {
+  /** Set up a logger to use for providing logging. */
+  private static final Logger logger = LoggerFactory.getLogger(TestCommand.class);
+
   /** This command is named "test". It should be invoked as "java -jar jphyloref.jar test ..." */
   @Override
   public String getName() {
@@ -119,13 +124,13 @@ public class TestCommand implements Command {
       try {
         inputStreamToReadFrom = new FileInputStream(inputFilename);
       } catch (FileNotFoundException ex) {
-        System.err.println("Could not open input file '" + inputFilename + "': " + ex);
+        logger.error("Could not open input file '{}': {}", inputFilename, ex);
         return 1;
       }
     }
 
     // Report the name of the file being tested.
-    System.err.println("Input: " + inputFilename);
+    logger.info("Input: {}", inputFilename);
 
     // Set up an OWL Ontology Manager to work with.
     OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
@@ -133,7 +138,7 @@ public class TestCommand implements Command {
     // Is purl.obolibrary.org down? No worries, you can access local copies
     // of your ontologies in the 'ontologies/' folder.
     AutoIRIMapper mapper = new AutoIRIMapper(new File("ontologies"), true);
-    System.err.println("Found local ontologies: " + mapper.getOntologyIRIs());
+    logger.info("Found local ontologies: {}", mapper.getOntologyIRIs());
     manager.addIRIMapper(mapper);
 
     // Is this a JSON or JSON-LD file?
@@ -157,15 +162,15 @@ public class TestCommand implements Command {
         ontology = manager.loadOntologyFromOntologyDocument(inputStreamToReadFrom);
       }
     } catch (OWLOntologyCreationException ex) {
-      System.err.println("Could not create ontology '" + inputFilename + "': " + ex);
+      logger.error("Could not create ontology '{}': {}", inputFilename, ex);
       return 1;
     } catch (IOException ex) {
-      System.err.println("Could not read and load ontology '" + inputFilename + "': " + ex);
+      logger.error("Could not read and load ontology '{}': {}", inputFilename, ex);
       return 1;
     }
 
     // Ontology loaded.
-    System.err.println("Loaded ontology: " + ontology);
+    logger.info("Loaded ontology: {}", ontology);
 
     // Reason over the loaded ontology -- but only if the user wants that!
     // Set up an OWLReasoner to work with.
@@ -175,7 +180,7 @@ public class TestCommand implements Command {
 
     // Get a list of all phyloreferences.
     Set<OWLClass> phylorefs = PhylorefHelper.getPhyloreferences(ontology, reasoner);
-    System.err.println("Phyloreferences identified: " + phylorefs);
+    logger.info("Phyloreferences identified: {}", phylorefs);
 
     // Okay, time to start testing! Each phyloreference counts as one test.
     // TAP (https://testanything.org/) can be read by downstream software

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -134,14 +134,11 @@ public class WebserverCommand implements Command {
 
       start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
       logger.info(
-          "Webserver started with reasoner "
-              + ReasonerHelper.getReasonerNameAndVersion(
-                  ReasonerHelper.getReasonerFactoryFromCmdLine(cmdLine))
-              + ". Try accessing it at http://"
-              + hostname
-              + ":"
-              + port
-              + "/");
+          "Webserver started with reasoner {}. Try accessing it at http://{}:{}/",
+          ReasonerHelper.getReasonerNameAndVersion(
+              ReasonerHelper.getReasonerFactoryFromCmdLine(cmdLine)),
+          hostname,
+          port);
     }
 
     /** Respond to a request for reasoning over a JSON-LD file (/reason). */

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -133,7 +133,7 @@ public class WebserverCommand implements Command {
       this.cmdLine = cmdLine;
 
       start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
-      System.out.println(
+      logger.info(
           "Webserver started with reasoner "
               + ReasonerHelper.getReasonerNameAndVersion(
                   ReasonerHelper.getReasonerFactoryFromCmdLine(cmdLine))

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -102,7 +102,7 @@ public class WebserverCommand implements Command {
       Webserver webserver = new Webserver(this, hostname, port, cmdLine);
       while (webserver.isAlive()) {}
     } catch (IOException ex) {
-      logger.error("An error occurred while running webserver: {}", (Object) ex);
+      logger.error("An error occurred while running webserver: {}", ex.toString());
     }
 
     return 0;

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -36,6 +36,8 @@ import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 import org.semanticweb.owlapi.util.AutoIRIMapper;
 import org.semanticweb.owlapi.util.VersionInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Sets up a webserver that allows reasoning over phyloreferences over HTTP.
@@ -50,6 +52,9 @@ import org.semanticweb.owlapi.util.VersionInfo;
  * @author Gaurav Vaidya <gaurav@ggvaidya.com>
  */
 public class WebserverCommand implements Command {
+  /** Set up a logger to use for providing logging. */
+  private static final Logger logger = LoggerFactory.getLogger(WebserverCommand.class);
+
   /**
    * This command is named "webserver". It should be invoked as "java -jar jphyloref.jar webserver
    * ..."
@@ -97,7 +102,7 @@ public class WebserverCommand implements Command {
       Webserver webserver = new Webserver(this, hostname, port, cmdLine);
       while (webserver.isAlive()) {}
     } catch (IOException ex) {
-      System.err.println("An error occurred while running webserver: " + ex);
+      logger.error("An error occurred while running webserver: {}", (Object) ex);
     }
 
     return 0;
@@ -150,7 +155,7 @@ public class WebserverCommand implements Command {
       // Is purl.obolibrary.org down? No worries, you can access local copies
       // of your ontologies in the 'ontologies/' folder.
       AutoIRIMapper mapper = new AutoIRIMapper(new File("ontologies"), true);
-      System.err.println("Found local ontologies: " + mapper.getOntologyIRIs());
+      logger.info("Found local ontologies: {}", mapper.getOntologyIRIs());
       manager.addIRIMapper(mapper);
 
       // Setup ready; parse the file!
@@ -204,7 +209,7 @@ public class WebserverCommand implements Command {
       reasoner.dispose();
 
       // Log reasoning results.
-      System.err.println("Phyloreferencing reasoning results: " + nodesPerPhylorefAsString);
+      logger.info("Phyloreferencing reasoning results: {}", nodesPerPhylorefAsString);
 
       // Record phyloreferences and matching nodes in JSON response.
       response.put("phylorefs", nodesPerPhylorefAsString);
@@ -267,7 +272,7 @@ public class WebserverCommand implements Command {
       String path = session.getUri();
       Map<String, List<String>> params = session.getParameters();
 
-      System.out.println(">> Request received to '" + path + "': " + params);
+      logger.info(">> Request received to '{}': {}", path, params);
 
       if (path.equals("/reason")) {
         // If it is an OPTIONS request, it's probably someone wanting a

--- a/src/test/java/org/phyloref/jphyloref/AppTest.java
+++ b/src/test/java/org/phyloref/jphyloref/AppTest.java
@@ -73,7 +73,9 @@ class AppTest {
 
     try {
       assertEquals("", output.toString("UTF-8"));
-      assertEquals("Error: command 'unknown' has not been implemented.\n", error.toString("UTF-8"));
+      assertEquals(
+          "[main] ERROR org.phyloref.jphyloref.JPhyloRef - Command 'unknown' has not been implemented.\n",
+          error.toString("UTF-8"));
     } catch (UnsupportedEncodingException ex) {
       throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);
     }
@@ -89,7 +91,7 @@ class AppTest {
     try {
       assertEquals("", output.toString("UTF-8"));
       assertEquals(
-          "Could not parse command line options: org.apache.commons.cli.UnrecognizedOptionException: Unrecognized option: ----\n",
+          "[main] ERROR org.phyloref.jphyloref.JPhyloRef - Could not parse command line options: org.apache.commons.cli.UnrecognizedOptionException: Unrecognized option: ----\n",
           error.toString("UTF-8"));
     } catch (UnsupportedEncodingException ex) {
       throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);


### PR DESCRIPTION
This PR replaces most of our System.err calls with calls to the SLF4J logging system. This will make it easier to add debugging information in the future, when we can use verbose flags (`-v`, `-vv`) to provide increasingly detailed debugging information (#31).

Closes #51.