### PR TITLE
Added support for receiving JSON-LD files compressed with Gzip

### DIFF
--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -292,7 +292,7 @@ public class WebserverCommand implements Command {
         // For simplicity's sake, we convert all the possible forms into a
         // File for processing.
         try {
-          String jsonldFile = null;
+          File jsonldFile = null;
 
           if (params.containsKey("jsonldFile")) {
             // It's already a file!
@@ -320,9 +320,9 @@ public class WebserverCommand implements Command {
               BufferedReader reader = new BufferedReader(new InputStreamReader(gzis, "UTF-8"));
               StringBuffer jsonldStringBuffer = new StringBuffer();
 
-              String read;
-              while ((read = reader.readLine()) != null) {
-                jsonldStringBuffer.append(readed);
+              String buffer;
+              while ((buffer = reader.readLine()) != null) {
+                jsonldStringBuffer.append(buffer);
               }
 
               // Store UTF-8 string for further processing.
@@ -338,7 +338,6 @@ public class WebserverCommand implements Command {
             // Store the JSON-LD into a file for further processing.
             if (jsonld != null) {
               jsonldFile = File.createTempFile("jphyloref", null);
-
               FileWriter writer = new FileWriter(jsonldFile);
               writer.write(String.join(";", jsonld));
               writer.close();


### PR DESCRIPTION
When I tried hosting JPhyloRef on my own server, I ran into extremely long upload times when uploading Brochu 2003 JSON-LD file (which is around 22mb in size) to JPhyloRef (~7 mins from Colorado to NYC). I managed to reduce this tremendously (to ~2 seconds) by allowing clients to upload JSON-LD files that had been compressed with [gzip](https://en.wikipedia.org/wiki/Gzip) and then converted into a string as [base64](https://en.wikipedia.org/wiki/Base64). This PR adds support for this on JPhyloRef's webserver: if a string is provided in the `jsonldGzipped` form field, it is converted from base64 into binary data and then uncompressed into a UTF-8 string for processing.

This should be merged after #62 has been merged.