### PR TITLE
Make WebserverCommand work on macOS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.2</version>
+        <version>0.8.4</version>
         <configuration>
           <!-- These rules are to ensure that CI output records that we still
           haven't finished testing this code, which is why we don't halt on failure. -->

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -265,6 +265,20 @@ public class WebserverCommand implements Command {
       System.out.println(">> Request received to '" + path + "': " + params);
 
       if (path.equals("/reason")) {
+        // If it is an OPTIONS request, it's probably someone wanting a
+        // pre-flight CORS request. Let's give them that.
+        if (session.getMethod().equals(Method.OPTIONS)) {
+          Response preflightResponse =
+              newFixedLengthResponse(Response.Status.OK, MIME_PLAINTEXT, "Options");
+
+          // Indicate that any resource can access this resource.
+          preflightResponse.addHeader("Access-Control-Allow-Origin", "*");
+          preflightResponse.addHeader("Access-Control-Allow-Methods", "POST");
+          preflightResponse.addHeader("Access-Control-Allow-Headers", "x-hub-signature");
+
+          return preflightResponse;
+        }
+
         // We accept two kinds of inputs:
         //  1. A form containing 'jsonld' as a JSON-LD string to process.
         //  2. A form containing 'jsonldFile' as a JSON-LD file to read.


### PR DESCRIPTION
I tried running JPhyloRef's webserver on my Mac laptop, and ran into two issues when using it as a local backend for the Open Tree Resolver:
1. Version 0.8.2 of the [Java Code Coverage Library (Jacoco)](https://github.com/jacoco/jacoco) used in our build process didn't run correctly on macOS. Updating it to 0.8.4 fixed this problem.
2. On macOS, Firefox would send the webserver a [CORS preflight request](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) which it did not correctly respond to. I've modified it to respond correctly.