### PR TITLE
Document how we execute JPhyloRef on our backend server

### DIFF
--- a/webhook/README.md
+++ b/webhook/README.md
@@ -1,0 +1,29 @@
+# Webhook configuration and scripts
+
+This folder documents the server settings needed to host JPhyloRef as a
+web server on a cluster that uses [`srun`](https://slurm.schedmd.com/srun.html) to execute programs. We use the
+[webhook](https://github.com/adnanh/webhook/) tool to set up a web server
+that accepts jobs for execution. To set this up requires the
+[`webhook` binary](https://github.com/adnanh/webhook/releases) to be
+downloaded to the same folder as these scripts.
+
+The files in this folder are:
+* [start.sh](./start.sh) should be executed to start the server. It sets up the
+[Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin)
+and
+[Access-Control-Allow-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers)
+HTTP headers to ensure that requests from other websites via
+[CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) is allowed. The `$PORT` variable should be set to the HTTP port to listen to.
+* [hooks.json](./hooks.json) is the settings file for Webhook. It expects a
+`jsonld` form value containing a JSON-LD document to be reasoned over. It uses
+[X-Hub-Signature](https://www.npmjs.com/package/x-hub-signature) to ensure that
+the browser knows a shared secret (which should be set as `$SECRET`) with the
+reasoner.
+* [exec_jphyloref_webhook.sh](./exec_jphyloref_webhook.sh) is a helper script that
+executes JPhyloRef and prints the JSON document containing resolved phyloreferences
+to standard output. It calls JPhyloRef with paticular settings at three levels:
+  * Some settings (number of tasks, number of CPUs per task, timeout) are sent to
+    [`srun`](https://slurm.schedmd.com/srun.html), which starts JPhyloRef on a cluster.
+  * Some settings (maximum memory, HTTP proxy settings) are sent to Java to set up
+    the environment in which JPhyloRef can run.
+  * Some settings (the name of the input file) are sent to JPhyloRef for processing.

--- a/webhook/exec_jphyloref_webhook.sh
+++ b/webhook/exec_jphyloref_webhook.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Webhooks should set: $JSONLD_FILENAME (JSON-LD input as file)
+
+# Settings
+MEMORY=16G
+
+# Configuration
+JARFILE=jphyloref-0.2-resolve.jar
+# How many jobs to spawn. This should always be 1!
+NTASKS=1
+CPUS_PER_TASK=4
+# Timeout is in minutes.
+TIMEOUT=2
+# If SHARE is set to '-s' or '--share', we'll share a compute node with
+# another job.
+SHARE=-s
+
+# Set up proxy
+HTTP_PROXY_HOST= # TODO enter proxy server hostname here
+HTTP_PROXY_PORT= # TODO enter proxy server port here
+HTTPS_PROXY_HOST=$HTTP_PROXY_HOST
+HTTPS_PROXY_PORT=$HTTP_PROXY_PORT
+
+# Do it!
+echo "{\"phylorefs\":"
+srun $SHARE --ntasks=$NTASKS --cpus-per-task=$CPUS_PER_TASK --mem=$MEMORY -t $TIMEOUT java -Dhttp.proxyHost=$HTTP_PROXY_HOST -Dhttp.proxyPort=$HTTP_PROXY_PORT -Dhttps.proxyHost=$HTTPS_PROXY_HOST -Dhttps.proxyPort=$HTTP_PROXY_PORT -Xmx$MEMORY -jar $JARFILE resolve $JSONLD_FILENAME -j 2> /dev/null
+echo "}"

--- a/webhook/hooks.json
+++ b/webhook/hooks.json
@@ -1,0 +1,35 @@
+[
+	{
+		"id": "reason",
+		"execute-command": "./exec_jphyloref_webhook.sh",
+		"command-working-directory": ".",
+		"pass-file-to-command": [
+			{
+				"source": "payload",
+				"name": "jsonld",
+				"envname": "JSONLD_FILENAME"
+			}
+		],
+		"include-command-output-in-response": true,
+		"response-headers": [
+			{
+				"name": "Content-type",
+				"value": "application/json"
+			},
+			{
+				"name": "Access-Control-Allow-Origin",
+				"value": "*"
+			}
+		],
+		"trigger-rule": {
+			"match": {
+				"type": "payload-hash-sha1",
+				"secret": "$SECRET",
+				"parameter": {
+					"source": "header",
+					"name": "X-Hub-Signature"
+				}
+			}
+		}
+	}
+]

--- a/webhook/start.sh
+++ b/webhook/start.sh
@@ -1,0 +1,1 @@
+./webhook -port $PORT -hooks hooks.json -header Access-Control-Allow-Origin=* -header Access-Control-Allow-Headers=x-hub-signature -verbose


### PR DESCRIPTION
This PR documents how we execute JPhyloRef on our backend server by using the [webhook](https://github.com/adnanh/webhook/) tool to host a webserver that can accept jobs and submit them to a Slurm workload manager by using the [srun](https://slurm.schedmd.com/srun.html) command. I've tried to remove any internal details, but note that the X-Hub-Signature secret will always be disclosed in the HTML source of our one-page apps, unless we hide it behind a server somewhere.

I'm not completely convinced that we need to document this information on our Github page rather than just keeping the documentation on our backend server. If you think this is too much information to make public, feel free to delete this PR.