### PR TITLE
Add the filename to the testing output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 
 ## [Unreleased]
+- Display the filename of the input file in the testing output.
 - Added a "resolve" command that resolves phylorefs in input ontologies (in OWL
   or JSON-LD) and returns the result as a JSON string (#52).
 - Centralized code for determining nodes in phylorefs (#53, #54).

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -183,6 +183,7 @@ public class TestCommand implements Command {
     TapProducer tapProducer = TapProducerFactory.makeTap13Producer();
     TestSet testSet = new TestSet();
     testSet.setPlan(new Plan(phylorefs.size()));
+    testSet.addComment(new Comment("From file: " + inputFilename));
     testSet.addComment(
         new Comment(
             "Using reasoner: "

--- a/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
+++ b/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
@@ -51,7 +51,9 @@ class TestCommandTest {
             "Testing complete:1 successes, 0 failures, 0 failures marked TODO, 0 skipped.\n"),
         "Stderr should end with single success but returned: " + stderrStr);
     assertEquals(
-        "1..1\n# Using reasoner: ELK/2016-01-11T13:41:15Z\nok 1 "
+        "1..1\n# From file: "
+            + filename
+            + "\n# Using reasoner: ELK/2016-01-11T13:41:15Z\nok 1 "
             + phylorefName
             + "\n# The following nodes were matched and expected this phyloreference: [1]\n\n",
         stdoutStr);


### PR DESCRIPTION
This PR adds the name of the input file to the testing output, which makes your life easier if you're testing multiple files in sequence and concatenating the results together. Also updates tests.