### PR TITLE
Use model 2.0 expected resolution information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 - Initial release, with support for testing phyloreferences expressed in OWL
   and stored in RDF/XML.
 
-[Unreleased]: https://github.com/phyloref/jphyloref/compare/v0.3...HEAD
+[Unreleased]: https://github.com/phyloref/jphyloref/compare/v0.3.1...HEAD
 [0.3.1]: https://github.com/phyloref/jphyloref/releases/tag/v0.3.1
 [0.3]: https://github.com/phyloref/jphyloref/releases/tag/v0.3
 [0.2]: https://github.com/phyloref/jphyloref/releases/tag/v0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 
+## [Unreleased]
+- Updated JPhyloRef to use model 2.0 expectations, encoded as logical expressions
+  on the phylogeny node, rather than comparing labels or using text-based properties.
+  You will need to use Phyx.js 0.2.0 or higher to generate ontologies that can be
+  tested with this version of JPhyloRef.
+
 ## [0.3.1] - 2020-05-13
 - JPhyloRef was incorrectly returning an exit code of `0` whether or not
   testing succeeded. It now returns `0` only if all testing succeeded,

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.4</version>
+        <version>0.8.6</version>
         <configuration>
           <!-- These rules are to ensure that CI output records that we still
           haven't finished testing this code, which is why we don't halt on failure. -->

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -443,8 +443,10 @@ public class TestCommand implements Command {
   private List<String> removeDefaultURIPrefixes(
       Set<OWLNamedIndividual> indivs, String defaultURIPrefix) {
     if (defaultURIPrefix == null) {
-      // Just convert the hasIRIs into strings and return.
-      return indivs.stream().map(indiv -> indiv.getIRI().toString()).collect(Collectors.toList());
+      // Nothing to remove! Just convert the hasIRIs into strings and return.
+      return indivs.stream()
+        .map(indiv -> indiv.getIRI().toString())
+        .collect(Collectors.toList());
     }
 
     // Remove the default URI prefix if one exists.
@@ -453,7 +455,9 @@ public class TestCommand implements Command {
         .map(
             indiv -> {
               String iriString = indiv.getIRI().toString();
+              // Does this IRI string start with the default URI prefix?
               if (iriString.startsWith(defaultURIPrefix))
+                // If so, remove them!
                 return iriString.substring(defaultURIPrefix.length());
               return iriString;
             })

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -23,9 +23,7 @@ import org.semanticweb.owlapi.model.OWLAnnotationProperty;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLClassExpression;
 import org.semanticweb.owlapi.model.OWLDataFactory;
-import org.semanticweb.owlapi.model.OWLDataProperty;
 import org.semanticweb.owlapi.model.OWLNamedIndividual;
-import org.semanticweb.owlapi.model.OWLObjectProperty;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
@@ -207,12 +205,6 @@ public class TestCommand implements Command {
     // Terms associated with phyloreferences
     OWLAnnotationProperty labelAnnotationProperty =
         dataFactory.getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI());
-    OWLDataProperty expectedPhyloreferenceNamedProperty =
-        dataFactory.getOWLDataProperty(PhylorefHelper.IRI_NAME_OF_EXPECTED_PHYLOREF);
-    OWLObjectProperty unmatchedSpecifierProperty =
-        dataFactory.getOWLObjectProperty(PhylorefHelper.IRI_PHYLOREF_UNMATCHED_SPECIFIER);
-    // OWLDataProperty specifierDefinitionProperty =
-    // dataFactory.getOWLDataProperty(PhylorefHelper.IRI_CLADE_DEFINITION);
 
     // Count the number of test results.
     int testNumber = 0;

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -20,7 +20,6 @@ import org.phyloref.jphyloref.helpers.PhylorefHelper;
 import org.phyloref.jphyloref.helpers.ReasonerHelper;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
-import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLClassExpression;
 import org.semanticweb.owlapi.model.OWLDataFactory;
@@ -32,7 +31,6 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
-import org.semanticweb.owlapi.search.EntitySearcher;
 import org.semanticweb.owlapi.util.AutoIRIMapper;
 import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
 import org.slf4j.Logger;
@@ -335,7 +333,7 @@ public class TestCommand implements Command {
             result.addComment(
                 new Comment(
                     "This phyloref resolved as expected, and should be marked as pso:submitted instead of: "
-                      + activeStatuses));
+                        + activeStatuses));
           }
           testSet.addTapLine(result);
           countSuccess++;
@@ -405,9 +403,7 @@ public class TestCommand implements Command {
       Set<OWLNamedIndividual> indivs, String defaultURIPrefix) {
     if (defaultURIPrefix == null) {
       // Nothing to remove! Just convert the hasIRIs into strings and return.
-      return indivs.stream()
-        .map(indiv -> indiv.getIRI().toString())
-        .collect(Collectors.toList());
+      return indivs.stream().map(indiv -> indiv.getIRI().toString()).collect(Collectors.toList());
     }
 
     // Remove the default URI prefix if one exists.

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -254,37 +254,6 @@ public class TestCommand implements Command {
       List<PhylorefHelper.PhylorefStatus> statuses =
           PhylorefHelper.getStatusesForPhyloref(phyloref, ontology);
 
-      // Look for all unmatched specifiers reported for this phyloreference.
-      Set<OWLAxiom> axioms = new HashSet<>(EntitySearcher.getReferencingAxioms(phyloref, ontology));
-      Set<OWLNamedIndividual> unmatched_specifiers = new HashSet<>();
-      for (OWLAxiom axiom : axioms) {
-        if (axiom.containsEntityInSignature(unmatchedSpecifierProperty)) {
-          // This axiom references this phyloreference AND the unmatched specifier property!
-          // Therefore, any NamedIndividuals that are not phyloref should be added to
-          // unmatched_specifiers!
-          for (OWLNamedIndividual ni : axiom.getIndividualsInSignature()) {
-            if (ni != phyloref) unmatched_specifiers.add(ni);
-          }
-        }
-      }
-
-      // Report all unmatched specifiers
-      for (OWLNamedIndividual unmatched_specifier : unmatched_specifiers) {
-        Set<String> unmatched_specifier_label =
-            OWLHelper.getAnnotationLiteralsForEntity(
-                ontology, unmatched_specifier, labelAnnotationProperty, Arrays.asList("en"));
-        if (!unmatched_specifier_label.isEmpty()) {
-          result.addComment(
-              new Comment("Specifier '" + unmatched_specifier_label + "' is marked as unmatched."));
-        } else {
-          result.addComment(
-              new Comment(
-                  "Specifier '"
-                      + unmatched_specifier.getIRI().getShortForm()
-                      + "' is marked as unmatched."));
-        }
-      }
-
       // Instead of checking which time interval we are currently in, we take a simpler approach:
       // we look for all statuses asserted to be "active", i.e. those with a start time but no end
       // time.
@@ -383,14 +352,6 @@ public class TestCommand implements Command {
                   DirectiveValues.TODO,
                   "Phyloreference is not expected to resolve as it has a status of "
                       + activeStatuses));
-          flagTODO = true;
-        }
-
-        if (!unmatched_specifiers.isEmpty()) {
-          result.setDirective(
-              new Directive(
-                  DirectiveValues.TODO,
-                  "Phyloreference could not be tested, as one or more specifiers did not match."));
           flagTODO = true;
         }
 

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -44,22 +44,6 @@ public class PhylorefHelper {
   public static final IRI IRI_PHYLOREFERENCE =
       IRI.create("http://ontology.phyloref.org/phyloref.owl#Phyloreference");
 
-  /** IRI for the OWL object property indicating which phylogeny a node belongs to */
-  public static final IRI IRI_PHYLOGENY_CONTAINING_NODE =
-      IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#in_phylogeny");
-
-  /** IRI for the OWL data property indicating the label of the expected phyloreference */
-  public static final IRI IRI_NAME_OF_EXPECTED_PHYLOREF =
-      IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#expected_phyloreference_named");
-
-  /** IRI for the OWL object property indicating which specifiers had not been matched */
-  public static final IRI IRI_PHYLOREF_UNMATCHED_SPECIFIER =
-      IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#has_unmatched_specifier");
-
-  /** IRI for the OWL data property with the verbatim clade definition */
-  public static final IRI IRI_CLADE_DEFINITION =
-      IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#clade_definition");
-
   /** IRI for the OBI is_specified_output_of property. */
   public static final IRI IRI_OBI_IS_SPECIFIED_OUTPUT_OF =
       IRI.create("http://purl.obolibrary.org/obo/OBI_0000312");

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -60,6 +60,14 @@ public class PhylorefHelper {
   public static final IRI IRI_CLADE_DEFINITION =
       IRI.create("http://vocab.phyloref.org/phyloref/testcase.owl#clade_definition");
 
+  /** IRI for the OBI is_specified_output_of property. */
+  public static final IRI IRI_OBI_IS_SPECIFIED_OUTPUT_OF =
+      IRI.create("http://purl.obolibrary.org/obo/OBI_0000312");
+
+  /** IRI for the OBI has_specified_input property. */
+  public static final IRI IRI_OBI_HAS_SPECIFIED_INPUT =
+      IRI.create("http://purl.obolibrary.org/obo/OBI_0000293");
+
   /**
    * IRI for the OWL object property that associates a publication with its publication status at a
    * particular time.

--- a/src/test/java/org/phyloref/jphyloref/ResolveCommandTest.java
+++ b/src/test/java/org/phyloref/jphyloref/ResolveCommandTest.java
@@ -25,6 +25,8 @@ class ResolveCommandTest {
 
   private static final String EXPECTED_DUMMY1_RESOLUTION =
       "{\"phylorefs\":{\"#phyloref0\":[\"#phylogeny0_node2\"]}}\n";
+  private static final String EXPECTED_DUMMY1_RESOLUTION_RDF =
+      "{\"phylorefs\":{\"file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref0\":[\"file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2\"]}}\n";
 
   /** Set up input and output streams */
   @BeforeAll
@@ -59,7 +61,7 @@ class ResolveCommandTest {
       }
 
       assertEquals(0, exitCode);
-      assertEquals(EXPECTED_DUMMY1_RESOLUTION, outputStr);
+      assertEquals(EXPECTED_DUMMY1_RESOLUTION_RDF, outputStr);
     }
   }
 

--- a/src/test/java/org/phyloref/jphyloref/ResolveCommandTest.java
+++ b/src/test/java/org/phyloref/jphyloref/ResolveCommandTest.java
@@ -24,7 +24,7 @@ class ResolveCommandTest {
   static ByteArrayOutputStream error = new ByteArrayOutputStream();
 
   private static final String EXPECTED_DUMMY1_RESOLUTION =
-      "{\"phylorefs\":{\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001\":[\"http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2\"]}}\n";
+      "{\"phylorefs\":{\"#phyloref0\":[\"#phylogeny0_node2\"]}}\n";
 
   /** Set up input and output streams */
   @BeforeAll

--- a/src/test/java/org/phyloref/jphyloref/ResolveCommandTest.java
+++ b/src/test/java/org/phyloref/jphyloref/ResolveCommandTest.java
@@ -25,8 +25,6 @@ class ResolveCommandTest {
 
   private static final String EXPECTED_DUMMY1_RESOLUTION =
       "{\"phylorefs\":{\"#phyloref0\":[\"#phylogeny0_node2\"]}}\n";
-  private static final String EXPECTED_DUMMY1_RESOLUTION_RDF =
-      "{\"phylorefs\":{\"file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref0\":[\"file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2\"]}}\n";
 
   /** Set up input and output streams */
   @BeforeAll
@@ -61,7 +59,7 @@ class ResolveCommandTest {
       }
 
       assertEquals(0, exitCode);
-      assertEquals(EXPECTED_DUMMY1_RESOLUTION_RDF, outputStr);
+      assertEquals(EXPECTED_DUMMY1_RESOLUTION, outputStr);
     }
   }
 

--- a/src/test/java/org/phyloref/jphyloref/ResolveCommandTest.java
+++ b/src/test/java/org/phyloref/jphyloref/ResolveCommandTest.java
@@ -59,7 +59,7 @@ class ResolveCommandTest {
       }
 
       assertEquals(0, exitCode);
-      assertEquals(outputStr, EXPECTED_DUMMY1_RESOLUTION);
+      assertEquals(EXPECTED_DUMMY1_RESOLUTION, outputStr);
     }
   }
 

--- a/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
+++ b/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
@@ -90,7 +90,7 @@ class TestCommandTest {
       expectSinglePhylorefResolvingCorrectly(
           "src/test/resources/phylorefs/dummy1.owl",
           "Phyloreference '1'",
-          "file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2",
+          "#phylogeny0_node2",
           outputStr,
           errorStr);
     }

--- a/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
+++ b/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
@@ -90,7 +90,7 @@ class TestCommandTest {
       expectSinglePhylorefResolvingCorrectly(
           "src/test/resources/phylorefs/dummy1.owl",
           "Phyloreference '1'",
-          "#phylogeny0_node2",
+          "file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2",
           outputStr,
           errorStr);
     }
@@ -228,9 +228,13 @@ class TestCommandTest {
                 + testFilename
                 + "\n# Using reasoner: ELK/2016-01-11T13:41:15Z\n"
                 + "ok 1 Phyloreference '1'\n"
-                + "# The following nodes were matched and expected this phyloreference: [1]\n"
+                + "# Resolved nodes: [#phylogeny0_node2]\n"
+                + "# Expected nodes: [#phylogeny0_node2]\n"
                 + "not ok 2 Phyloreference '2'\n"
-                + "# The following nodes were matched but did not expect this phyloreference: [1]\n\n",
+                + "# Resolved nodes: [#phylogeny0_node2]\n"
+                + "# Expected nodes: [#phylogeny0_node1]\n"
+                + "# Some nodes were resolved but were not expected: [<http://example.org/jphyloref#phylogeny0_node2>]\n"
+                + "# Some nodes were expected but were not resolved: [<http://example.org/jphyloref#phylogeny0_node1>]\n\n",
             outputStr);
 
       } catch (UnsupportedEncodingException ex) {

--- a/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
+++ b/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
@@ -42,7 +42,11 @@ class TestCommandTest {
    * succeeded.
    */
   private void expectSinglePhylorefResolvingCorrectly(
-      String filename, String phylorefName, String stdoutStr, String stderrStr) {
+      String filename,
+      String phylorefName,
+      String resolvedNode,
+      String stdoutStr,
+      String stderrStr) {
     assertTrue(
         stderrStr.contains("Input: " + filename),
         "Make sure JPhyloRef reports the name of the file being processed");
@@ -55,7 +59,12 @@ class TestCommandTest {
             + filename
             + "\n# Using reasoner: ELK/2016-01-11T13:41:15Z\nok 1 "
             + phylorefName
-            + "\n# The following nodes were matched and expected this phyloreference: [1]\n\n",
+            + "\n# Resolved nodes: ["
+            + resolvedNode
+            + "]"
+            + "\n# Expected nodes: ["
+            + resolvedNode
+            + "]\n\n",
         stdoutStr);
   }
 
@@ -79,7 +88,11 @@ class TestCommandTest {
 
       assertEquals(0, exitCode);
       expectSinglePhylorefResolvingCorrectly(
-          "src/test/resources/phylorefs/dummy1.owl", "Phyloreference '1'", outputStr, errorStr);
+          "src/test/resources/phylorefs/dummy1.owl",
+          "Phyloreference '1'",
+          "#phylogeny0_node2",
+          outputStr,
+          errorStr);
     }
   }
 
@@ -103,7 +116,11 @@ class TestCommandTest {
 
       assertEquals(0, exitCode);
       expectSinglePhylorefResolvingCorrectly(
-          "src/test/resources/phylorefs/dummy1.jsonld", "Phyloreference '1'", outputStr, errorStr);
+          "src/test/resources/phylorefs/dummy1.jsonld",
+          "Phyloreference '1'",
+          "#phylogeny0_node2",
+          outputStr,
+          errorStr);
       resetIO();
 
       // Run 'test dummy1.txt' with the '--jsonld' option and see if we get the correct response.
@@ -120,7 +137,11 @@ class TestCommandTest {
 
       assertEquals(0, exitCode);
       expectSinglePhylorefResolvingCorrectly(
-          "src/test/resources/phylorefs/dummy1.txt", "Phyloreference '1'", outputStr, errorStr);
+          "src/test/resources/phylorefs/dummy1.txt",
+          "Phyloreference '1'",
+          "#phylogeny0_node2",
+          outputStr,
+          errorStr);
       resetIO();
     }
 
@@ -153,7 +174,8 @@ class TestCommandTest {
 
         // Test whether the exit code, STDERR and STDOUT is as expected.
         assertEquals(0, exitCode);
-        expectSinglePhylorefResolvingCorrectly("-", "Phyloreference '1'", outputStr, errorStr);
+        expectSinglePhylorefResolvingCorrectly(
+            "-", "Phyloreference '1'", "#phylogeny0_node2", outputStr, errorStr);
       } catch (UnsupportedEncodingException ex) {
         // Could be thrown when converting STDOUT/STDERR to String as UTF-8.
         throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);

--- a/src/test/resources/phylorefs/dummy1.json
+++ b/src/test/resources/phylorefs/dummy1.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json",
+    "@context": "http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json",
     "citation": "Dummy phyloreference for testing",
     "phylogenies": [
         {
@@ -13,26 +13,18 @@
             "cladeDefinition": "Node-based, includes C and E, should resolve to (C, D, E) clade.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Cc c"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nameComplete": "Cc c"
+                    }
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Ee e"
-                                }
-                            ]
-                        }
-                    ]
+                  "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                  "hasName": {
+                      "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                      "nameComplete": "Ee e"
+                  }
                 }
             ],
             "externalSpecifiers": []

--- a/src/test/resources/phylorefs/dummy1.jsonld
+++ b/src/test/resources/phylorefs/dummy1.jsonld
@@ -1,509 +1,393 @@
 [
     {
-        "@context": "http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json",
-        "@id": "http://phyloref.org/clade-ontology/clado.owl",
-        "@type": "owl:Ontology",
-        "owl:imports": [
-            "http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl",
-            "http://ontology.phyloref.org/2018-12-14/phyloref.owl",
-            "http://ontology.phyloref.org/2018-12-14/tcan.owl"
-        ]
-    },
-    {
-        "label": "1",
-        "internalSpecifiers": [
+        "@context": "http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json",
+        "citation": "Dummy phyloreference for testing",
+        "phylogenies": [
             {
-                "referencesTaxonomicUnits": [
+                "description": "Dummy phylogeny for testing",
+                "newick": "(Aa_a,(Bb_b,(Cc_c,Dd_d,Ee_e)1)2)3",
+                "@id": "#phylogeny0",
+                "@type": "testcase:PhyloreferenceTestPhylogeny",
+                "nodes": [
                     {
-                        "scientificNames": [
+                        "@id": "#phylogeny0_node0",
+                        "rdf:type": [
                             {
-                                "scientificName": "Cc c"
+                                "@id": "obo:CDAO_0000140"
                             }
                         ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal1_tunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal1",
-                "@type": [
-                    "testcase:Specifier"
-                ]
-            },
-            {
-                "referencesTaxonomicUnits": [
+                        "labels": [
+                            "3"
+                        ],
+                        "representsTaxonomicUnits": [],
+                        "children": [
+                            "#phylogeny0_node1",
+                            "#phylogeny0_node7"
+                        ]
+                    },
                     {
-                        "scientificNames": [
+                        "@id": "#phylogeny0_node1",
+                        "rdf:type": [
                             {
-                                "scientificName": "Ee e"
+                                "@id": "obo:CDAO_0000140"
                             }
                         ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal2_tunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal2",
-                "@type": [
-                    "testcase:Specifier"
-                ]
-            }
-        ],
-        "externalSpecifiers": [],
-        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001",
-        "hasInternalSpecifier": [
-            {
-                "referencesTaxonomicUnits": [
-                    {
-                        "scientificNames": [
-                            {
-                                "scientificName": "Cc c"
-                            }
+                        "labels": [
+                            "2"
                         ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal1_tunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal1",
-                "@type": [
-                    "testcase:Specifier"
-                ]
-            },
-            {
-                "referencesTaxonomicUnits": [
-                    {
-                        "scientificNames": [
-                            {
-                                "scientificName": "Ee e"
-                            }
+                        "representsTaxonomicUnits": [],
+                        "parent": "#phylogeny0_node0",
+                        "siblings": [
+                            "#phylogeny0_node7"
                         ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal2_tunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal2",
-                "@type": [
-                    "testcase:Specifier"
-                ]
-            }
-        ],
-        "hasExternalSpecifier": [],
-        "subClassOf": "phyloref:Phyloreference",
-        "obo:IAO_0000115": "Node-based, includes C and E, should resolve to (C, D, E) clade.",
-        "hasAdditionalClass": [],
-        "equivalentClass": [
-            {
-                "@type": "owl:Restriction",
-                "onProperty": "obo:CDAO_0000149",
-                "someValuesFrom": {
-                    "@type": "owl:Class",
-                    "intersectionOf": [
-                        {
-                            "@type": "owl:Restriction",
-                            "onProperty": "phyloref:excludes_TU",
-                            "someValuesFrom": {
+                        "children": [
+                            "#phylogeny0_node2",
+                            "#phylogeny0_node6"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node2",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            },
+                            {
                                 "@type": "owl:Restriction",
-                                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                "onProperty": "obo:OBI_0000312",
                                 "someValuesFrom": {
                                     "@type": "owl:Class",
                                     "intersectionOf": [
                                         {
-                                            "@id": "obo:NOMEN_0000107"
+                                            "@id": "obo:OBI_0302910"
                                         },
                                         {
                                             "@type": "owl:Restriction",
-                                            "onProperty": "dwc:scientificName",
-                                            "hasValue": "Cc c"
+                                            "onProperty": "obo:OBI_0000293",
+                                            "someValuesFrom": {
+                                                "@id": "#phyloref0"
+                                            }
                                         }
                                     ]
                                 }
                             }
-                        },
-                        {
-                            "@type": "owl:Restriction",
-                            "onProperty": "phyloref:includes_TU",
-                            "someValuesFrom": {
+                        ],
+                        "labels": [
+                            "1"
+                        ],
+                        "representsTaxonomicUnits": [],
+                        "parent": "#phylogeny0_node1",
+                        "siblings": [
+                            "#phylogeny0_node6"
+                        ],
+                        "children": [
+                            "#phylogeny0_node3",
+                            "#phylogeny0_node4",
+                            "#phylogeny0_node5"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node3",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            },
+                            {
                                 "@type": "owl:Restriction",
-                                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                "onProperty": "obo:CDAO_0000187",
                                 "someValuesFrom": {
-                                    "@type": "owl:Class",
-                                    "intersectionOf": [
-                                        {
-                                            "@id": "obo:NOMEN_0000107"
-                                        },
-                                        {
-                                            "@type": "owl:Restriction",
-                                            "onProperty": "dwc:scientificName",
-                                            "hasValue": "Ee e"
-                                        }
-                                    ]
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                        "hasValue": "Ee e"
+                                    }
                                 }
                             }
-                        }
-                    ]
+                        ],
+                        "labels": [
+                            "Ee_e"
+                        ],
+                        "representsTaxonomicUnits": [
+                            {
+                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                                "hasName": {
+                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                                    "label": "Ee_e",
+                                    "nameComplete": "Ee e",
+                                    "genusPart": "Ee",
+                                    "specificEpithet": "e"
+                                },
+                                "label": "Ee_e"
+                            }
+                        ],
+                        "parent": "#phylogeny0_node2",
+                        "siblings": [
+                            "#phylogeny0_node4",
+                            "#phylogeny0_node5"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node4",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            },
+                            {
+                                "@type": "owl:Restriction",
+                                "onProperty": "obo:CDAO_0000187",
+                                "someValuesFrom": {
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                        "hasValue": "Dd d"
+                                    }
+                                }
+                            }
+                        ],
+                        "labels": [
+                            "Dd_d"
+                        ],
+                        "representsTaxonomicUnits": [
+                            {
+                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                                "hasName": {
+                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                                    "label": "Dd_d",
+                                    "nameComplete": "Dd d",
+                                    "genusPart": "Dd",
+                                    "specificEpithet": "d"
+                                },
+                                "label": "Dd_d"
+                            }
+                        ],
+                        "parent": "#phylogeny0_node2",
+                        "siblings": [
+                            "#phylogeny0_node3",
+                            "#phylogeny0_node5"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node5",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            },
+                            {
+                                "@type": "owl:Restriction",
+                                "onProperty": "obo:CDAO_0000187",
+                                "someValuesFrom": {
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                        "hasValue": "Cc c"
+                                    }
+                                }
+                            }
+                        ],
+                        "labels": [
+                            "Cc_c"
+                        ],
+                        "representsTaxonomicUnits": [
+                            {
+                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                                "hasName": {
+                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                                    "label": "Cc_c",
+                                    "nameComplete": "Cc c",
+                                    "genusPart": "Cc",
+                                    "specificEpithet": "c"
+                                },
+                                "label": "Cc_c"
+                            }
+                        ],
+                        "parent": "#phylogeny0_node2",
+                        "siblings": [
+                            "#phylogeny0_node3",
+                            "#phylogeny0_node4"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node6",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            },
+                            {
+                                "@type": "owl:Restriction",
+                                "onProperty": "obo:CDAO_0000187",
+                                "someValuesFrom": {
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                        "hasValue": "Bb b"
+                                    }
+                                }
+                            }
+                        ],
+                        "labels": [
+                            "Bb_b"
+                        ],
+                        "representsTaxonomicUnits": [
+                            {
+                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                                "hasName": {
+                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                                    "label": "Bb_b",
+                                    "nameComplete": "Bb b",
+                                    "genusPart": "Bb",
+                                    "specificEpithet": "b"
+                                },
+                                "label": "Bb_b"
+                            }
+                        ],
+                        "parent": "#phylogeny0_node1",
+                        "siblings": [
+                            "#phylogeny0_node2"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node7",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            },
+                            {
+                                "@type": "owl:Restriction",
+                                "onProperty": "obo:CDAO_0000187",
+                                "someValuesFrom": {
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                        "hasValue": "Aa a"
+                                    }
+                                }
+                            }
+                        ],
+                        "labels": [
+                            "Aa_a"
+                        ],
+                        "representsTaxonomicUnits": [
+                            {
+                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                                "hasName": {
+                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                                    "label": "Aa_a",
+                                    "nameComplete": "Aa a",
+                                    "genusPart": "Aa",
+                                    "specificEpithet": "a"
+                                },
+                                "label": "Aa_a"
+                            }
+                        ],
+                        "parent": "#phylogeny0_node0",
+                        "siblings": [
+                            "#phylogeny0_node1"
+                        ]
+                    }
+                ],
+                "hasRootNode": {
+                    "@id": "#phylogeny0_node0"
                 }
             }
         ],
-        "@context": "http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json"
-    },
-    {
-        "description": "Dummy phylogeny for testing",
-        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002",
-        "@type": "testcase:PhyloreferenceTestPhylogeny",
-        "nodes": [
+        "phylorefs": [
             {
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node0",
-                "labels": [
-                    "3"
-                ],
-                "representsTaxonomicUnits": [],
-                "children": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1",
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node7"
-                ],
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                "label": "1",
+                "cladeDefinition": "Node-based, includes C and E, should resolve to (C, D, E) clade.",
+                "internalSpecifiers": [
                     {
-                        "@id": "http://purl.obolibrary.org/obo/CDAO_0000140"
-                    }
-                ]
-            },
-            {
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1",
-                "labels": [
-                    "2"
-                ],
-                "representsTaxonomicUnits": [],
-                "parent": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node0",
-                "siblings": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node7"
-                ],
-                "children": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2",
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node6"
-                ],
-                "obo:CDAO_0000179": {
-                    "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node0"
-                },
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                    {
-                        "@id": "http://purl.obolibrary.org/obo/CDAO_0000140"
-                    }
-                ]
-            },
-            {
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2",
-                "labels": [
-                    "1"
-                ],
-                "representsTaxonomicUnits": [],
-                "parent": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1",
-                "siblings": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node6"
-                ],
-                "children": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node3",
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node4",
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node5"
-                ],
-                "obo:CDAO_0000179": {
-                    "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1"
-                },
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                    {
-                        "@id": "http://purl.obolibrary.org/obo/CDAO_0000140"
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                        "hasName": {
+                            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                            "label": "Cc c",
+                            "nameComplete": "Cc c",
+                            "genusPart": "Cc",
+                            "specificEpithet": "c"
+                        },
+                        "label": "Cc c"
                     },
                     {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                        "hasName": {
+                            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                            "label": "Dd d",
+                            "nameComplete": "Dd d",
+                            "genusPart": "Dd",
+                            "specificEpithet": "d"
+                        },
+                        "label": "Dd d"
+                    }
+                ],
+                "externalSpecifiers": [],
+                "@id": "#phyloref0",
+                "@type": "owl:Class",
+                "subClassOf": "phyloref:Phyloreference",
+                "hasAdditionalClass": [],
+                "equivalentClass": [
+                    {
                         "@type": "owl:Restriction",
-                        "onProperty": "obo:OBI_0000312",
+                        "onProperty": "obo:CDAO_0000149",
                         "someValuesFrom": {
                             "@type": "owl:Class",
                             "intersectionOf": [
                                 {
-                                    "@id": "obo:OBI_0302910"
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "phyloref:excludes_TU",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                        "someValuesFrom": {
+                                            "@type": "owl:Restriction",
+                                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                            "hasValue": "Cc c"
+                                        }
+                                    }
                                 },
                                 {
                                     "@type": "owl:Restriction",
-                                    "onProperty": "obo:OBI_0000293",
+                                    "onProperty": "phyloref:includes_TU",
                                     "someValuesFrom": {
-                                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001"
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                        "someValuesFrom": {
+                                            "@type": "owl:Restriction",
+                                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                            "hasValue": "Dd d"
+                                        }
                                     }
                                 }
                             ]
                         }
                     }
                 ]
-            },
-            {
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node3",
-                "labels": [
-                    "Ee_e"
-                ],
-                "representsTaxonomicUnits": [
-                    {
-                        "scientificNames": [
-                            {
-                                "scientificName": "Ee e",
-                                "binomialName": "Ee e",
-                                "genus": "Ee",
-                                "specificEpithet": "e"
-                            }
-                        ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node3_taxonomicunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "parent": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2",
-                "siblings": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node4",
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node5"
-                ],
-                "obo:CDAO_0000179": {
-                    "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2"
-                },
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                    {
-                        "@id": "http://purl.obolibrary.org/obo/CDAO_0000140"
-                    },
-                    {
-                        "@type": "owl:Restriction",
-                        "onProperty": "obo:CDAO_0000187",
-                        "someValuesFrom": {
-                            "@type": "owl:Restriction",
-                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                            "someValuesFrom": {
-                                "@type": "owl:Class",
-                                "intersectionOf": [
-                                    {
-                                        "@id": "obo:NOMEN_0000107"
-                                    },
-                                    {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "dwc:scientificName",
-                                        "hasValue": "Ee e"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                ]
-            },
-            {
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node4",
-                "labels": [
-                    "Dd_d"
-                ],
-                "representsTaxonomicUnits": [
-                    {
-                        "scientificNames": [
-                            {
-                                "scientificName": "Dd d",
-                                "binomialName": "Dd d",
-                                "genus": "Dd",
-                                "specificEpithet": "d"
-                            }
-                        ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node4_taxonomicunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "parent": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2",
-                "siblings": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node3",
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node5"
-                ],
-                "obo:CDAO_0000179": {
-                    "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2"
-                },
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                    {
-                        "@id": "http://purl.obolibrary.org/obo/CDAO_0000140"
-                    },
-                    {
-                        "@type": "owl:Restriction",
-                        "onProperty": "obo:CDAO_0000187",
-                        "someValuesFrom": {
-                            "@type": "owl:Restriction",
-                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                            "someValuesFrom": {
-                                "@type": "owl:Class",
-                                "intersectionOf": [
-                                    {
-                                        "@id": "obo:NOMEN_0000107"
-                                    },
-                                    {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "dwc:scientificName",
-                                        "hasValue": "Dd d"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                ]
-            },
-            {
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node5",
-                "labels": [
-                    "Cc_c"
-                ],
-                "representsTaxonomicUnits": [
-                    {
-                        "scientificNames": [
-                            {
-                                "scientificName": "Cc c",
-                                "binomialName": "Cc c",
-                                "genus": "Cc",
-                                "specificEpithet": "c"
-                            }
-                        ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node5_taxonomicunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "parent": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2",
-                "siblings": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node3",
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node4"
-                ],
-                "obo:CDAO_0000179": {
-                    "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2"
-                },
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                    {
-                        "@id": "http://purl.obolibrary.org/obo/CDAO_0000140"
-                    },
-                    {
-                        "@type": "owl:Restriction",
-                        "onProperty": "obo:CDAO_0000187",
-                        "someValuesFrom": {
-                            "@type": "owl:Restriction",
-                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                            "someValuesFrom": {
-                                "@type": "owl:Class",
-                                "intersectionOf": [
-                                    {
-                                        "@id": "obo:NOMEN_0000107"
-                                    },
-                                    {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "dwc:scientificName",
-                                        "hasValue": "Cc c"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                ]
-            },
-            {
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node6",
-                "labels": [
-                    "Bb_b"
-                ],
-                "representsTaxonomicUnits": [
-                    {
-                        "scientificNames": [
-                            {
-                                "scientificName": "Bb b",
-                                "binomialName": "Bb b",
-                                "genus": "Bb",
-                                "specificEpithet": "b"
-                            }
-                        ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node6_taxonomicunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "parent": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1",
-                "siblings": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2"
-                ],
-                "obo:CDAO_0000179": {
-                    "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1"
-                },
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                    {
-                        "@id": "http://purl.obolibrary.org/obo/CDAO_0000140"
-                    },
-                    {
-                        "@type": "owl:Restriction",
-                        "onProperty": "obo:CDAO_0000187",
-                        "someValuesFrom": {
-                            "@type": "owl:Restriction",
-                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                            "someValuesFrom": {
-                                "@type": "owl:Class",
-                                "intersectionOf": [
-                                    {
-                                        "@id": "obo:NOMEN_0000107"
-                                    },
-                                    {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "dwc:scientificName",
-                                        "hasValue": "Bb b"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                ]
-            },
-            {
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node7",
-                "labels": [
-                    "Aa_a"
-                ],
-                "representsTaxonomicUnits": [
-                    {
-                        "scientificNames": [
-                            {
-                                "scientificName": "Aa a",
-                                "binomialName": "Aa a",
-                                "genus": "Aa",
-                                "specificEpithet": "a"
-                            }
-                        ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node7_taxonomicunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "parent": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node0",
-                "siblings": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1"
-                ],
-                "obo:CDAO_0000179": {
-                    "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node0"
-                },
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                    {
-                        "@id": "http://purl.obolibrary.org/obo/CDAO_0000140"
-                    },
-                    {
-                        "@type": "owl:Restriction",
-                        "onProperty": "obo:CDAO_0000187",
-                        "someValuesFrom": {
-                            "@type": "owl:Restriction",
-                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                            "someValuesFrom": {
-                                "@type": "owl:Class",
-                                "intersectionOf": [
-                                    {
-                                        "@id": "obo:NOMEN_0000107"
-                                    },
-                                    {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "dwc:scientificName",
-                                        "hasValue": "Aa a"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                ]
             }
         ],
-        "hasRootNode": {
-            "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node0"
-        },
-        "phyloref:newick_expression": "(Aa_a, (Bb_b, (Cc_c, Dd_d, Ee_e)1)2)3",
-        "@context": "http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json"
+        "hasTaxonomicUnitMatches": [],
+        "@id": "",
+        "@type": [
+            "testcase:PhyloreferenceTestCase",
+            "owl:Ontology"
+        ],
+        "owl:imports": [
+            "http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl",
+            "http://ontology.phyloref.org/2018-12-14/phyloref.owl",
+            "http://ontology.phyloref.org/2018-12-14/tcan.owl"
+        ]
     }
 ]

--- a/src/test/resources/phylorefs/dummy1.jsonld
+++ b/src/test/resources/phylorefs/dummy1.jsonld
@@ -1,393 +1,380 @@
-[
+{
+  "@context": "http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json",
+  "citation": "Dummy phyloreference for testing",
+  "phylogenies": [
     {
-        "@context": "http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json",
-        "citation": "Dummy phyloreference for testing",
-        "phylogenies": [
+      "description": "Dummy phylogeny for testing",
+      "newick": "(Aa_a, (Bb_b, (Cc_c, Dd_d, Ee_e)1)2)3",
+      "@id": "#phylogeny0",
+      "@type": "testcase:PhyloreferenceTestPhylogeny",
+      "nodes": [
+        {
+          "@id": "#phylogeny0_node0",
+          "rdf:type": [
             {
-                "description": "Dummy phylogeny for testing",
-                "newick": "(Aa_a,(Bb_b,(Cc_c,Dd_d,Ee_e)1)2)3",
-                "@id": "#phylogeny0",
-                "@type": "testcase:PhyloreferenceTestPhylogeny",
-                "nodes": [
-                    {
-                        "@id": "#phylogeny0_node0",
-                        "rdf:type": [
-                            {
-                                "@id": "obo:CDAO_0000140"
-                            }
-                        ],
-                        "labels": [
-                            "3"
-                        ],
-                        "representsTaxonomicUnits": [],
-                        "children": [
-                            "#phylogeny0_node1",
-                            "#phylogeny0_node7"
-                        ]
-                    },
-                    {
-                        "@id": "#phylogeny0_node1",
-                        "rdf:type": [
-                            {
-                                "@id": "obo:CDAO_0000140"
-                            }
-                        ],
-                        "labels": [
-                            "2"
-                        ],
-                        "representsTaxonomicUnits": [],
-                        "parent": "#phylogeny0_node0",
-                        "siblings": [
-                            "#phylogeny0_node7"
-                        ],
-                        "children": [
-                            "#phylogeny0_node2",
-                            "#phylogeny0_node6"
-                        ]
-                    },
-                    {
-                        "@id": "#phylogeny0_node2",
-                        "rdf:type": [
-                            {
-                                "@id": "obo:CDAO_0000140"
-                            },
-                            {
-                                "@type": "owl:Restriction",
-                                "onProperty": "obo:OBI_0000312",
-                                "someValuesFrom": {
-                                    "@type": "owl:Class",
-                                    "intersectionOf": [
-                                        {
-                                            "@id": "obo:OBI_0302910"
-                                        },
-                                        {
-                                            "@type": "owl:Restriction",
-                                            "onProperty": "obo:OBI_0000293",
-                                            "someValuesFrom": {
-                                                "@id": "#phyloref0"
-                                            }
-                                        }
-                                    ]
-                                }
-                            }
-                        ],
-                        "labels": [
-                            "1"
-                        ],
-                        "representsTaxonomicUnits": [],
-                        "parent": "#phylogeny0_node1",
-                        "siblings": [
-                            "#phylogeny0_node6"
-                        ],
-                        "children": [
-                            "#phylogeny0_node3",
-                            "#phylogeny0_node4",
-                            "#phylogeny0_node5"
-                        ]
-                    },
-                    {
-                        "@id": "#phylogeny0_node3",
-                        "rdf:type": [
-                            {
-                                "@id": "obo:CDAO_0000140"
-                            },
-                            {
-                                "@type": "owl:Restriction",
-                                "onProperty": "obo:CDAO_0000187",
-                                "someValuesFrom": {
-                                    "@type": "owl:Restriction",
-                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                                    "someValuesFrom": {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
-                                        "hasValue": "Ee e"
-                                    }
-                                }
-                            }
-                        ],
-                        "labels": [
-                            "Ee_e"
-                        ],
-                        "representsTaxonomicUnits": [
-                            {
-                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                                "hasName": {
-                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
-                                    "label": "Ee_e",
-                                    "nameComplete": "Ee e",
-                                    "genusPart": "Ee",
-                                    "specificEpithet": "e"
-                                },
-                                "label": "Ee_e"
-                            }
-                        ],
-                        "parent": "#phylogeny0_node2",
-                        "siblings": [
-                            "#phylogeny0_node4",
-                            "#phylogeny0_node5"
-                        ]
-                    },
-                    {
-                        "@id": "#phylogeny0_node4",
-                        "rdf:type": [
-                            {
-                                "@id": "obo:CDAO_0000140"
-                            },
-                            {
-                                "@type": "owl:Restriction",
-                                "onProperty": "obo:CDAO_0000187",
-                                "someValuesFrom": {
-                                    "@type": "owl:Restriction",
-                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                                    "someValuesFrom": {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
-                                        "hasValue": "Dd d"
-                                    }
-                                }
-                            }
-                        ],
-                        "labels": [
-                            "Dd_d"
-                        ],
-                        "representsTaxonomicUnits": [
-                            {
-                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                                "hasName": {
-                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
-                                    "label": "Dd_d",
-                                    "nameComplete": "Dd d",
-                                    "genusPart": "Dd",
-                                    "specificEpithet": "d"
-                                },
-                                "label": "Dd_d"
-                            }
-                        ],
-                        "parent": "#phylogeny0_node2",
-                        "siblings": [
-                            "#phylogeny0_node3",
-                            "#phylogeny0_node5"
-                        ]
-                    },
-                    {
-                        "@id": "#phylogeny0_node5",
-                        "rdf:type": [
-                            {
-                                "@id": "obo:CDAO_0000140"
-                            },
-                            {
-                                "@type": "owl:Restriction",
-                                "onProperty": "obo:CDAO_0000187",
-                                "someValuesFrom": {
-                                    "@type": "owl:Restriction",
-                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                                    "someValuesFrom": {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
-                                        "hasValue": "Cc c"
-                                    }
-                                }
-                            }
-                        ],
-                        "labels": [
-                            "Cc_c"
-                        ],
-                        "representsTaxonomicUnits": [
-                            {
-                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                                "hasName": {
-                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
-                                    "label": "Cc_c",
-                                    "nameComplete": "Cc c",
-                                    "genusPart": "Cc",
-                                    "specificEpithet": "c"
-                                },
-                                "label": "Cc_c"
-                            }
-                        ],
-                        "parent": "#phylogeny0_node2",
-                        "siblings": [
-                            "#phylogeny0_node3",
-                            "#phylogeny0_node4"
-                        ]
-                    },
-                    {
-                        "@id": "#phylogeny0_node6",
-                        "rdf:type": [
-                            {
-                                "@id": "obo:CDAO_0000140"
-                            },
-                            {
-                                "@type": "owl:Restriction",
-                                "onProperty": "obo:CDAO_0000187",
-                                "someValuesFrom": {
-                                    "@type": "owl:Restriction",
-                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                                    "someValuesFrom": {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
-                                        "hasValue": "Bb b"
-                                    }
-                                }
-                            }
-                        ],
-                        "labels": [
-                            "Bb_b"
-                        ],
-                        "representsTaxonomicUnits": [
-                            {
-                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                                "hasName": {
-                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
-                                    "label": "Bb_b",
-                                    "nameComplete": "Bb b",
-                                    "genusPart": "Bb",
-                                    "specificEpithet": "b"
-                                },
-                                "label": "Bb_b"
-                            }
-                        ],
-                        "parent": "#phylogeny0_node1",
-                        "siblings": [
-                            "#phylogeny0_node2"
-                        ]
-                    },
-                    {
-                        "@id": "#phylogeny0_node7",
-                        "rdf:type": [
-                            {
-                                "@id": "obo:CDAO_0000140"
-                            },
-                            {
-                                "@type": "owl:Restriction",
-                                "onProperty": "obo:CDAO_0000187",
-                                "someValuesFrom": {
-                                    "@type": "owl:Restriction",
-                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                                    "someValuesFrom": {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
-                                        "hasValue": "Aa a"
-                                    }
-                                }
-                            }
-                        ],
-                        "labels": [
-                            "Aa_a"
-                        ],
-                        "representsTaxonomicUnits": [
-                            {
-                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                                "hasName": {
-                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
-                                    "label": "Aa_a",
-                                    "nameComplete": "Aa a",
-                                    "genusPart": "Aa",
-                                    "specificEpithet": "a"
-                                },
-                                "label": "Aa_a"
-                            }
-                        ],
-                        "parent": "#phylogeny0_node0",
-                        "siblings": [
-                            "#phylogeny0_node1"
-                        ]
-                    }
-                ],
-                "hasRootNode": {
-                    "@id": "#phylogeny0_node0"
-                }
+              "@id": "obo:CDAO_0000140"
             }
-        ],
-        "phylorefs": [
+          ],
+          "labels": [
+            "3"
+          ],
+          "representsTaxonomicUnits": [],
+          "children": [
+            "#phylogeny0_node1",
+            "#phylogeny0_node7"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node1",
+          "rdf:type": [
             {
-                "label": "1",
-                "cladeDefinition": "Node-based, includes C and E, should resolve to (C, D, E) clade.",
-                "internalSpecifiers": [
-                    {
-                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                        "hasName": {
-                            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
-                            "label": "Cc c",
-                            "nameComplete": "Cc c",
-                            "genusPart": "Cc",
-                            "specificEpithet": "c"
-                        },
-                        "label": "Cc c"
-                    },
-                    {
-                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                        "hasName": {
-                            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
-                            "label": "Dd d",
-                            "nameComplete": "Dd d",
-                            "genusPart": "Dd",
-                            "specificEpithet": "d"
-                        },
-                        "label": "Dd d"
-                    }
-                ],
-                "externalSpecifiers": [],
-                "@id": "#phyloref0",
+              "@id": "obo:CDAO_0000140"
+            }
+          ],
+          "labels": [
+            "2"
+          ],
+          "representsTaxonomicUnits": [],
+          "parent": "#phylogeny0_node0",
+          "siblings": [
+            "#phylogeny0_node7"
+          ],
+          "children": [
+            "#phylogeny0_node2",
+            "#phylogeny0_node6"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node2",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:OBI_0000312",
+              "someValuesFrom": {
                 "@type": "owl:Class",
-                "subClassOf": "phyloref:Phyloreference",
-                "hasAdditionalClass": [],
-                "equivalentClass": [
-                    {
-                        "@type": "owl:Restriction",
-                        "onProperty": "obo:CDAO_0000149",
-                        "someValuesFrom": {
-                            "@type": "owl:Class",
-                            "intersectionOf": [
-                                {
-                                    "@type": "owl:Restriction",
-                                    "onProperty": "phyloref:excludes_TU",
-                                    "someValuesFrom": {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                                        "someValuesFrom": {
-                                            "@type": "owl:Restriction",
-                                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
-                                            "hasValue": "Cc c"
-                                        }
-                                    }
-                                },
-                                {
-                                    "@type": "owl:Restriction",
-                                    "onProperty": "phyloref:includes_TU",
-                                    "someValuesFrom": {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                                        "someValuesFrom": {
-                                            "@type": "owl:Restriction",
-                                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
-                                            "hasValue": "Dd d"
-                                        }
-                                    }
-                                }
-                            ]
-                        }
+                "intersectionOf": [
+                  {
+                    "@id": "obo:OBI_0302910"
+                  },
+                  {
+                    "@type": "owl:Restriction",
+                    "onProperty": "obo:OBI_0000293",
+                    "someValuesFrom": {
+                      "@id": "#phyloref0"
                     }
+                  }
                 ]
+              }
             }
-        ],
-        "hasTaxonomicUnitMatches": [],
-        "@id": "",
-        "@type": [
-            "testcase:PhyloreferenceTestCase",
-            "owl:Ontology"
-        ],
-        "owl:imports": [
-            "http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl",
-            "http://ontology.phyloref.org/2018-12-14/phyloref.owl",
-            "http://ontology.phyloref.org/2018-12-14/tcan.owl"
-        ]
+          ],
+          "labels": [
+            "1"
+          ],
+          "representsTaxonomicUnits": [],
+          "parent": "#phylogeny0_node1",
+          "siblings": [
+            "#phylogeny0_node6"
+          ],
+          "children": [
+            "#phylogeny0_node3",
+            "#phylogeny0_node4",
+            "#phylogeny0_node5"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node3",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Ee e"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Ee_e"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Ee_e",
+                "nameComplete": "Ee e",
+                "genusPart": "Ee",
+                "specificEpithet": "e"
+              },
+              "label": "Ee_e"
+            }
+          ],
+          "parent": "#phylogeny0_node2",
+          "siblings": [
+            "#phylogeny0_node4",
+            "#phylogeny0_node5"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node4",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Dd d"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Dd_d"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Dd_d",
+                "nameComplete": "Dd d",
+                "genusPart": "Dd",
+                "specificEpithet": "d"
+              },
+              "label": "Dd_d"
+            }
+          ],
+          "parent": "#phylogeny0_node2",
+          "siblings": [
+            "#phylogeny0_node3",
+            "#phylogeny0_node5"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node5",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Cc c"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Cc_c"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Cc_c",
+                "nameComplete": "Cc c",
+                "genusPart": "Cc",
+                "specificEpithet": "c"
+              },
+              "label": "Cc_c"
+            }
+          ],
+          "parent": "#phylogeny0_node2",
+          "siblings": [
+            "#phylogeny0_node3",
+            "#phylogeny0_node4"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node6",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Bb b"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Bb_b"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Bb_b",
+                "nameComplete": "Bb b",
+                "genusPart": "Bb",
+                "specificEpithet": "b"
+              },
+              "label": "Bb_b"
+            }
+          ],
+          "parent": "#phylogeny0_node1",
+          "siblings": [
+            "#phylogeny0_node2"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node7",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Aa a"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Aa_a"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Aa_a",
+                "nameComplete": "Aa a",
+                "genusPart": "Aa",
+                "specificEpithet": "a"
+              },
+              "label": "Aa_a"
+            }
+          ],
+          "parent": "#phylogeny0_node0",
+          "siblings": [
+            "#phylogeny0_node1"
+          ]
+        }
+      ],
+      "hasRootNode": {
+        "@id": "#phylogeny0_node0"
+      }
     }
-]
+  ],
+  "phylorefs": [
+    {
+      "label": "1",
+      "cladeDefinition": "Node-based, includes C and E, should resolve to (C, D, E) clade.",
+      "internalSpecifiers": [
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nameComplete": "Cc c"
+          }
+        },
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nameComplete": "Ee e"
+          }
+        }
+      ],
+      "externalSpecifiers": [],
+      "@id": "#phyloref0",
+      "@type": "owl:Class",
+      "subClassOf": "phyloref:Phyloreference",
+      "hasAdditionalClass": [],
+      "equivalentClass": [
+        {
+          "@type": "owl:Restriction",
+          "onProperty": "obo:CDAO_0000149",
+          "someValuesFrom": {
+            "@type": "owl:Class",
+            "intersectionOf": [
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:excludes_TU",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                    "hasValue": "Cc c"
+                  }
+                }
+              },
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:includes_TU",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                    "hasValue": "Ee e"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "hasTaxonomicUnitMatches": [],
+  "@type": [
+    "testcase:PhyloreferenceTestCase",
+    "owl:Ontology"
+  ],
+  "owl:imports": [
+    "http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl",
+    "http://ontology.phyloref.org/2018-12-14/phyloref.owl",
+    "http://ontology.phyloref.org/2018-12-14/tcan.owl"
+  ]
+}

--- a/src/test/resources/phylorefs/dummy1.owl
+++ b/src/test/resources/phylorefs/dummy1.owl
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
-   xmlns="http://example.org/jphyloref-test-dummy1"
    xmlns:dwc="http://rs.tdwg.org/dwc/terms/"
    xmlns:ns1="http://rs.tdwg.org/ontology/voc/TaxonName#"
    xmlns:ns2="http://rs.tdwg.org/ontology/voc/TaxonConcept#"

--- a/src/test/resources/phylorefs/dummy1.owl
+++ b/src/test/resources/phylorefs/dummy1.owl
@@ -1,405 +1,341 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
-   xmlns:ns1="http://purl.obolibrary.org/obo/"
-   xmlns:ns2="http://www.w3.org/2002/07/owl#"
+   xmlns:ns1="http://www.w3.org/2002/07/owl#"
+   xmlns:ns2="http://purl.obolibrary.org/obo/"
    xmlns:ns3="http://vocab.phyloref.org/phyloref/testcase.owl#"
-   xmlns:ns4="http://ontology.phyloref.org/phyloref.owl#"
-   xmlns:ns5="http://rs.tdwg.org/dwc/terms/"
+   xmlns:ns4="http://rs.tdwg.org/ontology/voc/TaxonConcept#"
+   xmlns:ns5="http://ontology.phyloref.org/phyloref.owl#"
+   xmlns:ns6="http://rs.tdwg.org/ontology/voc/TaxonName#"
+   xmlns:ns7="http://rs.tdwg.org/dwc/terms/"
+   xmlns:ns8="http://purl.org/opentree/nexson#"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 >
-  <rdf:Description rdf:nodeID="Ncf6f46f5de5342d8b30da3a00c355245">
-    <ns2:onProperty rdf:resource="http://ontology.phyloref.org/phyloref.owl#includes_TU"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns2:someValuesFrom rdf:nodeID="Nb72df789288e4ee0835e0d04c523db3d"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Ncd94fb264ee5463795c0d87808077e83">
-    <ns5:scientificName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb b</ns5:scientificName>
-    <ns5:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">b</ns5:specificEpithet>
-    <ns5:genus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb</ns5:genus>
-    <ns3:has_binomial_name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb b</ns3:has_binomial_name>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N259f0746e6ff40a28bd8e8aa72aa3f7b">
-    <ns5:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a</ns5:specificEpithet>
-    <ns3:has_binomial_name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa a</ns3:has_binomial_name>
-    <ns5:genus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa</ns5:genus>
-    <ns5:scientificName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa a</ns5:scientificName>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N5ba12ce90d5a468fbbe7450d0e2747e6">
-    <ns2:someValuesFrom rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001"/>
-    <ns2:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000293"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node7">
-    <ns1:CDAO_0000187 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node7_taxonomicunit0"/>
-    <rdf:type rdf:nodeID="Nf8782f0b61a241bbaf1921c710dcbd3a"/>
+  <rdf:Description rdf:about="#phylogeny0_node3">
+    <ns2:CDAO_0000187 rdf:nodeID="Nf31c776d807d4fa38cdf42737dd86ce4"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee_e</rdfs:label>
+    <ns5:has_Sibling rdf:resource="#phylogeny0_node5"/>
+    <rdf:type rdf:nodeID="N673f80827c864e2dbd291da3925a9ab2"/>
     <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa_a</rdfs:label>
-    <ns1:CDAO_0000179 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node0"/>
-    <ns4:has_Sibling rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1"/>
+    <ns5:has_Sibling rdf:resource="#phylogeny0_node4"/>
+    <ns2:CDAO_0000179 rdf:resource="#phylogeny0_node2"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="N7f7f06a4c00d48e6802ffea71e670c26">
-    <ns2:intersectionOf rdf:nodeID="N037ccc44a4d34a51a1b4c8f05c149a49"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  <rdf:Description rdf:about="#phylogeny0_node5">
+    <ns2:CDAO_0000187 rdf:nodeID="N2844acfaede143a0be97c9fe5dcf8f09"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc_c</rdfs:label>
+    <ns5:has_Sibling rdf:resource="#phylogeny0_node4"/>
+    <rdf:type rdf:nodeID="Ncfe0edde0bdd4573a85941a4b81b9f86"/>
+    <ns2:CDAO_0000179 rdf:resource="#phylogeny0_node2"/>
+    <ns5:has_Sibling rdf:resource="#phylogeny0_node3"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node3_taxonomicunit0">
-    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000138"/>
-    <ns3:has_scientific_name rdf:nodeID="Ne8f8adb25d2845b8aac092a39555f00a"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nce75b1fa90be418bb167c8af38b794a8">
-    <rdf:rest rdf:nodeID="Nebb1eba1f2af4884abc5c5c8ced5290f"/>
-    <rdf:first rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000107"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nde74f40c31384723a3f0f004abebe86c">
-    <ns2:someValuesFrom rdf:nodeID="Nd5fd5b24d59c43e7a96567f05505a995"/>
+  <rdf:Description rdf:nodeID="Ncfe0edde0bdd4573a85941a4b81b9f86">
+    <ns1:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns2:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
+    <ns1:someValuesFrom rdf:nodeID="Nfe7e684923d3473d890b2775aabe644f"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001">
-    <ns3:has_internal_specifier rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal1"/>
-    <ns3:has_internal_specifier rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal2"/>
+  <rdf:Description rdf:nodeID="N7963c7c155654bc6980c080601e824d4">
+    <ns1:someValuesFrom rdf:resource="#phyloref0"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <ns1:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000293"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Neca9377caa2e4f3ea05cc187aaed60ea">
+    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <ns1:someValuesFrom rdf:nodeID="Ne89067c9e94d4d56a2acfd438c32428c"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N3033c138eba7496da82b5106bce79e64">
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb_b</rdfs:label>
+    <ns4:hasName rdf:nodeID="Nb1bcae3c80f2417fa386816ffaa1e5e4"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N58790a746d9a4f398cdacc6ca437ba8b">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <ns1:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</ns1:hasValue>
+    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N65c81f30906c4270a9fdc2e94b9d7737">
+    <ns6:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</ns6:nameComplete>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</rdfs:label>
+    <ns6:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
+    <ns7:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">c</ns7:specificEpithet>
+  </rdf:Description>
+  <rdf:Description rdf:about="#phylogeny0">
+    <ns5:newick_expression rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(Aa_a,(Bb_b,(Cc_c,Dd_d,Ee_e)X)Y)Z</ns5:newick_expression>
+    <ns3:has_node rdf:resource="#phylogeny0_node0"/>
+    <ns3:has_node rdf:resource="#phylogeny0_node5"/>
+    <ns3:has_node rdf:resource="#phylogeny0_node4"/>
+    <ns3:has_root_node rdf:resource="#phylogeny0_node0"/>
+    <ns3:has_node rdf:resource="#phylogeny0_node7"/>
+    <ns3:has_node rdf:resource="#phylogeny0_node6"/>
+    <ns3:has_node rdf:resource="#phylogeny0_node1"/>
+    <ns3:has_node rdf:resource="#phylogeny0_node2"/>
+    <ns3:has_node rdf:resource="#phylogeny0_node3"/>
+    <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#PhyloreferenceTestPhylogeny"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N2844acfaede143a0be97c9fe5dcf8f09">
+    <ns4:hasName rdf:nodeID="N02367d5eb53c4d2a9a768cb710fe69db"/>
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc_c</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N37ca6c0a6ccb47aebd1c65cef82897f4">
+    <ns1:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000149"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <ns1:someValuesFrom rdf:nodeID="N2166d2aa9f794829971af87d0b3e1abf"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N37f6c342d8c142809889b123c0967719">
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd_d</rdfs:label>
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+    <ns4:hasName rdf:nodeID="Ncbd4c7d5bad84643aec6495cb40b5a8c"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="#phylogeny0_node7">
+    <ns2:CDAO_0000179 rdf:resource="#phylogeny0_node0"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa_a</rdfs:label>
+    <ns5:has_Sibling rdf:resource="#phylogeny0_node1"/>
+    <rdf:type rdf:nodeID="N2ea025d94c764f4c9e6b0d54e527b3f1"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+    <ns2:CDAO_0000187 rdf:nodeID="N3d88693567e54a73ab43bee033f85439"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///home/vaidyagi/code/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld">
+    <ns8:studyPublicationReference>Dummy phyloreference for testing</ns8:studyPublicationReference>
+    <ns1:imports rdf:resource="http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl"/>
+    <ns1:imports rdf:resource="http://ontology.phyloref.org/2018-12-14/tcan.owl"/>
+    <ns1:imports rdf:resource="http://ontology.phyloref.org/2018-12-14/phyloref.owl"/>
+    <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#PhyloreferenceTestCase"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
+    <ns3:has_phylogeny rdf:resource="#phylogeny0"/>
+    <ns3:has_phyloreference rdf:resource="#phyloref0"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nf66c8d8bb83648138b7639c004927a9a">
+    <ns1:someValuesFrom rdf:nodeID="N4bba2db301564031a924003f96e06b96"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <ns1:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="#phyloref0">
+    <ns3:internal_specifier rdf:nodeID="N720d70cfd43d4260ae64f9cc00a4fa73"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <ns1:equivalentClass rdf:nodeID="N37ca6c0a6ccb47aebd1c65cef82897f4"/>
+    <ns2:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Node-based, includes C and E, should resolve to (C, D, E) clade.</ns2:IAO_0000115>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</rdfs:label>
-    <ns1:IAO_0000115>Node-based, includes C and E, should resolve to (C, D, E) clade.</ns1:IAO_0000115>
-    <ns2:equivalentClass rdf:nodeID="N526e2d46810d4184b6bf07d1abdc22e4"/>
+    <ns3:internal_specifier rdf:nodeID="Nb11f2aab73d34b05a5477d8b0cffc30d"/>
     <rdfs:subClassOf rdf:resource="http://ontology.phyloref.org/phyloref.owl#Phyloreference"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002">
-    <ns3:has_node rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1"/>
-    <ns3:has_root_node rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node0"/>
-    <ns3:has_node rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node3"/>
-    <ns3:has_node rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node4"/>
-    <ns3:has_node rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node7"/>
-    <ns3:has_node rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node6"/>
-    <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#PhyloreferenceTestPhylogeny"/>
-    <ns3:has_node rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node5"/>
-    <ns3:has_node rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node0"/>
-    <ns4:newick_expression>(Aa_a, (Bb_b, (Cc_c, Dd_d, Ee_e)1)2)3</ns4:newick_expression>
-    <ns3:has_node rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N037ccc44a4d34a51a1b4c8f05c149a49">
-    <rdf:first rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000107"/>
-    <rdf:rest rdf:nodeID="Nfcc3c3452e22485c98b1706773a8607d"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nf705fa0f1dab4e0c8f0252b363994441">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns2:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</ns2:hasValue>
-    <ns2:onProperty rdf:resource="http://rs.tdwg.org/dwc/terms/scientificName"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N526e2d46810d4184b6bf07d1abdc22e4">
-    <ns2:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000149"/>
-    <ns2:someValuesFrom rdf:nodeID="N63baac2b126442f6af2eed4267a2f809"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N8313ca8e878547cc8ebca665d2895bfa">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns2:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
-    <ns2:someValuesFrom rdf:nodeID="Na136dc4692494d66b13ad5891417e70c"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node5">
-    <ns4:has_Sibling rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node4"/>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc_c</rdfs:label>
-    <rdf:type rdf:nodeID="Nc892bdcc67c64a1f8c217e9fe4f92900"/>
-    <ns1:CDAO_0000179 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2"/>
-    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <ns4:has_Sibling rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node3"/>
-    <ns1:CDAO_0000187 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node5_taxonomicunit0"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2">
-    <ns4:has_Sibling rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node6"/>
-    <ns1:CDAO_0000149 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node5"/>
-    <ns1:CDAO_0000179 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1"/>
-    <rdf:type rdf:nodeID="Nde74f40c31384723a3f0f004abebe86c"/>
-    <ns1:CDAO_0000149 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node3"/>
-    <ns1:CDAO_0000149 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node4"/>
+  <rdf:Description rdf:about="#phylogeny0_node2">
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</rdfs:label>
     <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+    <ns5:has_Sibling rdf:resource="#phylogeny0_node6"/>
+    <rdf:type rdf:nodeID="Nf66c8d8bb83648138b7639c004927a9a"/>
+    <ns2:CDAO_0000149 rdf:resource="#phylogeny0_node3"/>
+    <ns2:CDAO_0000179 rdf:resource="#phylogeny0_node1"/>
+    <ns2:CDAO_0000149 rdf:resource="#phylogeny0_node5"/>
+    <ns2:CDAO_0000149 rdf:resource="#phylogeny0_node4"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node4_taxonomicunit0">
-    <ns3:has_scientific_name rdf:nodeID="Na1cb5da2f1b84cda92a3ea2a78d5dd08"/>
-    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000138"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N112f4d4c21dc4df38152d4b493372123">
-    <ns2:someValuesFrom rdf:nodeID="N11d09f9096fd414298ec4d29fb471e1e"/>
+  <rdf:Description rdf:nodeID="Na96c45d73cb24becae85b9e5e07c4d39">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns2:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
+    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
+    <ns1:someValuesFrom rdf:nodeID="N58790a746d9a4f398cdacc6ca437ba8b"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="N85e8996c2ed142b7938acd66554b65cb">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns2:onProperty rdf:resource="http://ontology.phyloref.org/phyloref.owl#excludes_TU"/>
-    <ns2:someValuesFrom rdf:nodeID="Nd9c51972e411499f9c99e47e5cae9d9b"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N655635437520433999a830d88cb04968">
-    <rdf:first rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000107"/>
-    <rdf:rest rdf:nodeID="N672d86bab01d4e1392ead995d722cec6"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N8e4903ba01214bdf9a3b0113f992d583">
-    <ns2:intersectionOf rdf:nodeID="N655635437520433999a830d88cb04968"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node4">
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd_d</rdfs:label>
-    <rdf:type rdf:nodeID="Ne1754ff9d1394eb2b83c44f60833aa40"/>
-    <ns1:CDAO_0000187 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node4_taxonomicunit0"/>
+  <rdf:Description rdf:about="#phylogeny0_node6">
+    <ns2:CDAO_0000179 rdf:resource="#phylogeny0_node1"/>
+    <ns2:CDAO_0000187 rdf:nodeID="N3033c138eba7496da82b5106bce79e64"/>
     <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <ns4:has_Sibling rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node5"/>
-    <ns4:has_Sibling rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node3"/>
-    <ns1:CDAO_0000179 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nfcc3c3452e22485c98b1706773a8607d">
-    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
-    <rdf:first rdf:nodeID="Nf705fa0f1dab4e0c8f0252b363994441"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nd9c51972e411499f9c99e47e5cae9d9b">
-    <ns2:someValuesFrom rdf:nodeID="Nec8d384bd94a45e1a1be29617a7fdd57"/>
-    <ns2:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nc892bdcc67c64a1f8c217e9fe4f92900">
-    <ns2:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
-    <ns2:someValuesFrom rdf:nodeID="Ncc95385b220e477187e18c08a48f1515"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nf5adbcd749e64f84b3314d557e8ab34f">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <ns2:intersectionOf rdf:nodeID="N9b1fbf5071ec480b8b7b56a19fd332c6"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Naa75160a4df241b0ab2d7c757ab1e6a7">
-    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
-    <rdf:first rdf:nodeID="Ne5a5db2a894349d5bb92ef59c99eb29d"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nf8782f0b61a241bbaf1921c710dcbd3a">
-    <ns2:someValuesFrom rdf:nodeID="N8313ca8e878547cc8ebca665d2895bfa"/>
-    <ns2:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nd4e14212d5a044e4b52ab2eb5c05bc33">
-    <rdf:first rdf:nodeID="N5ba12ce90d5a468fbbe7450d0e2747e6"/>
-    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N6ff38edd60914c33841d0f3e40980716">
-    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
-    <rdf:first rdf:nodeID="N63b25432fe824cab98aff0e23ded4e18"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node5_taxonomicunit0">
-    <ns3:has_scientific_name rdf:nodeID="N19f2f4599b0a495492acee6162b8dc48"/>
-    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000138"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Ne5a5db2a894349d5bb92ef59c99eb29d">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns2:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</ns2:hasValue>
-    <ns2:onProperty rdf:resource="http://rs.tdwg.org/dwc/terms/scientificName"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N88c6194479b946d198d9832c1e6ffe2d">
-    <ns2:someValuesFrom rdf:nodeID="Nbec04c0080ce4ec7ae1216c35aaeb88b"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns2:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Ne1754ff9d1394eb2b83c44f60833aa40">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns2:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
-    <ns2:someValuesFrom rdf:nodeID="N88c6194479b946d198d9832c1e6ffe2d"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N48521fb93d7a437fb74687ab571f4d21">
-    <rdf:rest rdf:nodeID="Naa75160a4df241b0ab2d7c757ab1e6a7"/>
-    <rdf:first rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000107"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N655c300e430e4f558177e36049cff479">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns2:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa a</ns2:hasValue>
-    <ns2:onProperty rdf:resource="http://rs.tdwg.org/dwc/terms/scientificName"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nfbde52ede42d42758a9ff128d35d69a8">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns2:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb b</ns2:hasValue>
-    <ns2:onProperty rdf:resource="http://rs.tdwg.org/dwc/terms/scientificName"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N19f2f4599b0a495492acee6162b8dc48">
-    <ns5:scientificName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</ns5:scientificName>
-    <ns3:has_binomial_name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</ns3:has_binomial_name>
-    <ns5:genus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc</ns5:genus>
-    <ns5:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">c</ns5:specificEpithet>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nbec04c0080ce4ec7ae1216c35aaeb88b">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <ns2:intersectionOf rdf:nodeID="Nd863b9a86f9f479e81ea354f6a02d65d"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal2">
-    <ns3:references_taxonomic_unit rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal2_tunit0"/>
-    <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#Specifier"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node0">
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</rdfs:label>
-    <ns1:CDAO_0000149 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1"/>
-    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <ns1:CDAO_0000149 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node7"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Neaedf3a72ddf4f3bbf79f0c936dfbb4e">
-    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
-    <rdf:first rdf:nodeID="N97b7ef5f353e4173a389ca1050a5f872"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node6">
-    <ns1:CDAO_0000187 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node6_taxonomicunit0"/>
-    <rdf:type rdf:nodeID="N371c0422bb3e459d8c4856b75caab1d8"/>
-    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <ns4:has_Sibling rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2"/>
-    <ns1:CDAO_0000179 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1"/>
+    <rdf:type rdf:nodeID="Nfaa4441010b44bb589e2f5ccef9f94aa"/>
+    <ns5:has_Sibling rdf:resource="#phylogeny0_node2"/>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb_b</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node6_taxonomicunit0">
-    <ns3:has_scientific_name rdf:nodeID="Ncd94fb264ee5463795c0d87808077e83"/>
-    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000138"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nebb1eba1f2af4884abc5c5c8ced5290f">
-    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
-    <rdf:first rdf:nodeID="Nfbde52ede42d42758a9ff128d35d69a8"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N97b7ef5f353e4173a389ca1050a5f872">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns2:onProperty rdf:resource="http://rs.tdwg.org/dwc/terms/scientificName"/>
-    <ns2:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee e</ns2:hasValue>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Ne33ef0e2bc8b4c3d906b5f88e2021d2e">
-    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
-    <rdf:first rdf:nodeID="N655c300e430e4f558177e36049cff479"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N0d09f6e904794fd79a3c8d60f6d66637">
-    <ns2:intersectionOf rdf:nodeID="Nce75b1fa90be418bb167c8af38b794a8"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1">
-    <ns1:CDAO_0000149 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2"/>
-    <ns1:CDAO_0000179 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node0"/>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2</rdfs:label>
-    <ns4:has_Sibling rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node7"/>
-    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <ns1:CDAO_0000149 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node6"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N63b25432fe824cab98aff0e23ded4e18">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns2:onProperty rdf:resource="http://rs.tdwg.org/dwc/terms/scientificName"/>
-    <ns2:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</ns2:hasValue>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl">
-    <ns2:imports rdf:resource="http://ontology.phyloref.org/2018-12-14/tcan.owl"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
-    <ns2:imports rdf:resource="http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl"/>
-    <ns2:imports rdf:resource="http://ontology.phyloref.org/2018-12-14/phyloref.owl"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N821df74e0bea4f1c948d1b41cf7f85d4">
-    <rdf:rest rdf:nodeID="Nfa8e973acfce4b4f83128e3a46ff5f1b"/>
-    <rdf:first rdf:nodeID="N85e8996c2ed142b7938acd66554b65cb"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node3">
-    <ns1:CDAO_0000187 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node3_taxonomicunit0"/>
-    <ns4:has_Sibling rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node4"/>
+  <rdf:Description rdf:nodeID="N0a889ec4f7a347b291d67c9636032b2f">
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee_e</rdfs:label>
-    <rdf:type rdf:nodeID="N112f4d4c21dc4df38152d4b493372123"/>
-    <ns1:CDAO_0000179 rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2"/>
+    <ns6:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
+    <ns6:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee e</ns6:nameComplete>
+    <ns7:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">e</ns7:specificEpithet>
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Naea3f5f05f1b491b83846addf5440314">
+    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <ns1:someValuesFrom rdf:nodeID="N39d0966386714cb9902528703ca91a07"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nb1bcae3c80f2417fa386816ffaa1e5e4">
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb_b</rdfs:label>
+    <ns7:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">b</ns7:specificEpithet>
+    <ns6:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb b</ns6:nameComplete>
+    <ns6:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N02aeb8b086b74e9e8d88f5d3bc961d5f">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <ns1:someValuesFrom rdf:nodeID="Na96c45d73cb24becae85b9e5e07c4d39"/>
+    <ns1:onProperty rdf:resource="http://ontology.phyloref.org/phyloref.owl#excludes_TU"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="#phylogeny0_node1">
     <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <ns4:has_Sibling rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node5"/>
+    <ns5:has_Sibling rdf:resource="#phylogeny0_node7"/>
+    <ns2:CDAO_0000149 rdf:resource="#phylogeny0_node6"/>
+    <ns2:CDAO_0000179 rdf:resource="#phylogeny0_node0"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2</rdfs:label>
+    <ns2:CDAO_0000149 rdf:resource="#phylogeny0_node2"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="Na1cb5da2f1b84cda92a3ea2a78d5dd08">
-    <ns5:genus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd</ns5:genus>
-    <ns5:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">d</ns5:specificEpithet>
-    <ns5:scientificName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</ns5:scientificName>
-    <ns3:has_binomial_name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</ns3:has_binomial_name>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nad5556f7fc97448099df1137be54d27f">
+  <rdf:Description rdf:nodeID="N39d0966386714cb9902528703ca91a07">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns2:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee e</ns2:hasValue>
-    <ns2:onProperty rdf:resource="http://rs.tdwg.org/dwc/terms/scientificName"/>
+    <ns1:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb b</ns1:hasValue>
+    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="Nd863b9a86f9f479e81ea354f6a02d65d">
-    <rdf:rest rdf:nodeID="N6ff38edd60914c33841d0f3e40980716"/>
-    <rdf:first rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000107"/>
+  <rdf:Description rdf:nodeID="Nd5b56a4da0b24423b774169f50722e92">
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
+    <ns6:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</ns6:nameComplete>
+    <ns7:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">d</ns7:specificEpithet>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</rdfs:label>
+    <ns6:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="Ncc95385b220e477187e18c08a48f1515">
-    <ns2:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
-    <ns2:someValuesFrom rdf:nodeID="N7f7f06a4c00d48e6802ffea71e670c26"/>
+  <rdf:Description rdf:nodeID="Nb72d1e0c2cfd40dd8ecda763bb8af11d">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
+    <ns1:someValuesFrom rdf:nodeID="N02348986775847a6af735fc4b164fff9"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="#phylogeny0_node4">
+    <ns5:has_Sibling rdf:resource="#phylogeny0_node5"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+    <ns2:CDAO_0000187 rdf:nodeID="N37f6c342d8c142809889b123c0967719"/>
+    <rdf:type rdf:nodeID="N46d7c2621330443db664119f937730cc"/>
+    <ns2:CDAO_0000179 rdf:resource="#phylogeny0_node2"/>
+    <ns5:has_Sibling rdf:resource="#phylogeny0_node3"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd_d</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N02348986775847a6af735fc4b164fff9">
+    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <ns1:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee e</ns1:hasValue>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nfe7e684923d3473d890b2775aabe644f">
+    <ns1:someValuesFrom rdf:nodeID="Nc3350abb8fde45b6bf08ac1a1e70eba7"/>
+    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="N2a893a2d0d4f4dd5b6bee5cd142388a1">
-    <ns2:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
-    <ns2:someValuesFrom rdf:nodeID="N0d09f6e904794fd79a3c8d60f6d66637"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  <rdf:Description rdf:about="#phylogeny0_node0">
+    <ns2:CDAO_0000149 rdf:resource="#phylogeny0_node7"/>
+    <ns2:CDAO_0000149 rdf:resource="#phylogeny0_node1"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="N371c0422bb3e459d8c4856b75caab1d8">
-    <ns2:someValuesFrom rdf:nodeID="N2a893a2d0d4f4dd5b6bee5cd142388a1"/>
-    <ns2:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
+  <rdf:Description rdf:nodeID="N01a8cc63e42f4027bff96b18c6296540">
+    <ns1:someValuesFrom rdf:nodeID="N7e250018e4704deb996ff212bc26be81"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="N672d86bab01d4e1392ead995d722cec6">
+  <rdf:Description rdf:nodeID="Nfaa4441010b44bb589e2f5ccef9f94aa">
+    <ns1:someValuesFrom rdf:nodeID="Naea3f5f05f1b491b83846addf5440314"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <ns1:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N720d70cfd43d4260ae64f9cc00a4fa73">
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</rdfs:label>
+    <ns4:hasName rdf:nodeID="Nd5b56a4da0b24423b774169f50722e92"/>
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N3d88693567e54a73ab43bee033f85439">
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+    <ns4:hasName rdf:nodeID="N794f519b938044d38ff041fe59f7e2b9"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa_a</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N02367d5eb53c4d2a9a768cb710fe69db">
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc_c</rdfs:label>
+    <ns6:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</ns6:nameComplete>
+    <ns6:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
+    <ns7:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">c</ns7:specificEpithet>
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nc35b24e70193404ebe068f52dc02c47d">
+    <rdf:rest rdf:nodeID="Nfaf54d387a84444ea14ea2fa52ff7ff5"/>
+    <rdf:first rdf:nodeID="N02aeb8b086b74e9e8d88f5d3bc961d5f"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nfaf54d387a84444ea14ea2fa52ff7ff5">
+    <rdf:first rdf:nodeID="N657cc0e52f394b87bb7f7726c9acda7a"/>
     <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
-    <rdf:first rdf:nodeID="Nad5556f7fc97448099df1137be54d27f"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="N62b70f3dfad54cd88f61bc05b4471d77">
-    <ns5:scientificName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</ns5:scientificName>
+  <rdf:Description rdf:nodeID="Ncbd4c7d5bad84643aec6495cb40b5a8c">
+    <ns6:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
+    <ns6:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</ns6:nameComplete>
+    <ns7:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">d</ns7:specificEpithet>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd_d</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="Nd5fd5b24d59c43e7a96567f05505a995">
-    <ns2:intersectionOf rdf:nodeID="Naf6331727f7248aea6df78172d6f3327"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  <rdf:Description rdf:nodeID="N2ea025d94c764f4c9e6b0d54e527b3f1">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <ns1:someValuesFrom rdf:nodeID="N01a8cc63e42f4027bff96b18c6296540"/>
+    <ns1:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="N9b1fbf5071ec480b8b7b56a19fd332c6">
-    <rdf:first rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000107"/>
-    <rdf:rest rdf:nodeID="Neaedf3a72ddf4f3bbf79f0c936dfbb4e"/>
+  <rdf:Description rdf:nodeID="Nc3350abb8fde45b6bf08ac1a1e70eba7">
+    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <ns1:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</ns1:hasValue>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="Naf6331727f7248aea6df78172d6f3327">
-    <rdf:rest rdf:nodeID="Nd4e14212d5a044e4b52ab2eb5c05bc33"/>
+  <rdf:Description rdf:nodeID="Nd54bf386b9c243d7aa28e6a11c65f7ca">
+    <rdf:rest rdf:nodeID="N2fe57724c4d14a3b8c36eb037e3673bd"/>
     <rdf:first rdf:resource="http://purl.obolibrary.org/obo/OBI_0302910"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal2_tunit0">
-    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000138"/>
-    <ns3:has_scientific_name rdf:nodeID="N77a283e5b22f4c7aa76f347be64f9183"/>
+  <rdf:Description rdf:nodeID="N794f519b938044d38ff041fe59f7e2b9">
+    <ns6:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
+    <ns7:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a</ns7:specificEpithet>
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa_a</rdfs:label>
+    <ns6:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa a</ns6:nameComplete>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="Na136dc4692494d66b13ad5891417e70c">
-    <ns2:intersectionOf rdf:nodeID="N61f94942ef004dc8b0b46b3556f15f30"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  <rdf:Description rdf:nodeID="N673f80827c864e2dbd291da3925a9ab2">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <ns1:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
+    <ns1:someValuesFrom rdf:nodeID="Nb72d1e0c2cfd40dd8ecda763bb8af11d"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="Ne8f8adb25d2845b8aac092a39555f00a">
-    <ns5:scientificName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee e</ns5:scientificName>
-    <ns5:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">e</ns5:specificEpithet>
-    <ns3:has_binomial_name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee e</ns3:has_binomial_name>
-    <ns5:genus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee</ns5:genus>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal1_tunit0">
-    <ns3:has_scientific_name rdf:nodeID="N62b70f3dfad54cd88f61bc05b4471d77"/>
-    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000138"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nb72df789288e4ee0835e0d04c523db3d">
-    <ns2:someValuesFrom rdf:nodeID="N8e4903ba01214bdf9a3b0113f992d583"/>
-    <ns2:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
+  <rdf:Description rdf:nodeID="Nf7048925f7b04c12bf2accad40de0a9b">
+    <ns1:someValuesFrom rdf:nodeID="N1f5539d21daa4b1eb498ae8408b38209"/>
+    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node7_taxonomicunit0">
-    <ns3:has_scientific_name rdf:nodeID="N259f0746e6ff40a28bd8e8aa72aa3f7b"/>
-    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000138"/>
+  <rdf:Description rdf:nodeID="N46d7c2621330443db664119f937730cc">
+    <ns1:someValuesFrom rdf:nodeID="Neca9377caa2e4f3ea05cc187aaed60ea"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <ns1:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="N61f94942ef004dc8b0b46b3556f15f30">
-    <rdf:rest rdf:nodeID="Ne33ef0e2bc8b4c3d906b5f88e2021d2e"/>
-    <rdf:first rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000107"/>
+  <rdf:Description rdf:nodeID="Nb11f2aab73d34b05a5477d8b0cffc30d">
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+    <ns4:hasName rdf:nodeID="N65c81f30906c4270a9fdc2e94b9d7737"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="Nfa8e973acfce4b4f83128e3a46ff5f1b">
+  <rdf:Description rdf:nodeID="N1f5539d21daa4b1eb498ae8408b38209">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
+    <ns1:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</ns1:hasValue>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N2fe57724c4d14a3b8c36eb037e3673bd">
     <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
-    <rdf:first rdf:nodeID="Ncf6f46f5de5342d8b30da3a00c355245"/>
+    <rdf:first rdf:nodeID="N7963c7c155654bc6980c080601e824d4"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="N11d09f9096fd414298ec4d29fb471e1e">
+  <rdf:Description rdf:nodeID="N657cc0e52f394b87bb7f7726c9acda7a">
+    <ns1:someValuesFrom rdf:nodeID="Nf7048925f7b04c12bf2accad40de0a9b"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns2:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
-    <ns2:someValuesFrom rdf:nodeID="Nf5adbcd749e64f84b3314d557e8ab34f"/>
+    <ns1:onProperty rdf:resource="http://ontology.phyloref.org/phyloref.owl#includes_TU"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="Nec8d384bd94a45e1a1be29617a7fdd57">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <ns2:intersectionOf rdf:nodeID="N48521fb93d7a437fb74687ab571f4d21"/>
+  <rdf:Description rdf:nodeID="Ne89067c9e94d4d56a2acfd438c32428c">
+    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
+    <ns1:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</ns1:hasValue>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal1">
-    <ns3:references_taxonomic_unit rdf:resource="http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal1_tunit0"/>
-    <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#Specifier"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N63baac2b126442f6af2eed4267a2f809">
-    <ns2:intersectionOf rdf:nodeID="N821df74e0bea4f1c948d1b41cf7f85d4"/>
+  <rdf:Description rdf:nodeID="N4bba2db301564031a924003f96e06b96">
+    <ns1:intersectionOf rdf:nodeID="Nd54bf386b9c243d7aa28e6a11c65f7ca"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="N77a283e5b22f4c7aa76f347be64f9183">
-    <ns5:scientificName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee e</ns5:scientificName>
+  <rdf:Description rdf:nodeID="N2166d2aa9f794829971af87d0b3e1abf">
+    <ns1:intersectionOf rdf:nodeID="Nc35b24e70193404ebe068f52dc02c47d"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N7e250018e4704deb996ff212bc26be81">
+    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
+    <ns1:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa a</ns1:hasValue>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nf31c776d807d4fa38cdf42737dd86ce4">
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee_e</rdfs:label>
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+    <ns4:hasName rdf:nodeID="N0a889ec4f7a347b291d67c9636032b2f"/>
   </rdf:Description>
 </rdf:RDF>

--- a/src/test/resources/phylorefs/dummy1.owl
+++ b/src/test/resources/phylorefs/dummy1.owl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
+   xmlns="http://example.org/jphyloref-test-dummy1"
    xmlns:dwc="http://rs.tdwg.org/dwc/terms/"
    xmlns:ns1="http://rs.tdwg.org/ontology/voc/TaxonName#"
    xmlns:ns2="http://rs.tdwg.org/ontology/voc/TaxonConcept#"
@@ -11,13 +12,13 @@
    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
    xmlns:testcase="http://vocab.phyloref.org/phyloref/testcase.owl#"
 >
-  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node5">
-    <obo:CDAO_0000179 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2"/>
+  <rdf:Description rdf:about="#phylogeny0_node5">
+    <obo:CDAO_0000179 rdf:resource="#phylogeny0_node2"/>
     <obo:CDAO_0000187 rdf:nodeID="N50286511daa9461baf2e1bd1dbc42a76"/>
     <rdf:type rdf:nodeID="Ncd0b3127b3f246159933ab17fe43103e"/>
-    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node4"/>
+    <phyloref:has_Sibling rdf:resource="#phylogeny0_node4"/>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc_c</rdfs:label>
-    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node3"/>
+    <phyloref:has_Sibling rdf:resource="#phylogeny0_node3"/>
     <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
   </rdf:Description>
   <rdf:Description rdf:nodeID="N21dc675474324a3ca8d6d794f6c16306">
@@ -38,7 +39,7 @@
     <ns1:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
     <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
   </rdf:Description>
-  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref0">
+  <rdf:Description rdf:about="#phyloref0">
     <rdfs:subClassOf rdf:resource="http://ontology.phyloref.org/phyloref.owl#Phyloreference"/>
     <testcase:internal_specifier rdf:nodeID="N475c97f1ee8244869ee8ca23600d907c"/>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</rdfs:label>
@@ -47,37 +48,37 @@
     <owl:equivalentClass rdf:nodeID="Nb361e884855a4498b9728ad8f5a798cb"/>
     <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Node-based, includes C and E, should resolve to (C, D, E) clade.</obo:IAO_0000115>
   </rdf:Description>
-  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2">
-    <obo:CDAO_0000149 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node3"/>
+  <rdf:Description rdf:about="#phylogeny0_node2">
+    <obo:CDAO_0000149 rdf:resource="#phylogeny0_node3"/>
     <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <obo:CDAO_0000149 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node4"/>
-    <obo:CDAO_0000149 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node5"/>
-    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node6"/>
+    <obo:CDAO_0000149 rdf:resource="#phylogeny0_node4"/>
+    <obo:CDAO_0000149 rdf:resource="#phylogeny0_node5"/>
+    <phyloref:has_Sibling rdf:resource="#phylogeny0_node6"/>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</rdfs:label>
     <rdf:type rdf:nodeID="N2d6dfe5fc05a4a1f8d61d316de50c79c"/>
-    <obo:CDAO_0000179 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node1"/>
+    <obo:CDAO_0000179 rdf:resource="#phylogeny0_node1"/>
   </rdf:Description>
   <rdf:Description rdf:nodeID="Ncd0b3127b3f246159933ab17fe43103e">
     <owl:someValuesFrom rdf:nodeID="N3c77b9d699a949108444226360c6ad4d"/>
     <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
   </rdf:Description>
-  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node7">
-    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node1"/>
+  <rdf:Description rdf:about="#phylogeny0_node7">
+    <phyloref:has_Sibling rdf:resource="#phylogeny0_node1"/>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa_a</rdfs:label>
     <obo:CDAO_0000187 rdf:nodeID="Ne4346cb347104b90af66f788a9fcea7f"/>
-    <obo:CDAO_0000179 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node0"/>
+    <obo:CDAO_0000179 rdf:resource="#phylogeny0_node0"/>
     <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
     <rdf:type rdf:nodeID="N757b154d50464b14a76f6521ee0eed60"/>
   </rdf:Description>
-  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node3">
+  <rdf:Description rdf:about="#phylogeny0_node3">
     <rdf:type rdf:nodeID="N411c3d2b75cf43c9a8a59ec5f87be486"/>
     <obo:CDAO_0000187 rdf:nodeID="Neecad25a9fb54815ae366ed8cad53706"/>
-    <obo:CDAO_0000179 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2"/>
+    <obo:CDAO_0000179 rdf:resource="#phylogeny0_node2"/>
     <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node5"/>
+    <phyloref:has_Sibling rdf:resource="#phylogeny0_node5"/>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee_e</rdfs:label>
-    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node4"/>
+    <phyloref:has_Sibling rdf:resource="#phylogeny0_node4"/>
   </rdf:Description>
   <rdf:Description rdf:nodeID="Ne4346cb347104b90af66f788a9fcea7f">
     <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
@@ -89,18 +90,18 @@
     <owl:someValuesFrom rdf:nodeID="Nbdfd836174dc42ce8d8d8d2fdd47ccd7"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
   </rdf:Description>
-  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0">
-    <testcase:has_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node6"/>
-    <testcase:has_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node7"/>
-    <testcase:has_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node3"/>
-    <testcase:has_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node4"/>
-    <testcase:has_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node5"/>
+  <rdf:Description rdf:about="#phylogeny0">
+    <testcase:has_node rdf:resource="#phylogeny0_node6"/>
+    <testcase:has_node rdf:resource="#phylogeny0_node7"/>
+    <testcase:has_node rdf:resource="#phylogeny0_node3"/>
+    <testcase:has_node rdf:resource="#phylogeny0_node4"/>
+    <testcase:has_node rdf:resource="#phylogeny0_node5"/>
     <phyloref:newick_expression rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(Aa_a, (Bb_b, (Cc_c, Dd_d, Ee_e)1)2)3</phyloref:newick_expression>
-    <testcase:has_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node0"/>
-    <testcase:has_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2"/>
+    <testcase:has_node rdf:resource="#phylogeny0_node0"/>
+    <testcase:has_node rdf:resource="#phylogeny0_node2"/>
     <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#PhyloreferenceTestPhylogeny"/>
-    <testcase:has_root_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node0"/>
-    <testcase:has_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node1"/>
+    <testcase:has_root_node rdf:resource="#phylogeny0_node0"/>
+    <testcase:has_node rdf:resource="#phylogeny0_node1"/>
   </rdf:Description>
   <rdf:Description rdf:nodeID="Nf81c6ce94e4843b3ba39d9316423e8c8">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
@@ -112,22 +113,22 @@
     <owl:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee e</owl:hasValue>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
   </rdf:Description>
-  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node0">
+  <rdf:Description rdf:about="#phylogeny0_node0">
     <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <obo:CDAO_0000149 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node7"/>
-    <obo:CDAO_0000149 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node1"/>
+    <obo:CDAO_0000149 rdf:resource="#phylogeny0_node7"/>
+    <obo:CDAO_0000149 rdf:resource="#phylogeny0_node1"/>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:nodeID="N475c97f1ee8244869ee8ca23600d907c">
     <ns2:hasName rdf:nodeID="N9054b41ff5db4a109dd44fd89402a902"/>
     <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
   </rdf:Description>
-  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node1">
-    <obo:CDAO_0000179 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node0"/>
-    <obo:CDAO_0000149 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2"/>
-    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node7"/>
+  <rdf:Description rdf:about="#phylogeny0_node1">
+    <obo:CDAO_0000179 rdf:resource="#phylogeny0_node0"/>
+    <obo:CDAO_0000149 rdf:resource="#phylogeny0_node2"/>
+    <phyloref:has_Sibling rdf:resource="#phylogeny0_node7"/>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2</rdfs:label>
-    <obo:CDAO_0000149 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node6"/>
+    <obo:CDAO_0000149 rdf:resource="#phylogeny0_node6"/>
     <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
   </rdf:Description>
   <rdf:Description rdf:nodeID="Ne961b24ed802407eb8cdd3e57f4c6e7f">
@@ -140,7 +141,7 @@
   <rdf:Description rdf:nodeID="N9fbd2039a3b649409d6c4f6e5b879bda">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
     <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000293"/>
-    <owl:someValuesFrom rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref0"/>
+    <owl:someValuesFrom rdf:resource="#phyloref0"/>
   </rdf:Description>
   <rdf:Description rdf:nodeID="Neecad25a9fb54815ae366ed8cad53706">
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee_e</rdfs:label>
@@ -163,8 +164,8 @@
     <owl:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
   </rdf:Description>
   <rdf:Description rdf:nodeID="N770bec34455f4a728018936ce284756c">
-    <testcase:has_phyloreference rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref0"/>
-    <testcase:has_phylogeny rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0"/>
+    <testcase:has_phyloreference rdf:resource="#phyloref0"/>
+    <testcase:has_phylogeny rdf:resource="#phylogeny0"/>
     <owl:imports rdf:resource="http://ontology.phyloref.org/2018-12-14/phyloref.owl"/>
     <owl:imports rdf:resource="http://ontology.phyloref.org/2018-12-14/tcan.owl"/>
     <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#PhyloreferenceTestCase"/>
@@ -182,12 +183,12 @@
     <owl:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
     <owl:someValuesFrom rdf:nodeID="N1640e782d42b4929a9b669553f226b03"/>
   </rdf:Description>
-  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node6">
+  <rdf:Description rdf:about="#phylogeny0_node6">
     <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
     <obo:CDAO_0000187 rdf:nodeID="N5f8395cc7ac149db8305a61f9f6c9fa8"/>
-    <obo:CDAO_0000179 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node1"/>
+    <obo:CDAO_0000179 rdf:resource="#phylogeny0_node1"/>
     <rdf:type rdf:nodeID="N068a3af710b24327b1a47c38e89245dc"/>
-    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2"/>
+    <phyloref:has_Sibling rdf:resource="#phylogeny0_node2"/>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb_b</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:nodeID="N757b154d50464b14a76f6521ee0eed60">
@@ -297,14 +298,14 @@
     <rdf:first rdf:resource="http://purl.obolibrary.org/obo/OBI_0302910"/>
     <rdf:rest rdf:nodeID="Nfa7688e0bd924fe6a6ea56063713648e"/>
   </rdf:Description>
-  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node4">
-    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node3"/>
+  <rdf:Description rdf:about="#phylogeny0_node4">
+    <phyloref:has_Sibling rdf:resource="#phylogeny0_node3"/>
     <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <obo:CDAO_0000179 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2"/>
+    <obo:CDAO_0000179 rdf:resource="#phylogeny0_node2"/>
     <obo:CDAO_0000187 rdf:nodeID="N45edb26335da457a9c7b8319fbd2f86c"/>
     <rdf:type rdf:nodeID="Ne5704532ac804df5a8f254a2f9c1a050"/>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd_d</rdfs:label>
-    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node5"/>
+    <phyloref:has_Sibling rdf:resource="#phylogeny0_node5"/>
   </rdf:Description>
   <rdf:Description rdf:nodeID="Nd5e2488796784c5c95a92c9ced95c82b">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>

--- a/src/test/resources/phylorefs/dummy1.owl
+++ b/src/test/resources/phylorefs/dummy1.owl
@@ -1,341 +1,333 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
-   xmlns:ns1="http://www.w3.org/2002/07/owl#"
-   xmlns:ns2="http://purl.obolibrary.org/obo/"
-   xmlns:ns3="http://vocab.phyloref.org/phyloref/testcase.owl#"
-   xmlns:ns4="http://rs.tdwg.org/ontology/voc/TaxonConcept#"
-   xmlns:ns5="http://ontology.phyloref.org/phyloref.owl#"
-   xmlns:ns6="http://rs.tdwg.org/ontology/voc/TaxonName#"
-   xmlns:ns7="http://rs.tdwg.org/dwc/terms/"
-   xmlns:ns8="http://purl.org/opentree/nexson#"
+   xmlns:dwc="http://rs.tdwg.org/dwc/terms/"
+   xmlns:ns1="http://rs.tdwg.org/ontology/voc/TaxonName#"
+   xmlns:ns2="http://rs.tdwg.org/ontology/voc/TaxonConcept#"
+   xmlns:obo="http://purl.obolibrary.org/obo/"
+   xmlns:ot="http://purl.org/opentree/nexson#"
+   xmlns:owl="http://www.w3.org/2002/07/owl#"
+   xmlns:phyloref="http://ontology.phyloref.org/phyloref.owl#"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+   xmlns:testcase="http://vocab.phyloref.org/phyloref/testcase.owl#"
 >
-  <rdf:Description rdf:about="#phylogeny0_node3">
-    <ns2:CDAO_0000187 rdf:nodeID="Nf31c776d807d4fa38cdf42737dd86ce4"/>
+  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node5">
+    <obo:CDAO_0000179 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2"/>
+    <obo:CDAO_0000187 rdf:nodeID="N50286511daa9461baf2e1bd1dbc42a76"/>
+    <rdf:type rdf:nodeID="Ncd0b3127b3f246159933ab17fe43103e"/>
+    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node4"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc_c</rdfs:label>
+    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node3"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N21dc675474324a3ca8d6d794f6c16306">
+    <ns1:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
+    <ns1:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee e</ns1:nameComplete>
+    <dwc:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">e</dwc:specificEpithet>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee_e</rdfs:label>
-    <ns5:has_Sibling rdf:resource="#phylogeny0_node5"/>
-    <rdf:type rdf:nodeID="N673f80827c864e2dbd291da3925a9ab2"/>
-    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <ns5:has_Sibling rdf:resource="#phylogeny0_node4"/>
-    <ns2:CDAO_0000179 rdf:resource="#phylogeny0_node2"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="#phylogeny0_node5">
-    <ns2:CDAO_0000187 rdf:nodeID="N2844acfaede143a0be97c9fe5dcf8f09"/>
-    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc_c</rdfs:label>
-    <ns5:has_Sibling rdf:resource="#phylogeny0_node4"/>
-    <rdf:type rdf:nodeID="Ncfe0edde0bdd4573a85941a4b81b9f86"/>
-    <ns2:CDAO_0000179 rdf:resource="#phylogeny0_node2"/>
-    <ns5:has_Sibling rdf:resource="#phylogeny0_node3"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Ncfe0edde0bdd4573a85941a4b81b9f86">
-    <ns1:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:someValuesFrom rdf:nodeID="Nfe7e684923d3473d890b2775aabe644f"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N7963c7c155654bc6980c080601e824d4">
-    <ns1:someValuesFrom rdf:resource="#phyloref0"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000293"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Neca9377caa2e4f3ea05cc187aaed60ea">
-    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:someValuesFrom rdf:nodeID="Ne89067c9e94d4d56a2acfd438c32428c"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N3033c138eba7496da82b5106bce79e64">
-    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb_b</rdfs:label>
-    <ns4:hasName rdf:nodeID="Nb1bcae3c80f2417fa386816ffaa1e5e4"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N58790a746d9a4f398cdacc6ca437ba8b">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</ns1:hasValue>
-    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N65c81f30906c4270a9fdc2e94b9d7737">
-    <ns6:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</ns6:nameComplete>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</rdfs:label>
-    <ns6:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
     <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
-    <ns7:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">c</ns7:specificEpithet>
   </rdf:Description>
-  <rdf:Description rdf:about="#phylogeny0">
-    <ns5:newick_expression rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(Aa_a,(Bb_b,(Cc_c,Dd_d,Ee_e)X)Y)Z</ns5:newick_expression>
-    <ns3:has_node rdf:resource="#phylogeny0_node0"/>
-    <ns3:has_node rdf:resource="#phylogeny0_node5"/>
-    <ns3:has_node rdf:resource="#phylogeny0_node4"/>
-    <ns3:has_root_node rdf:resource="#phylogeny0_node0"/>
-    <ns3:has_node rdf:resource="#phylogeny0_node7"/>
-    <ns3:has_node rdf:resource="#phylogeny0_node6"/>
-    <ns3:has_node rdf:resource="#phylogeny0_node1"/>
-    <ns3:has_node rdf:resource="#phylogeny0_node2"/>
-    <ns3:has_node rdf:resource="#phylogeny0_node3"/>
-    <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#PhyloreferenceTestPhylogeny"/>
+  <rdf:Description rdf:nodeID="Nfa7688e0bd924fe6a6ea56063713648e">
+    <rdf:first rdf:nodeID="N9fbd2039a3b649409d6c4f6e5b879bda"/>
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="N2844acfaede143a0be97c9fe5dcf8f09">
-    <ns4:hasName rdf:nodeID="N02367d5eb53c4d2a9a768cb710fe69db"/>
-    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc_c</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N37ca6c0a6ccb47aebd1c65cef82897f4">
-    <ns1:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000149"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:someValuesFrom rdf:nodeID="N2166d2aa9f794829971af87d0b3e1abf"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N37f6c342d8c142809889b123c0967719">
+  <rdf:Description rdf:nodeID="Nead7dd3f592a40a68cd06910708df7e5">
+    <dwc:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">d</dwc:specificEpithet>
+    <ns1:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</ns1:nameComplete>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd_d</rdfs:label>
-    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
-    <ns4:hasName rdf:nodeID="Ncbd4c7d5bad84643aec6495cb40b5a8c"/>
+    <ns1:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
   </rdf:Description>
-  <rdf:Description rdf:about="#phylogeny0_node7">
-    <ns2:CDAO_0000179 rdf:resource="#phylogeny0_node0"/>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa_a</rdfs:label>
-    <ns5:has_Sibling rdf:resource="#phylogeny0_node1"/>
-    <rdf:type rdf:nodeID="N2ea025d94c764f4c9e6b0d54e527b3f1"/>
-    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <ns2:CDAO_0000187 rdf:nodeID="N3d88693567e54a73ab43bee033f85439"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="file:///home/vaidyagi/code/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld">
-    <ns8:studyPublicationReference>Dummy phyloreference for testing</ns8:studyPublicationReference>
-    <ns1:imports rdf:resource="http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl"/>
-    <ns1:imports rdf:resource="http://ontology.phyloref.org/2018-12-14/tcan.owl"/>
-    <ns1:imports rdf:resource="http://ontology.phyloref.org/2018-12-14/phyloref.owl"/>
-    <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#PhyloreferenceTestCase"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
-    <ns3:has_phylogeny rdf:resource="#phylogeny0"/>
-    <ns3:has_phyloreference rdf:resource="#phyloref0"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nf66c8d8bb83648138b7639c004927a9a">
-    <ns1:someValuesFrom rdf:nodeID="N4bba2db301564031a924003f96e06b96"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="#phyloref0">
-    <ns3:internal_specifier rdf:nodeID="N720d70cfd43d4260ae64f9cc00a4fa73"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <ns1:equivalentClass rdf:nodeID="N37ca6c0a6ccb47aebd1c65cef82897f4"/>
-    <ns2:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Node-based, includes C and E, should resolve to (C, D, E) clade.</ns2:IAO_0000115>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</rdfs:label>
-    <ns3:internal_specifier rdf:nodeID="Nb11f2aab73d34b05a5477d8b0cffc30d"/>
+  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref0">
     <rdfs:subClassOf rdf:resource="http://ontology.phyloref.org/phyloref.owl#Phyloreference"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="#phylogeny0_node2">
+    <testcase:internal_specifier rdf:nodeID="N475c97f1ee8244869ee8ca23600d907c"/>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</rdfs:label>
-    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <ns5:has_Sibling rdf:resource="#phylogeny0_node6"/>
-    <rdf:type rdf:nodeID="Nf66c8d8bb83648138b7639c004927a9a"/>
-    <ns2:CDAO_0000149 rdf:resource="#phylogeny0_node3"/>
-    <ns2:CDAO_0000179 rdf:resource="#phylogeny0_node1"/>
-    <ns2:CDAO_0000149 rdf:resource="#phylogeny0_node5"/>
-    <ns2:CDAO_0000149 rdf:resource="#phylogeny0_node4"/>
+    <testcase:internal_specifier rdf:nodeID="Nf14e5dae9a4e4987b1721ef32b9a7739"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <owl:equivalentClass rdf:nodeID="Nb361e884855a4498b9728ad8f5a798cb"/>
+    <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Node-based, includes C and E, should resolve to (C, D, E) clade.</obo:IAO_0000115>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="Na96c45d73cb24becae85b9e5e07c4d39">
+  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2">
+    <obo:CDAO_0000149 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node3"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+    <obo:CDAO_0000149 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node4"/>
+    <obo:CDAO_0000149 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node5"/>
+    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node6"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</rdfs:label>
+    <rdf:type rdf:nodeID="N2d6dfe5fc05a4a1f8d61d316de50c79c"/>
+    <obo:CDAO_0000179 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node1"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Ncd0b3127b3f246159933ab17fe43103e">
+    <owl:someValuesFrom rdf:nodeID="N3c77b9d699a949108444226360c6ad4d"/>
+    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
-    <ns1:someValuesFrom rdf:nodeID="N58790a746d9a4f398cdacc6ca437ba8b"/>
   </rdf:Description>
-  <rdf:Description rdf:about="#phylogeny0_node6">
-    <ns2:CDAO_0000179 rdf:resource="#phylogeny0_node1"/>
-    <ns2:CDAO_0000187 rdf:nodeID="N3033c138eba7496da82b5106bce79e64"/>
+  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node7">
+    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node1"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa_a</rdfs:label>
+    <obo:CDAO_0000187 rdf:nodeID="Ne4346cb347104b90af66f788a9fcea7f"/>
+    <obo:CDAO_0000179 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node0"/>
     <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <rdf:type rdf:nodeID="Nfaa4441010b44bb589e2f5ccef9f94aa"/>
-    <ns5:has_Sibling rdf:resource="#phylogeny0_node2"/>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb_b</rdfs:label>
+    <rdf:type rdf:nodeID="N757b154d50464b14a76f6521ee0eed60"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="N0a889ec4f7a347b291d67c9636032b2f">
+  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node3">
+    <rdf:type rdf:nodeID="N411c3d2b75cf43c9a8a59ec5f87be486"/>
+    <obo:CDAO_0000187 rdf:nodeID="Neecad25a9fb54815ae366ed8cad53706"/>
+    <obo:CDAO_0000179 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node5"/>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee_e</rdfs:label>
-    <ns6:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
-    <ns6:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee e</ns6:nameComplete>
-    <ns7:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">e</ns7:specificEpithet>
-    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
+    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node4"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="Naea3f5f05f1b491b83846addf5440314">
-    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
+  <rdf:Description rdf:nodeID="Ne4346cb347104b90af66f788a9fcea7f">
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+    <ns2:hasName rdf:nodeID="Ne961b24ed802407eb8cdd3e57f4c6e7f"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa_a</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N2d6dfe5fc05a4a1f8d61d316de50c79c">
+    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
+    <owl:someValuesFrom rdf:nodeID="Nbdfd836174dc42ce8d8d8d2fdd47ccd7"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:someValuesFrom rdf:nodeID="N39d0966386714cb9902528703ca91a07"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="Nb1bcae3c80f2417fa386816ffaa1e5e4">
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb_b</rdfs:label>
-    <ns7:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">b</ns7:specificEpithet>
-    <ns6:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb b</ns6:nameComplete>
-    <ns6:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
-    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
+  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0">
+    <testcase:has_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node6"/>
+    <testcase:has_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node7"/>
+    <testcase:has_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node3"/>
+    <testcase:has_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node4"/>
+    <testcase:has_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node5"/>
+    <phyloref:newick_expression rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(Aa_a, (Bb_b, (Cc_c, Dd_d, Ee_e)1)2)3</phyloref:newick_expression>
+    <testcase:has_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node0"/>
+    <testcase:has_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2"/>
+    <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#PhyloreferenceTestPhylogeny"/>
+    <testcase:has_root_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node0"/>
+    <testcase:has_node rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node1"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="N02aeb8b086b74e9e8d88f5d3bc961d5f">
+  <rdf:Description rdf:nodeID="Nf81c6ce94e4843b3ba39d9316423e8c8">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:someValuesFrom rdf:nodeID="Na96c45d73cb24becae85b9e5e07c4d39"/>
-    <ns1:onProperty rdf:resource="http://ontology.phyloref.org/phyloref.owl#excludes_TU"/>
+    <owl:someValuesFrom rdf:nodeID="N2667c5192dbb4583b314d254193c92b4"/>
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
   </rdf:Description>
-  <rdf:Description rdf:about="#phylogeny0_node1">
+  <rdf:Description rdf:nodeID="N1640e782d42b4929a9b669553f226b03">
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
+    <owl:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee e</owl:hasValue>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node0">
     <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <ns5:has_Sibling rdf:resource="#phylogeny0_node7"/>
-    <ns2:CDAO_0000149 rdf:resource="#phylogeny0_node6"/>
-    <ns2:CDAO_0000179 rdf:resource="#phylogeny0_node0"/>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2</rdfs:label>
-    <ns2:CDAO_0000149 rdf:resource="#phylogeny0_node2"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N39d0966386714cb9902528703ca91a07">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb b</ns1:hasValue>
-    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nd5b56a4da0b24423b774169f50722e92">
-    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
-    <ns6:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</ns6:nameComplete>
-    <ns7:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">d</ns7:specificEpithet>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</rdfs:label>
-    <ns6:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nb72d1e0c2cfd40dd8ecda763bb8af11d">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
-    <ns1:someValuesFrom rdf:nodeID="N02348986775847a6af735fc4b164fff9"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="#phylogeny0_node4">
-    <ns5:has_Sibling rdf:resource="#phylogeny0_node5"/>
-    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
-    <ns2:CDAO_0000187 rdf:nodeID="N37f6c342d8c142809889b123c0967719"/>
-    <rdf:type rdf:nodeID="N46d7c2621330443db664119f937730cc"/>
-    <ns2:CDAO_0000179 rdf:resource="#phylogeny0_node2"/>
-    <ns5:has_Sibling rdf:resource="#phylogeny0_node3"/>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd_d</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N02348986775847a6af735fc4b164fff9">
-    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee e</ns1:hasValue>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nfe7e684923d3473d890b2775aabe644f">
-    <ns1:someValuesFrom rdf:nodeID="Nc3350abb8fde45b6bf08ac1a1e70eba7"/>
-    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="#phylogeny0_node0">
-    <ns2:CDAO_0000149 rdf:resource="#phylogeny0_node7"/>
-    <ns2:CDAO_0000149 rdf:resource="#phylogeny0_node1"/>
-    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+    <obo:CDAO_0000149 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node7"/>
+    <obo:CDAO_0000149 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node1"/>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="N01a8cc63e42f4027bff96b18c6296540">
-    <ns1:someValuesFrom rdf:nodeID="N7e250018e4704deb996ff212bc26be81"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nfaa4441010b44bb589e2f5ccef9f94aa">
-    <ns1:someValuesFrom rdf:nodeID="Naea3f5f05f1b491b83846addf5440314"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N720d70cfd43d4260ae64f9cc00a4fa73">
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</rdfs:label>
-    <ns4:hasName rdf:nodeID="Nd5b56a4da0b24423b774169f50722e92"/>
+  <rdf:Description rdf:nodeID="N475c97f1ee8244869ee8ca23600d907c">
+    <ns2:hasName rdf:nodeID="N9054b41ff5db4a109dd44fd89402a902"/>
     <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="N3d88693567e54a73ab43bee033f85439">
-    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
-    <ns4:hasName rdf:nodeID="N794f519b938044d38ff041fe59f7e2b9"/>
+  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node1">
+    <obo:CDAO_0000179 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node0"/>
+    <obo:CDAO_0000149 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2"/>
+    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node7"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2</rdfs:label>
+    <obo:CDAO_0000149 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node6"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Ne961b24ed802407eb8cdd3e57f4c6e7f">
+    <ns1:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
+    <ns1:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa a</ns1:nameComplete>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa_a</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N02367d5eb53c4d2a9a768cb710fe69db">
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc_c</rdfs:label>
-    <ns6:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</ns6:nameComplete>
-    <ns6:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
-    <ns7:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">c</ns7:specificEpithet>
+    <dwc:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a</dwc:specificEpithet>
     <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="Nc35b24e70193404ebe068f52dc02c47d">
-    <rdf:rest rdf:nodeID="Nfaf54d387a84444ea14ea2fa52ff7ff5"/>
-    <rdf:first rdf:nodeID="N02aeb8b086b74e9e8d88f5d3bc961d5f"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nfaf54d387a84444ea14ea2fa52ff7ff5">
-    <rdf:first rdf:nodeID="N657cc0e52f394b87bb7f7726c9acda7a"/>
-    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Ncbd4c7d5bad84643aec6495cb40b5a8c">
-    <ns6:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
-    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
-    <ns6:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</ns6:nameComplete>
-    <ns7:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">d</ns7:specificEpithet>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd_d</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N2ea025d94c764f4c9e6b0d54e527b3f1">
+  <rdf:Description rdf:nodeID="N9fbd2039a3b649409d6c4f6e5b879bda">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:someValuesFrom rdf:nodeID="N01a8cc63e42f4027bff96b18c6296540"/>
-    <ns1:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
+    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000293"/>
+    <owl:someValuesFrom rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref0"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="Nc3350abb8fde45b6bf08ac1a1e70eba7">
-    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</ns1:hasValue>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nd54bf386b9c243d7aa28e6a11c65f7ca">
-    <rdf:rest rdf:nodeID="N2fe57724c4d14a3b8c36eb037e3673bd"/>
-    <rdf:first rdf:resource="http://purl.obolibrary.org/obo/OBI_0302910"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N794f519b938044d38ff041fe59f7e2b9">
-    <ns6:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
-    <ns7:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a</ns7:specificEpithet>
-    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa_a</rdfs:label>
-    <ns6:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa a</ns6:nameComplete>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N673f80827c864e2dbd291da3925a9ab2">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
-    <ns1:someValuesFrom rdf:nodeID="Nb72d1e0c2cfd40dd8ecda763bb8af11d"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nf7048925f7b04c12bf2accad40de0a9b">
-    <ns1:someValuesFrom rdf:nodeID="N1f5539d21daa4b1eb498ae8408b38209"/>
-    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N46d7c2621330443db664119f937730cc">
-    <ns1:someValuesFrom rdf:nodeID="Neca9377caa2e4f3ea05cc187aaed60ea"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nb11f2aab73d34b05a5477d8b0cffc30d">
-    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
-    <ns4:hasName rdf:nodeID="N65c81f30906c4270a9fdc2e94b9d7737"/>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N1f5539d21daa4b1eb498ae8408b38209">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
-    <ns1:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</ns1:hasValue>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N2fe57724c4d14a3b8c36eb037e3673bd">
-    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
-    <rdf:first rdf:nodeID="N7963c7c155654bc6980c080601e824d4"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N657cc0e52f394b87bb7f7726c9acda7a">
-    <ns1:someValuesFrom rdf:nodeID="Nf7048925f7b04c12bf2accad40de0a9b"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-    <ns1:onProperty rdf:resource="http://ontology.phyloref.org/phyloref.owl#includes_TU"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Ne89067c9e94d4d56a2acfd438c32428c">
-    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
-    <ns1:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</ns1:hasValue>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N4bba2db301564031a924003f96e06b96">
-    <ns1:intersectionOf rdf:nodeID="Nd54bf386b9c243d7aa28e6a11c65f7ca"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N2166d2aa9f794829971af87d0b3e1abf">
-    <ns1:intersectionOf rdf:nodeID="Nc35b24e70193404ebe068f52dc02c47d"/>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="N7e250018e4704deb996ff212bc26be81">
-    <ns1:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
-    <ns1:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa a</ns1:hasValue>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="Nf31c776d807d4fa38cdf42737dd86ce4">
+  <rdf:Description rdf:nodeID="Neecad25a9fb54815ae366ed8cad53706">
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee_e</rdfs:label>
     <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
-    <ns4:hasName rdf:nodeID="N0a889ec4f7a347b291d67c9636032b2f"/>
+    <ns2:hasName rdf:nodeID="N21dc675474324a3ca8d6d794f6c16306"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N30437cb0ecc74d7d9ede8a6bcb5e0bdc">
+    <owl:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee e</owl:hasValue>
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N4843905dd25c4669a5da02c8201287c6">
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
+    <owl:someValuesFrom rdf:nodeID="N305db961373141a79ea537d0efc60c93"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N7536ba2211fb431d9fd484b2a7d61780">
+    <owl:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</owl:hasValue>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N770bec34455f4a728018936ce284756c">
+    <testcase:has_phyloreference rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phyloref0"/>
+    <testcase:has_phylogeny rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0"/>
+    <owl:imports rdf:resource="http://ontology.phyloref.org/2018-12-14/phyloref.owl"/>
+    <owl:imports rdf:resource="http://ontology.phyloref.org/2018-12-14/tcan.owl"/>
+    <rdf:type rdf:resource="http://vocab.phyloref.org/phyloref/testcase.owl#PhyloreferenceTestCase"/>
+    <ot:studyPublicationReference>Dummy phyloreference for testing</ot:studyPublicationReference>
+    <owl:imports rdf:resource="http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nc5e48eb3067243c1baceb23ceb496db7">
+    <owl:someValuesFrom rdf:nodeID="Ne434d36881a14da09a8f87ad3c2fc50a"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nd0f17ba3acf346eab4dc83a2806af26e">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
+    <owl:someValuesFrom rdf:nodeID="N1640e782d42b4929a9b669553f226b03"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node6">
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+    <obo:CDAO_0000187 rdf:nodeID="N5f8395cc7ac149db8305a61f9f6c9fa8"/>
+    <obo:CDAO_0000179 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node1"/>
+    <rdf:type rdf:nodeID="N068a3af710b24327b1a47c38e89245dc"/>
+    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb_b</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N757b154d50464b14a76f6521ee0eed60">
+    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
+    <owl:someValuesFrom rdf:nodeID="Nf81c6ce94e4843b3ba39d9316423e8c8"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N305db961373141a79ea537d0efc60c93">
+    <owl:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd d</owl:hasValue>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N45edb26335da457a9c7b8319fbd2f86c">
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+    <ns2:hasName rdf:nodeID="Nead7dd3f592a40a68cd06910708df7e5"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd_d</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Ne5704532ac804df5a8f254a2f9c1a050">
+    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:someValuesFrom rdf:nodeID="N4843905dd25c4669a5da02c8201287c6"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nbdfd836174dc42ce8d8d8d2fdd47ccd7">
+    <owl:intersectionOf rdf:nodeID="N906e8f59fdc94e46992650060ed5b03c"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nb361e884855a4498b9728ad8f5a798cb">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000149"/>
+    <owl:someValuesFrom rdf:nodeID="Nd5e2488796784c5c95a92c9ced95c82b"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N068a3af710b24327b1a47c38e89245dc">
+    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:someValuesFrom rdf:nodeID="Nc5e48eb3067243c1baceb23ceb496db7"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N9208bc783e864aa4b7a0f3e6d11215f5">
+    <owl:someValuesFrom rdf:nodeID="N30437cb0ecc74d7d9ede8a6bcb5e0bdc"/>
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Ne434d36881a14da09a8f87ad3c2fc50a">
+    <owl:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb b</owl:hasValue>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N9054b41ff5db4a109dd44fd89402a902">
+    <ns1:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ee e</ns1:nameComplete>
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N3c77b9d699a949108444226360c6ad4d">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:someValuesFrom rdf:nodeID="N7536ba2211fb431d9fd484b2a7d61780"/>
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N411c3d2b75cf43c9a8a59ec5f87be486">
+    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000187"/>
+    <owl:someValuesFrom rdf:nodeID="Nd0f17ba3acf346eab4dc83a2806af26e"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nf70ffe26b8cd4a18a71f7642facd3886">
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb_b</rdfs:label>
+    <ns1:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
+    <ns1:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb b</ns1:nameComplete>
+    <dwc:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">b</dwc:specificEpithet>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N50286511daa9461baf2e1bd1dbc42a76">
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc_c</rdfs:label>
+    <ns2:hasName rdf:nodeID="N83df00a441954830be2570a9349e7be6"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N75af2ed4bfac4bd082e2aa698de97c98">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:nodeID="Nab6e6ca5b2024fdcbd332ee47c1be5d1"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N2667c5192dbb4583b314d254193c92b4">
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aa a</owl:hasValue>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N1fae3cfb1b814db1ae747fc59055a8eb">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName"/>
+    <owl:someValuesFrom rdf:nodeID="Nfd426ff3c9ad4b1dbaf812fe80cd288c"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nab6e6ca5b2024fdcbd332ee47c1be5d1">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:someValuesFrom rdf:nodeID="N9208bc783e864aa4b7a0f3e6d11215f5"/>
+    <owl:onProperty rdf:resource="http://ontology.phyloref.org/phyloref.owl#includes_TU"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nfd426ff3c9ad4b1dbaf812fe80cd288c">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete"/>
+    <owl:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</owl:hasValue>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N1a4e8d057ed4431499314c3d7c07316c">
+    <owl:onProperty rdf:resource="http://ontology.phyloref.org/phyloref.owl#excludes_TU"/>
+    <owl:someValuesFrom rdf:nodeID="N1fae3cfb1b814db1ae747fc59055a8eb"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nc6fe7d2c9ee54294b7661571af0ee58e">
+    <rdf:rest rdf:nodeID="N75af2ed4bfac4bd082e2aa698de97c98"/>
+    <rdf:first rdf:nodeID="N1a4e8d057ed4431499314c3d7c07316c"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N906e8f59fdc94e46992650060ed5b03c">
+    <rdf:first rdf:resource="http://purl.obolibrary.org/obo/OBI_0302910"/>
+    <rdf:rest rdf:nodeID="Nfa7688e0bd924fe6a6ea56063713648e"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node4">
+    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node3"/>
+    <rdf:type rdf:resource="http://purl.obolibrary.org/obo/CDAO_0000140"/>
+    <obo:CDAO_0000179 rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node2"/>
+    <obo:CDAO_0000187 rdf:nodeID="N45edb26335da457a9c7b8319fbd2f86c"/>
+    <rdf:type rdf:nodeID="Ne5704532ac804df5a8f254a2f9c1a050"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dd_d</rdfs:label>
+    <phyloref:has_Sibling rdf:resource="file:///Users/gaurav/Development/phyloref/jphyloref/src/test/resources/phylorefs/dummy1.jsonld#phylogeny0_node5"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nd5e2488796784c5c95a92c9ced95c82b">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <owl:intersectionOf rdf:nodeID="Nc6fe7d2c9ee54294b7661571af0ee58e"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Nf14e5dae9a4e4987b1721ef32b9a7739">
+    <ns2:hasName rdf:nodeID="Na59c8d71293f4bafbea030182f64056c"/>
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N83df00a441954830be2570a9349e7be6">
+    <ns1:nomenclaturalCode rdf:resource="http://purl.obolibrary.org/obo/NOMEN_0000036"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc_c</rdfs:label>
+    <dwc:specificEpithet rdf:datatype="http://www.w3.org/2001/XMLSchema#string">c</dwc:specificEpithet>
+    <ns1:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</ns1:nameComplete>
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="Na59c8d71293f4bafbea030182f64056c">
+    <ns1:nameComplete rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cc c</ns1:nameComplete>
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="N5f8395cc7ac149db8305a61f9f6c9fa8">
+    <ns2:hasName rdf:nodeID="Nf70ffe26b8cd4a18a71f7642facd3886"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bb_b</rdfs:label>
+    <rdf:type rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
   </rdf:Description>
 </rdf:RDF>

--- a/src/test/resources/phylorefs/dummy1.txt
+++ b/src/test/resources/phylorefs/dummy1.txt
@@ -1,509 +1,393 @@
 [
     {
-        "@context": "http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json",
-        "@id": "http://phyloref.org/clade-ontology/clado.owl",
-        "@type": "owl:Ontology",
-        "owl:imports": [
-            "http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl",
-            "http://ontology.phyloref.org/2018-12-14/phyloref.owl",
-            "http://ontology.phyloref.org/2018-12-14/tcan.owl"
-        ]
-    },
-    {
-        "label": "1",
-        "internalSpecifiers": [
+        "@context": "http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json",
+        "citation": "Dummy phyloreference for testing",
+        "phylogenies": [
             {
-                "referencesTaxonomicUnits": [
+                "description": "Dummy phylogeny for testing",
+                "newick": "(Aa_a,(Bb_b,(Cc_c,Dd_d,Ee_e)1)2)3",
+                "@id": "#phylogeny0",
+                "@type": "testcase:PhyloreferenceTestPhylogeny",
+                "nodes": [
                     {
-                        "scientificNames": [
+                        "@id": "#phylogeny0_node0",
+                        "rdf:type": [
                             {
-                                "scientificName": "Cc c"
+                                "@id": "obo:CDAO_0000140"
                             }
                         ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal1_tunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal1",
-                "@type": [
-                    "testcase:Specifier"
-                ]
-            },
-            {
-                "referencesTaxonomicUnits": [
+                        "labels": [
+                            "3"
+                        ],
+                        "representsTaxonomicUnits": [],
+                        "children": [
+                            "#phylogeny0_node1",
+                            "#phylogeny0_node7"
+                        ]
+                    },
                     {
-                        "scientificNames": [
+                        "@id": "#phylogeny0_node1",
+                        "rdf:type": [
                             {
-                                "scientificName": "Ee e"
+                                "@id": "obo:CDAO_0000140"
                             }
                         ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal2_tunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal2",
-                "@type": [
-                    "testcase:Specifier"
-                ]
-            }
-        ],
-        "externalSpecifiers": [],
-        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001",
-        "hasInternalSpecifier": [
-            {
-                "referencesTaxonomicUnits": [
-                    {
-                        "scientificNames": [
-                            {
-                                "scientificName": "Cc c"
-                            }
+                        "labels": [
+                            "2"
                         ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal1_tunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal1",
-                "@type": [
-                    "testcase:Specifier"
-                ]
-            },
-            {
-                "referencesTaxonomicUnits": [
-                    {
-                        "scientificNames": [
-                            {
-                                "scientificName": "Ee e"
-                            }
+                        "representsTaxonomicUnits": [],
+                        "parent": "#phylogeny0_node0",
+                        "siblings": [
+                            "#phylogeny0_node7"
                         ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal2_tunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001_specifier_internal2",
-                "@type": [
-                    "testcase:Specifier"
-                ]
-            }
-        ],
-        "hasExternalSpecifier": [],
-        "subClassOf": "phyloref:Phyloreference",
-        "obo:IAO_0000115": "Node-based, includes C and E, should resolve to (C, D, E) clade.",
-        "hasAdditionalClass": [],
-        "equivalentClass": [
-            {
-                "@type": "owl:Restriction",
-                "onProperty": "obo:CDAO_0000149",
-                "someValuesFrom": {
-                    "@type": "owl:Class",
-                    "intersectionOf": [
-                        {
-                            "@type": "owl:Restriction",
-                            "onProperty": "phyloref:excludes_TU",
-                            "someValuesFrom": {
+                        "children": [
+                            "#phylogeny0_node2",
+                            "#phylogeny0_node6"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node2",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            },
+                            {
                                 "@type": "owl:Restriction",
-                                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                "onProperty": "obo:OBI_0000312",
                                 "someValuesFrom": {
                                     "@type": "owl:Class",
                                     "intersectionOf": [
                                         {
-                                            "@id": "obo:NOMEN_0000107"
+                                            "@id": "obo:OBI_0302910"
                                         },
                                         {
                                             "@type": "owl:Restriction",
-                                            "onProperty": "dwc:scientificName",
-                                            "hasValue": "Cc c"
+                                            "onProperty": "obo:OBI_0000293",
+                                            "someValuesFrom": {
+                                                "@id": "#phyloref0"
+                                            }
                                         }
                                     ]
                                 }
                             }
-                        },
-                        {
-                            "@type": "owl:Restriction",
-                            "onProperty": "phyloref:includes_TU",
-                            "someValuesFrom": {
+                        ],
+                        "labels": [
+                            "1"
+                        ],
+                        "representsTaxonomicUnits": [],
+                        "parent": "#phylogeny0_node1",
+                        "siblings": [
+                            "#phylogeny0_node6"
+                        ],
+                        "children": [
+                            "#phylogeny0_node3",
+                            "#phylogeny0_node4",
+                            "#phylogeny0_node5"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node3",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            },
+                            {
                                 "@type": "owl:Restriction",
-                                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                "onProperty": "obo:CDAO_0000187",
                                 "someValuesFrom": {
-                                    "@type": "owl:Class",
-                                    "intersectionOf": [
-                                        {
-                                            "@id": "obo:NOMEN_0000107"
-                                        },
-                                        {
-                                            "@type": "owl:Restriction",
-                                            "onProperty": "dwc:scientificName",
-                                            "hasValue": "Ee e"
-                                        }
-                                    ]
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                        "hasValue": "Ee e"
+                                    }
                                 }
                             }
-                        }
-                    ]
+                        ],
+                        "labels": [
+                            "Ee_e"
+                        ],
+                        "representsTaxonomicUnits": [
+                            {
+                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                                "hasName": {
+                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                                    "label": "Ee_e",
+                                    "nameComplete": "Ee e",
+                                    "genusPart": "Ee",
+                                    "specificEpithet": "e"
+                                },
+                                "label": "Ee_e"
+                            }
+                        ],
+                        "parent": "#phylogeny0_node2",
+                        "siblings": [
+                            "#phylogeny0_node4",
+                            "#phylogeny0_node5"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node4",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            },
+                            {
+                                "@type": "owl:Restriction",
+                                "onProperty": "obo:CDAO_0000187",
+                                "someValuesFrom": {
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                        "hasValue": "Dd d"
+                                    }
+                                }
+                            }
+                        ],
+                        "labels": [
+                            "Dd_d"
+                        ],
+                        "representsTaxonomicUnits": [
+                            {
+                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                                "hasName": {
+                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                                    "label": "Dd_d",
+                                    "nameComplete": "Dd d",
+                                    "genusPart": "Dd",
+                                    "specificEpithet": "d"
+                                },
+                                "label": "Dd_d"
+                            }
+                        ],
+                        "parent": "#phylogeny0_node2",
+                        "siblings": [
+                            "#phylogeny0_node3",
+                            "#phylogeny0_node5"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node5",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            },
+                            {
+                                "@type": "owl:Restriction",
+                                "onProperty": "obo:CDAO_0000187",
+                                "someValuesFrom": {
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                        "hasValue": "Cc c"
+                                    }
+                                }
+                            }
+                        ],
+                        "labels": [
+                            "Cc_c"
+                        ],
+                        "representsTaxonomicUnits": [
+                            {
+                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                                "hasName": {
+                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                                    "label": "Cc_c",
+                                    "nameComplete": "Cc c",
+                                    "genusPart": "Cc",
+                                    "specificEpithet": "c"
+                                },
+                                "label": "Cc_c"
+                            }
+                        ],
+                        "parent": "#phylogeny0_node2",
+                        "siblings": [
+                            "#phylogeny0_node3",
+                            "#phylogeny0_node4"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node6",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            },
+                            {
+                                "@type": "owl:Restriction",
+                                "onProperty": "obo:CDAO_0000187",
+                                "someValuesFrom": {
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                        "hasValue": "Bb b"
+                                    }
+                                }
+                            }
+                        ],
+                        "labels": [
+                            "Bb_b"
+                        ],
+                        "representsTaxonomicUnits": [
+                            {
+                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                                "hasName": {
+                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                                    "label": "Bb_b",
+                                    "nameComplete": "Bb b",
+                                    "genusPart": "Bb",
+                                    "specificEpithet": "b"
+                                },
+                                "label": "Bb_b"
+                            }
+                        ],
+                        "parent": "#phylogeny0_node1",
+                        "siblings": [
+                            "#phylogeny0_node2"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node7",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            },
+                            {
+                                "@type": "owl:Restriction",
+                                "onProperty": "obo:CDAO_0000187",
+                                "someValuesFrom": {
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                        "hasValue": "Aa a"
+                                    }
+                                }
+                            }
+                        ],
+                        "labels": [
+                            "Aa_a"
+                        ],
+                        "representsTaxonomicUnits": [
+                            {
+                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                                "hasName": {
+                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                                    "label": "Aa_a",
+                                    "nameComplete": "Aa a",
+                                    "genusPart": "Aa",
+                                    "specificEpithet": "a"
+                                },
+                                "label": "Aa_a"
+                            }
+                        ],
+                        "parent": "#phylogeny0_node0",
+                        "siblings": [
+                            "#phylogeny0_node1"
+                        ]
+                    }
+                ],
+                "hasRootNode": {
+                    "@id": "#phylogeny0_node0"
                 }
             }
         ],
-        "@context": "http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json"
-    },
-    {
-        "description": "Dummy phylogeny for testing",
-        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002",
-        "@type": "testcase:PhyloreferenceTestPhylogeny",
-        "nodes": [
+        "phylorefs": [
             {
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node0",
-                "labels": [
-                    "3"
-                ],
-                "representsTaxonomicUnits": [],
-                "children": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1",
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node7"
-                ],
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                "label": "1",
+                "cladeDefinition": "Node-based, includes C and E, should resolve to (C, D, E) clade.",
+                "internalSpecifiers": [
                     {
-                        "@id": "http://purl.obolibrary.org/obo/CDAO_0000140"
-                    }
-                ]
-            },
-            {
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1",
-                "labels": [
-                    "2"
-                ],
-                "representsTaxonomicUnits": [],
-                "parent": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node0",
-                "siblings": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node7"
-                ],
-                "children": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2",
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node6"
-                ],
-                "obo:CDAO_0000179": {
-                    "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node0"
-                },
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                    {
-                        "@id": "http://purl.obolibrary.org/obo/CDAO_0000140"
-                    }
-                ]
-            },
-            {
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2",
-                "labels": [
-                    "1"
-                ],
-                "representsTaxonomicUnits": [],
-                "parent": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1",
-                "siblings": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node6"
-                ],
-                "children": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node3",
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node4",
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node5"
-                ],
-                "obo:CDAO_0000179": {
-                    "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1"
-                },
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                    {
-                        "@id": "http://purl.obolibrary.org/obo/CDAO_0000140"
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                        "hasName": {
+                            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                            "label": "Cc c",
+                            "nameComplete": "Cc c",
+                            "genusPart": "Cc",
+                            "specificEpithet": "c"
+                        },
+                        "label": "Cc c"
                     },
                     {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                        "hasName": {
+                            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                            "label": "Dd d",
+                            "nameComplete": "Dd d",
+                            "genusPart": "Dd",
+                            "specificEpithet": "d"
+                        },
+                        "label": "Dd d"
+                    }
+                ],
+                "externalSpecifiers": [],
+                "@id": "#phyloref0",
+                "@type": "owl:Class",
+                "subClassOf": "phyloref:Phyloreference",
+                "hasAdditionalClass": [],
+                "equivalentClass": [
+                    {
                         "@type": "owl:Restriction",
-                        "onProperty": "obo:OBI_0000312",
+                        "onProperty": "obo:CDAO_0000149",
                         "someValuesFrom": {
                             "@type": "owl:Class",
                             "intersectionOf": [
                                 {
-                                    "@id": "obo:OBI_0302910"
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "phyloref:excludes_TU",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                        "someValuesFrom": {
+                                            "@type": "owl:Restriction",
+                                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                            "hasValue": "Cc c"
+                                        }
+                                    }
                                 },
                                 {
                                     "@type": "owl:Restriction",
-                                    "onProperty": "obo:OBI_0000293",
+                                    "onProperty": "phyloref:includes_TU",
                                     "someValuesFrom": {
-                                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000001"
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                        "someValuesFrom": {
+                                            "@type": "owl:Restriction",
+                                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                            "hasValue": "Dd d"
+                                        }
                                     }
                                 }
                             ]
                         }
                     }
                 ]
-            },
-            {
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node3",
-                "labels": [
-                    "Ee_e"
-                ],
-                "representsTaxonomicUnits": [
-                    {
-                        "scientificNames": [
-                            {
-                                "scientificName": "Ee e",
-                                "binomialName": "Ee e",
-                                "genus": "Ee",
-                                "specificEpithet": "e"
-                            }
-                        ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node3_taxonomicunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "parent": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2",
-                "siblings": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node4",
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node5"
-                ],
-                "obo:CDAO_0000179": {
-                    "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2"
-                },
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                    {
-                        "@id": "http://purl.obolibrary.org/obo/CDAO_0000140"
-                    },
-                    {
-                        "@type": "owl:Restriction",
-                        "onProperty": "obo:CDAO_0000187",
-                        "someValuesFrom": {
-                            "@type": "owl:Restriction",
-                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                            "someValuesFrom": {
-                                "@type": "owl:Class",
-                                "intersectionOf": [
-                                    {
-                                        "@id": "obo:NOMEN_0000107"
-                                    },
-                                    {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "dwc:scientificName",
-                                        "hasValue": "Ee e"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                ]
-            },
-            {
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node4",
-                "labels": [
-                    "Dd_d"
-                ],
-                "representsTaxonomicUnits": [
-                    {
-                        "scientificNames": [
-                            {
-                                "scientificName": "Dd d",
-                                "binomialName": "Dd d",
-                                "genus": "Dd",
-                                "specificEpithet": "d"
-                            }
-                        ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node4_taxonomicunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "parent": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2",
-                "siblings": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node3",
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node5"
-                ],
-                "obo:CDAO_0000179": {
-                    "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2"
-                },
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                    {
-                        "@id": "http://purl.obolibrary.org/obo/CDAO_0000140"
-                    },
-                    {
-                        "@type": "owl:Restriction",
-                        "onProperty": "obo:CDAO_0000187",
-                        "someValuesFrom": {
-                            "@type": "owl:Restriction",
-                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                            "someValuesFrom": {
-                                "@type": "owl:Class",
-                                "intersectionOf": [
-                                    {
-                                        "@id": "obo:NOMEN_0000107"
-                                    },
-                                    {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "dwc:scientificName",
-                                        "hasValue": "Dd d"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                ]
-            },
-            {
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node5",
-                "labels": [
-                    "Cc_c"
-                ],
-                "representsTaxonomicUnits": [
-                    {
-                        "scientificNames": [
-                            {
-                                "scientificName": "Cc c",
-                                "binomialName": "Cc c",
-                                "genus": "Cc",
-                                "specificEpithet": "c"
-                            }
-                        ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node5_taxonomicunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "parent": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2",
-                "siblings": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node3",
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node4"
-                ],
-                "obo:CDAO_0000179": {
-                    "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2"
-                },
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                    {
-                        "@id": "http://purl.obolibrary.org/obo/CDAO_0000140"
-                    },
-                    {
-                        "@type": "owl:Restriction",
-                        "onProperty": "obo:CDAO_0000187",
-                        "someValuesFrom": {
-                            "@type": "owl:Restriction",
-                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                            "someValuesFrom": {
-                                "@type": "owl:Class",
-                                "intersectionOf": [
-                                    {
-                                        "@id": "obo:NOMEN_0000107"
-                                    },
-                                    {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "dwc:scientificName",
-                                        "hasValue": "Cc c"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                ]
-            },
-            {
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node6",
-                "labels": [
-                    "Bb_b"
-                ],
-                "representsTaxonomicUnits": [
-                    {
-                        "scientificNames": [
-                            {
-                                "scientificName": "Bb b",
-                                "binomialName": "Bb b",
-                                "genus": "Bb",
-                                "specificEpithet": "b"
-                            }
-                        ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node6_taxonomicunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "parent": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1",
-                "siblings": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node2"
-                ],
-                "obo:CDAO_0000179": {
-                    "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1"
-                },
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                    {
-                        "@id": "http://purl.obolibrary.org/obo/CDAO_0000140"
-                    },
-                    {
-                        "@type": "owl:Restriction",
-                        "onProperty": "obo:CDAO_0000187",
-                        "someValuesFrom": {
-                            "@type": "owl:Restriction",
-                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                            "someValuesFrom": {
-                                "@type": "owl:Class",
-                                "intersectionOf": [
-                                    {
-                                        "@id": "obo:NOMEN_0000107"
-                                    },
-                                    {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "dwc:scientificName",
-                                        "hasValue": "Bb b"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                ]
-            },
-            {
-                "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node7",
-                "labels": [
-                    "Aa_a"
-                ],
-                "representsTaxonomicUnits": [
-                    {
-                        "scientificNames": [
-                            {
-                                "scientificName": "Aa a",
-                                "binomialName": "Aa a",
-                                "genus": "Aa",
-                                "specificEpithet": "a"
-                            }
-                        ],
-                        "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node7_taxonomicunit0",
-                        "@type": "http://purl.obolibrary.org/obo/CDAO_0000138"
-                    }
-                ],
-                "parent": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node0",
-                "siblings": [
-                    "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node1"
-                ],
-                "obo:CDAO_0000179": {
-                    "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node0"
-                },
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                    {
-                        "@id": "http://purl.obolibrary.org/obo/CDAO_0000140"
-                    },
-                    {
-                        "@type": "owl:Restriction",
-                        "onProperty": "obo:CDAO_0000187",
-                        "someValuesFrom": {
-                            "@type": "owl:Restriction",
-                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                            "someValuesFrom": {
-                                "@type": "owl:Class",
-                                "intersectionOf": [
-                                    {
-                                        "@id": "obo:NOMEN_0000107"
-                                    },
-                                    {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "dwc:scientificName",
-                                        "hasValue": "Aa a"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                ]
             }
         ],
-        "hasRootNode": {
-            "@id": "http://phyloref.org/clade-ontology/clado.owl#CLADO_00000002_node0"
-        },
-        "phyloref:newick_expression": "(Aa_a, (Bb_b, (Cc_c, Dd_d, Ee_e)1)2)3",
-        "@context": "http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json"
+        "hasTaxonomicUnitMatches": [],
+        "@id": "",
+        "@type": [
+            "testcase:PhyloreferenceTestCase",
+            "owl:Ontology"
+        ],
+        "owl:imports": [
+            "http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl",
+            "http://ontology.phyloref.org/2018-12-14/phyloref.owl",
+            "http://ontology.phyloref.org/2018-12-14/tcan.owl"
+        ]
     }
 ]

--- a/src/test/resources/phylorefs/failing1.json
+++ b/src/test/resources/phylorefs/failing1.json
@@ -20,12 +20,12 @@
                     "hasName": {
                         "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
                         "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
-                        "label": "Ee e",
-                        "nameComplete": "Ee e",
-                        "genusPart": "Ee",
-                        "specificEpithet": "e"
+                        "label": "Dd d",
+                        "nameComplete": "Dd d",
+                        "genusPart": "Dd",
+                        "specificEpithet": "d"
                     },
-                    "label": "Ee e"
+                    "label": "Dd d"
                 }
             ],
             "externalSpecifiers": []

--- a/src/test/resources/phylorefs/failing1.jsonld
+++ b/src/test/resources/phylorefs/failing1.jsonld
@@ -1,442 +1,477 @@
-[
+{
+  "phylorefs": [
     {
-        "phylorefs": [
+      "label": "1",
+      "internalSpecifiers": [
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+            "label": "Cc c",
+            "nameComplete": "Cc c",
+            "genusPart": "Cc",
+            "specificEpithet": "c"
+          },
+          "label": "Cc c"
+        },
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+            "label": "Dd d",
+            "nameComplete": "Dd d",
+            "genusPart": "Dd",
+            "specificEpithet": "d"
+          },
+          "label": "Dd d"
+        }
+      ],
+      "externalSpecifiers": [],
+      "@id": "#phyloref0",
+      "@type": "owl:Class",
+      "subClassOf": "phyloref:Phyloreference",
+      "hasAdditionalClass": [],
+      "equivalentClass": [
+        {
+          "@type": "owl:Restriction",
+          "onProperty": "obo:CDAO_0000149",
+          "someValuesFrom": {
+            "@type": "owl:Class",
+            "intersectionOf": [
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:excludes_TU",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                    "hasValue": "Cc c"
+                  }
+                }
+              },
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:includes_TU",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                    "hasValue": "Dd d"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "label": "2",
+      "internalSpecifiers": [
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+            "label": "Cc c",
+            "nameComplete": "Cc c",
+            "genusPart": "Cc",
+            "specificEpithet": "c"
+          },
+          "label": "Cc c"
+        },
+        {
+          "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+          "hasName": {
+            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+            "label": "Ee e",
+            "nameComplete": "Ee e",
+            "genusPart": "Ee",
+            "specificEpithet": "e"
+          },
+          "label": "Ee e"
+        }
+      ],
+      "externalSpecifiers": [],
+      "@id": "#phyloref1",
+      "@type": "owl:Class",
+      "subClassOf": "phyloref:Phyloreference",
+      "hasAdditionalClass": [],
+      "equivalentClass": [
+        {
+          "@type": "owl:Restriction",
+          "onProperty": "obo:CDAO_0000149",
+          "someValuesFrom": {
+            "@type": "owl:Class",
+            "intersectionOf": [
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:excludes_TU",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                    "hasValue": "Cc c"
+                  }
+                }
+              },
+              {
+                "@type": "owl:Restriction",
+                "onProperty": "phyloref:includes_TU",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                  "someValuesFrom": {
+                    "@type": "owl:Restriction",
+                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                    "hasValue": "Ee e"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "phylogenies": [
+    {
+      "newick": "(Aa_a, (Bb_b, (Cc_c, Dd_d, Ee_e)1)2)3",
+      "@id": "#phylogeny0",
+      "@type": "testcase:PhyloreferenceTestPhylogeny",
+      "nodes": [
+        {
+          "@id": "#phylogeny0_node0",
+          "rdf:type": [
             {
-                "label": "1",
-                "internalSpecifiers": [
-                    {
-                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                        "hasName": {
-                            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
-                            "label": "Cc c",
-                            "nameComplete": "Cc c",
-                            "genusPart": "Cc",
-                            "specificEpithet": "c"
-                        },
-                        "label": "Cc c"
-                    },
-                    {
-                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                        "hasName": {
-                            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
-                            "label": "Ee e",
-                            "nameComplete": "Ee e",
-                            "genusPart": "Ee",
-                            "specificEpithet": "e"
-                        },
-                        "label": "Ee e"
-                    }
-                ],
-                "externalSpecifiers": [],
-                "@id": "#phyloref0",
-                "@type": "owl:Class",
-                "subClassOf": "phyloref:Phyloreference",
-                "hasAdditionalClass": [],
-                "equivalentClass": [
-                    {
-                        "@type": "owl:Restriction",
-                        "onProperty": "obo:CDAO_0000149",
-                        "someValuesFrom": {
-                            "@type": "owl:Class",
-                            "intersectionOf": [
-                                {
-                                    "@type": "owl:Restriction",
-                                    "onProperty": "phyloref:excludes_TU",
-                                    "someValuesFrom": {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                                        "someValuesFrom": {
-                                            "@type": "owl:Restriction",
-                                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
-                                            "hasValue": "Cc c"
-                                        }
-                                    }
-                                },
-                                {
-                                    "@type": "owl:Restriction",
-                                    "onProperty": "phyloref:includes_TU",
-                                    "someValuesFrom": {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                                        "someValuesFrom": {
-                                            "@type": "owl:Restriction",
-                                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
-                                            "hasValue": "Ee e"
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
+              "@id": "obo:CDAO_0000140"
+            }
+          ],
+          "labels": [
+            "3"
+          ],
+          "representsTaxonomicUnits": [],
+          "children": [
+            "#phylogeny0_node1",
+            "#phylogeny0_node7"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node1",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
             },
             {
-                "label": "2",
-                "internalSpecifiers": [
-                    {
-                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                        "hasName": {
-                            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
-                            "label": "Cc c",
-                            "nameComplete": "Cc c",
-                            "genusPart": "Cc",
-                            "specificEpithet": "c"
-                        },
-                        "label": "Cc c"
-                    },
-                    {
-                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                        "hasName": {
-                            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
-                            "label": "Ee e",
-                            "nameComplete": "Ee e",
-                            "genusPart": "Ee",
-                            "specificEpithet": "e"
-                        },
-                        "label": "Ee e"
-                    }
-                ],
-                "externalSpecifiers": [],
-                "@id": "#phyloref1",
+              "@type": "owl:Restriction",
+              "onProperty": "obo:OBI_0000312",
+              "someValuesFrom": {
                 "@type": "owl:Class",
-                "subClassOf": "phyloref:Phyloreference",
-                "hasAdditionalClass": [],
-                "equivalentClass": [
-                    {
-                        "@type": "owl:Restriction",
-                        "onProperty": "obo:CDAO_0000149",
-                        "someValuesFrom": {
-                            "@type": "owl:Class",
-                            "intersectionOf": [
-                                {
-                                    "@type": "owl:Restriction",
-                                    "onProperty": "phyloref:excludes_TU",
-                                    "someValuesFrom": {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                                        "someValuesFrom": {
-                                            "@type": "owl:Restriction",
-                                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
-                                            "hasValue": "Cc c"
-                                        }
-                                    }
-                                },
-                                {
-                                    "@type": "owl:Restriction",
-                                    "onProperty": "phyloref:includes_TU",
-                                    "someValuesFrom": {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                                        "someValuesFrom": {
-                                            "@type": "owl:Restriction",
-                                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
-                                            "hasValue": "Ee e"
-                                        }
-                                    }
-                                }
-                            ]
-                        }
+                "intersectionOf": [
+                  {
+                    "@id": "obo:OBI_0302910"
+                  },
+                  {
+                    "@type": "owl:Restriction",
+                    "onProperty": "obo:OBI_0000293",
+                    "someValuesFrom": {
+                      "@id": "#phyloref1"
                     }
+                  }
                 ]
+              }
             }
-        ],
-        "phylogenies": [
+          ],
+          "labels": [
+            "2"
+          ],
+          "representsTaxonomicUnits": [],
+          "parent": "#phylogeny0_node0",
+          "siblings": [
+            "#phylogeny0_node7"
+          ],
+          "children": [
+            "#phylogeny0_node2",
+            "#phylogeny0_node6"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node2",
+          "rdf:type": [
             {
-                "newick": "(Aa_a, (Bb_b, (Cc_c, Dd_d, Ee_e)1)2)3",
-                "@id": "#phylogeny0",
-                "@type": "testcase:PhyloreferenceTestPhylogeny",
-                "nodes": [
-                    {
-                        "@id": "#phylogeny0_node0",
-                        "rdf:type": [
-                            {
-                                "@id": "obo:CDAO_0000140"
-                            }
-                        ],
-                        "labels": [
-                            "3"
-                        ],
-                        "representsTaxonomicUnits": [],
-                        "children": [
-                            "#phylogeny0_node1",
-                            "#phylogeny0_node7"
-                        ]
-                    },
-                    {
-                        "@id": "#phylogeny0_node1",
-                        "rdf:type": [
-                            {
-                                "@id": "obo:CDAO_0000140"
-                            }
-                        ],
-                        "labels": [
-                            "2"
-                        ],
-                        "representsTaxonomicUnits": [],
-                        "parent": "#phylogeny0_node0",
-                        "siblings": [
-                            "#phylogeny0_node7"
-                        ],
-                        "children": [
-                            "#phylogeny0_node2",
-                            "#phylogeny0_node6"
-                        ]
-                    },
-                    {
-                        "@id": "#phylogeny0_node2",
-                        "rdf:type": [
-                            {
-                                "@id": "obo:CDAO_0000140"
-                            }
-                        ],
-                        "labels": [
-                            "1"
-                        ],
-                        "representsTaxonomicUnits": [],
-                        "parent": "#phylogeny0_node1",
-                        "siblings": [
-                            "#phylogeny0_node6"
-                        ],
-                        "children": [
-                            "#phylogeny0_node3",
-                            "#phylogeny0_node4",
-                            "#phylogeny0_node5"
-                        ]
-                    },
-                    {
-                        "@id": "#phylogeny0_node3",
-                        "rdf:type": [
-                            {
-                                "@id": "obo:CDAO_0000140"
-                            },
-                            {
-                                "@type": "owl:Restriction",
-                                "onProperty": "obo:CDAO_0000187",
-                                "someValuesFrom": {
-                                    "@type": "owl:Restriction",
-                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                                    "someValuesFrom": {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
-                                        "hasValue": "Ee e"
-                                    }
-                                }
-                            }
-                        ],
-                        "labels": [
-                            "Ee_e"
-                        ],
-                        "representsTaxonomicUnits": [
-                            {
-                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                                "hasName": {
-                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
-                                    "label": "Ee_e",
-                                    "nameComplete": "Ee e",
-                                    "genusPart": "Ee",
-                                    "specificEpithet": "e"
-                                },
-                                "label": "Ee_e"
-                            }
-                        ],
-                        "parent": "#phylogeny0_node2",
-                        "siblings": [
-                            "#phylogeny0_node4",
-                            "#phylogeny0_node5"
-                        ]
-                    },
-                    {
-                        "@id": "#phylogeny0_node4",
-                        "rdf:type": [
-                            {
-                                "@id": "obo:CDAO_0000140"
-                            },
-                            {
-                                "@type": "owl:Restriction",
-                                "onProperty": "obo:CDAO_0000187",
-                                "someValuesFrom": {
-                                    "@type": "owl:Restriction",
-                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                                    "someValuesFrom": {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
-                                        "hasValue": "Dd d"
-                                    }
-                                }
-                            }
-                        ],
-                        "labels": [
-                            "Dd_d"
-                        ],
-                        "representsTaxonomicUnits": [
-                            {
-                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                                "hasName": {
-                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
-                                    "label": "Dd_d",
-                                    "nameComplete": "Dd d",
-                                    "genusPart": "Dd",
-                                    "specificEpithet": "d"
-                                },
-                                "label": "Dd_d"
-                            }
-                        ],
-                        "parent": "#phylogeny0_node2",
-                        "siblings": [
-                            "#phylogeny0_node3",
-                            "#phylogeny0_node5"
-                        ]
-                    },
-                    {
-                        "@id": "#phylogeny0_node5",
-                        "rdf:type": [
-                            {
-                                "@id": "obo:CDAO_0000140"
-                            },
-                            {
-                                "@type": "owl:Restriction",
-                                "onProperty": "obo:CDAO_0000187",
-                                "someValuesFrom": {
-                                    "@type": "owl:Restriction",
-                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                                    "someValuesFrom": {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
-                                        "hasValue": "Cc c"
-                                    }
-                                }
-                            }
-                        ],
-                        "labels": [
-                            "Cc_c"
-                        ],
-                        "representsTaxonomicUnits": [
-                            {
-                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                                "hasName": {
-                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
-                                    "label": "Cc_c",
-                                    "nameComplete": "Cc c",
-                                    "genusPart": "Cc",
-                                    "specificEpithet": "c"
-                                },
-                                "label": "Cc_c"
-                            }
-                        ],
-                        "parent": "#phylogeny0_node2",
-                        "siblings": [
-                            "#phylogeny0_node3",
-                            "#phylogeny0_node4"
-                        ]
-                    },
-                    {
-                        "@id": "#phylogeny0_node6",
-                        "rdf:type": [
-                            {
-                                "@id": "obo:CDAO_0000140"
-                            },
-                            {
-                                "@type": "owl:Restriction",
-                                "onProperty": "obo:CDAO_0000187",
-                                "someValuesFrom": {
-                                    "@type": "owl:Restriction",
-                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                                    "someValuesFrom": {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
-                                        "hasValue": "Bb b"
-                                    }
-                                }
-                            }
-                        ],
-                        "labels": [
-                            "Bb_b"
-                        ],
-                        "representsTaxonomicUnits": [
-                            {
-                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                                "hasName": {
-                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
-                                    "label": "Bb_b",
-                                    "nameComplete": "Bb b",
-                                    "genusPart": "Bb",
-                                    "specificEpithet": "b"
-                                },
-                                "label": "Bb_b"
-                            }
-                        ],
-                        "parent": "#phylogeny0_node1",
-                        "siblings": [
-                            "#phylogeny0_node2"
-                        ]
-                    },
-                    {
-                        "@id": "#phylogeny0_node7",
-                        "rdf:type": [
-                            {
-                                "@id": "obo:CDAO_0000140"
-                            },
-                            {
-                                "@type": "owl:Restriction",
-                                "onProperty": "obo:CDAO_0000187",
-                                "someValuesFrom": {
-                                    "@type": "owl:Restriction",
-                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
-                                    "someValuesFrom": {
-                                        "@type": "owl:Restriction",
-                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
-                                        "hasValue": "Aa a"
-                                    }
-                                }
-                            }
-                        ],
-                        "labels": [
-                            "Aa_a"
-                        ],
-                        "representsTaxonomicUnits": [
-                            {
-                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                                "hasName": {
-                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
-                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
-                                    "label": "Aa_a",
-                                    "nameComplete": "Aa a",
-                                    "genusPart": "Aa",
-                                    "specificEpithet": "a"
-                                },
-                                "label": "Aa_a"
-                            }
-                        ],
-                        "parent": "#phylogeny0_node0",
-                        "siblings": [
-                            "#phylogeny0_node1"
-                        ]
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:OBI_0000312",
+              "someValuesFrom": {
+                "@type": "owl:Class",
+                "intersectionOf": [
+                  {
+                    "@id": "obo:OBI_0302910"
+                  },
+                  {
+                    "@type": "owl:Restriction",
+                    "onProperty": "obo:OBI_0000293",
+                    "someValuesFrom": {
+                      "@id": "#phyloref0"
                     }
-                ],
-                "hasRootNode": {
-                    "@id": "#phylogeny0_node0"
-                }
+                  }
+                ]
+              }
             }
-        ],
-        "hasTaxonomicUnitMatches": [],
-        "@id": "",
-        "@type": [
-            "testcase:PhyloreferenceTestCase",
-            "owl:Ontology"
-        ],
-        "owl:imports": [
-            "http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl",
-            "http://ontology.phyloref.org/2018-12-14/phyloref.owl",
-            "http://ontology.phyloref.org/2018-12-14/tcan.owl"
-        ],
-        "@context": "http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json"
+          ],
+          "labels": [
+            "1"
+          ],
+          "representsTaxonomicUnits": [],
+          "parent": "#phylogeny0_node1",
+          "siblings": [
+            "#phylogeny0_node6"
+          ],
+          "children": [
+            "#phylogeny0_node3",
+            "#phylogeny0_node4",
+            "#phylogeny0_node5"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node3",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Ee e"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Ee_e"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Ee_e",
+                "nameComplete": "Ee e",
+                "genusPart": "Ee",
+                "specificEpithet": "e"
+              },
+              "label": "Ee_e"
+            }
+          ],
+          "parent": "#phylogeny0_node2",
+          "siblings": [
+            "#phylogeny0_node4",
+            "#phylogeny0_node5"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node4",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Dd d"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Dd_d"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Dd_d",
+                "nameComplete": "Dd d",
+                "genusPart": "Dd",
+                "specificEpithet": "d"
+              },
+              "label": "Dd_d"
+            }
+          ],
+          "parent": "#phylogeny0_node2",
+          "siblings": [
+            "#phylogeny0_node3",
+            "#phylogeny0_node5"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node5",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Cc c"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Cc_c"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Cc_c",
+                "nameComplete": "Cc c",
+                "genusPart": "Cc",
+                "specificEpithet": "c"
+              },
+              "label": "Cc_c"
+            }
+          ],
+          "parent": "#phylogeny0_node2",
+          "siblings": [
+            "#phylogeny0_node3",
+            "#phylogeny0_node4"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node6",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Bb b"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Bb_b"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Bb_b",
+                "nameComplete": "Bb b",
+                "genusPart": "Bb",
+                "specificEpithet": "b"
+              },
+              "label": "Bb_b"
+            }
+          ],
+          "parent": "#phylogeny0_node1",
+          "siblings": [
+            "#phylogeny0_node2"
+          ]
+        },
+        {
+          "@id": "#phylogeny0_node7",
+          "rdf:type": [
+            {
+              "@id": "obo:CDAO_0000140"
+            },
+            {
+              "@type": "owl:Restriction",
+              "onProperty": "obo:CDAO_0000187",
+              "someValuesFrom": {
+                "@type": "owl:Restriction",
+                "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                "someValuesFrom": {
+                  "@type": "owl:Restriction",
+                  "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                  "hasValue": "Aa a"
+                }
+              }
+            }
+          ],
+          "labels": [
+            "Aa_a"
+          ],
+          "representsTaxonomicUnits": [
+            {
+              "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+              "hasName": {
+                "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                "label": "Aa_a",
+                "nameComplete": "Aa a",
+                "genusPart": "Aa",
+                "specificEpithet": "a"
+              },
+              "label": "Aa_a"
+            }
+          ],
+          "parent": "#phylogeny0_node0",
+          "siblings": [
+            "#phylogeny0_node1"
+          ]
+        }
+      ],
+      "hasRootNode": {
+        "@id": "#phylogeny0_node0"
+      }
     }
-]
+  ],
+  "hasTaxonomicUnitMatches": [],
+  "@type": [
+    "testcase:PhyloreferenceTestCase",
+    "owl:Ontology"
+  ],
+  "owl:imports": [
+    "http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl",
+    "http://ontology.phyloref.org/2018-12-14/phyloref.owl",
+    "http://ontology.phyloref.org/2018-12-14/tcan.owl"
+  ],
+  "@context": "http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json"
+}


### PR DESCRIPTION
This PR includes a major rewrite and simplification of the TestCommand logic, which adds support for model 2.0 expected resolution information (as per PR phyloref/phyx.js#42).

Closes #58.