### PR TITLE
Release v0.3 of JPhyloRef

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: java
 cache:
   directories:
   - $HOME/.m2
+install: skip   # This tries to install dependencies, which fail for some
+                # reason. Just running the tests directly works fine.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 
 ## [Unreleased]
+- None as yet.
+
+## [0.3] - 2020-04-20
 - Replaced `System.err` and `System.out` with calls to SLF4J (#51).
 - Display the filename of the input file in the testing output.
 - Added a "resolve" command that resolves phylorefs in input ontologies (in OWL
@@ -11,7 +14,7 @@ Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 - Added support for the Elk reasoner (as "elk") and made it the default reasoner.
 - Phyloreferences were previously identified in input ontologies by looking for
   individuals defined as instances of the class phyloref:Phyloreference. They
-  are now identified as subclasses of phyloref:Phyloreference. This is in line 
+  are now identified as subclasses of phyloref:Phyloreference. This is in line
   with the changes introduced by moving from the 2018-12-04 release of the
   Phyloref Ontology to the 2018-12-14 release.
 - Removed ReasonCommand, which is no longer useful.
@@ -25,18 +28,22 @@ Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
   internally.
 - WebserverCommand now looks for ontologies in the local 'ontologies/' directory.
 
-## 0.2 - 2018-06-20
+## [0.2] - 2018-06-20
 - Added support for phyloreference statuses using the Publication Status Ontology
   as per [phyloref/curation-tool#25].
 - Added a `--no-reasoner` mode to testing, allowing pre-reasoned ontologies to be
   tested.
 - Fixed some spacing and line-ending issues.
 
-## 0.1 - 2018-06-20
+## [0.1] - 2018-06-20
 - Initial release, with support for testing phyloreferences expressed in OWL
   and stored in RDF/XML.
 
-[Unreleased]: https://github.com/phyloref/jphyloref/compare/v0.2...HEAD
+[Unreleased]: https://github.com/phyloref/jphyloref/compare/v0.3...HEAD
+[0.3]: https://github.com/phyloref/jphyloref/releases/tag/v0.3
+[0.2]: https://github.com/phyloref/jphyloref/releases/tag/v0.2
+[0.1]: https://github.com/phyloref/jphyloref/releases/tag/v0.1
+
 [phyloref/curation-tool#25]: https://github.com/phyloref/curation-tool/issues/25
 [phyloref/jphyloref#13]: https://github.com/phyloref/jphyloref/pull/13
 [phyloref/jphyloref#12]: https://github.com/phyloref/jphyloref/pull/12

--- a/README.md
+++ b/README.md
@@ -44,3 +44,21 @@ Many command line options can be used for all included commands:
 
 JPhyloRef can be [set up on a SLURM cluster using Webhook](webhook/README.md),
 allowing jobs to be executed on a separate computer from the web server.
+
+# Publishing to Sonatype OSSRH
+
+To publish this package to the [Sonatype OSSRH], we follow the workflow
+detailed on [the Sonatype website]. Note that you will need to set up a
+[Maven settings.xml file] with your GPG settings in order to sign the
+package for publication.
+
+Once you're set up, you can run `mvn clean deploy` to publish the package
+to the OSSRH. If your version number ends in `-SNAPSHOT`, this will be
+published to the OSSRH Snapshots repository. Otherwise, it will be
+published to a staging repository. Once you have confirmed that OSSRH is
+happy with the package to be published, you can run
+`mvn clean deploy -P release` to release it to Maven Central.
+
+  [Sonatype OSSRH]: https://central.sonatype.org/pages/ossrh-guide.html
+  [the Sonatype website]: https://central.sonatype.org/pages/apache-maven.html
+  [Maven settings.xml file]: https://central.sonatype.org/pages/apache-maven.html

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.phyloref</groupId>
     <artifactId>jphyloref</artifactId>
-    <version>0.3</version>
+    <version>0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>jphyloref</name>
@@ -23,6 +23,17 @@
             <url>http://code.berkeleybop.org/maven/repository/</url>
         </repository>
     </repositories>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
     <dependencies>
         <!-- For processing command line arguments -->
@@ -221,24 +232,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.2.1</version>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>java</goal>
-                        </goals>
-                        <configuration>
-                            <mainClass>${mainClass}</mainClass>
-                            <arguments>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                  </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.0.0</version>
@@ -259,6 +252,65 @@
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- We publish to Sonatype OSSRH -->
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.8</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+
+            <!-- We need to create source JARs for deployment -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- We need to create Javadoc JARs for deployment -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- We need to sign our plugins for deployment -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.phyloref</groupId>
     <artifactId>jphyloref</artifactId>
-    <version>0.2-SNAPSHOT</version>
+    <version>0.3</version>
     <packaging>jar</packaging>
 
     <name>jphyloref</name>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,31 @@
     <version>0.3</version>
     <packaging>jar</packaging>
 
-    <name>jphyloref</name>
+    <name>JPhyloRef</name>
+    <description>A tool for testing and resolving phyloreferences as OWL ontologies.</description>
+    <url>https://github.com/phyloref/jphyloref</url>
+
+    <scm>
+        <connection>scm:git:git://github.com/phyloref/jphyloref.git</connection>
+        <developerConnection>scm:git:ssh://github.com:phyloref/jphyloref.git</developerConnection>
+        <url>http://github.com/phyloref/jphyloref/</url>
+    </scm>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Gaurav Vaidya</name>
+            <email>gaurav@ggvaidya.com</email>
+            <organization>Renaissance Computing Institute, University of North Carolina</organization>
+            <organizationUrl>https://renci.org/</organizationUrl>
+        </developer>
+    </developers>
 
     <properties>
         <mainClass>org.phyloref.jphyloref.JPhyloRef</mainClass>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.phyloref</groupId>
     <artifactId>jphyloref</artifactId>
-    <version>0.3-SNAPSHOT</version>
+    <version>0.3</version>
     <packaging>jar</packaging>
 
     <name>jphyloref</name>

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -38,6 +38,7 @@ public class JPhyloRef {
    * Interpret the command line arguments to determine which command to execute.
    *
    * @param args Command line arguments
+   * @return The exit code to return to the shell (0 = success, other values = errors).
    */
   public int execute(String[] args) {
     // Prepare to parse command line arguments.

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -27,7 +27,7 @@ public class JPhyloRef {
   private static final Logger logger = LoggerFactory.getLogger(JPhyloRef.class);
 
   /** Version of JPhyloRef. */
-  public static final String VERSION = "0.2-SNAPSHOT";
+  public static final String VERSION = "0.3";
 
   /** List of all commands included in JPhyloRef. */
   private List<Command> commands =

--- a/src/main/java/org/phyloref/jphyloref/commands/Command.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/Command.java
@@ -7,7 +7,7 @@ import org.apache.commons.cli.Options;
  * Commands provide commands for jphyloref to run. These are usually in the form 'jphyloref
  * <em>command</em> ...'
  *
- * @author Gaurav Vaidya <gaurav@ggvaidya.com>
+ * @author Gaurav Vaidya
  */
 public interface Command {
   /**
@@ -20,7 +20,7 @@ public interface Command {
   /**
    * A one-line description of this command.
    *
-   * @return
+   * @return A one-line description of this command as a String.
    */
   public String getDescription();
 
@@ -30,6 +30,8 @@ public interface Command {
   /**
    * Execute this command with the provided command line options, and provide an exit value to
    * return to the operating system.
+   *
+   * @param cmdLine The CommandLine to be executed.
    */
   public int execute(CommandLine cmdLine);
 }

--- a/src/main/java/org/phyloref/jphyloref/commands/ResolveCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/ResolveCommand.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * command line, which is while for now it returns its results in the JSON format. We might
  * eventually want to switch over to YAML or another more command line friendly format.
  *
- * @author Gaurav Vaidya <gaurav@ggvaidya.com>
+ * @author Gaurav Vaidya
  */
 public class ResolveCommand implements Command {
   /** Set up a logger to use for providing logging. */

--- a/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/TestCommand.java
@@ -53,7 +53,7 @@ import org.tap4j.util.StatusValues;
  * <p>Testing output is produced using the Test Anything Protocol, which has nice libraries in both
  * Python and Java.
  *
- * @author Gaurav Vaidya <gaurav@ggvaidya.com>
+ * @author Gaurav Vaidya
  */
 public class TestCommand implements Command {
   /** Set up a logger to use for providing logging. */

--- a/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
+++ b/src/main/java/org/phyloref/jphyloref/commands/WebserverCommand.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  * which the keys are the IRIs for each phyloreference, and the values are lists of the IRIs of each
  * node matched by that phyloreference.
  *
- * @author Gaurav Vaidya <gaurav@ggvaidya.com>
+ * @author Gaurav Vaidya
  */
 public class WebserverCommand implements Command {
   /** Set up a logger to use for providing logging. */

--- a/src/main/java/org/phyloref/jphyloref/helpers/JSONLDHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/JSONLDHelper.java
@@ -17,12 +17,15 @@ import org.semanticweb.owlapi.util.AnonymousNodeChecker;
 /**
  * JSONLDHelper provides methods to help read and process JSON-LD files.
  *
- * @author Gaurav Vaidya <gaurav@ggvaidya.com>
+ * @author Gaurav Vaidya
  */
 public class JSONLDHelper {
   /**
-   * Create an RDFParser for JSON-LD files. When the parser's <tt>parse()</tt> method is called, its
-   * contents will be added to the OWLOntology passed to this method.
+   * Create an RDFParser for JSON-LD files. When the parser's <code>parse()</code> method is called,
+   * its contents will be added to the OWLOntology passed to this method.
+   *
+   * @param ontology The ontology to create an RDF parser for.
+   * @return An RDF Parser that can be used to read an OWL ontology from JSON-LD.
    */
   public static RDFParser createRDFParserForOntology(OWLOntology ontology) {
     // Set up a RioOWLRDFConsumerAdapter that will take in RDF and will

--- a/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/OWLHelper.java
@@ -17,7 +17,7 @@ import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
 /**
  * OWLHelper contains methods simplify accessing information from the OWL API.
  *
- * @author Gaurav Vaidya <gaurav@ggvaidya.com>
+ * @author Gaurav Vaidya
  */
 public final class OWLHelper {
   /** A variable we use to cache rdfs:label */
@@ -26,6 +26,9 @@ public final class OWLHelper {
   /**
    * Returns OWL property rdfs:label, using a cache so we don't need to load the property using the
    * data property.
+   *
+   * @param ontology The ontology whose OWLAnnotationProperty we want.
+   * @return The OWLAnnotationProperty of rdfs:label.
    */
   public static OWLAnnotationProperty getLabelProperty(OWLOntology ontology) {
     if (cache_labelProperty != null) return cache_labelProperty;

--- a/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/PhylorefHelper.java
@@ -32,7 +32,7 @@ import org.semanticweb.owlapi.search.EntitySearcher;
  * <p>Eventually, this will be reorganized into a Phyloreferencing Java library, but we don't need
  * that level of sophistication just yet.
  *
- * @author Gaurav Vaidya <gaurav@ggvaidya.com>
+ * @author Gaurav Vaidya
  */
 public class PhylorefHelper {
   // IRIs used in this package.

--- a/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
@@ -17,7 +17,7 @@ import uk.ac.manchester.cs.jfact.JFactFactory;
  * The ReasonerHelper provides methods to help create and manage OWL Reasoners, and to allow the
  * user to choose a different reasoner to carry out any specified task.
  *
- * @author Gaurav Vaidya <gaurav@ggvaidya.com>
+ * @author Gaurav Vaidya
  */
 public class ReasonerHelper {
   /** A map of reasoner names and the corresponding reasoner factory */


### PR DESCRIPTION
This PR includes [v0.3](https://github.com/phyloref/jphyloref/releases/tag/v0.3) of JPhyloRef, as deployed to Maven Central at https://search.maven.org/artifact/org.phyloref/jphyloref/0.3/jar. It includes some changes:
 - Modifications to pom.xml to incorporate the [nexus-staging-maven-plugin](https://github.com/sonatype/nexus-maven-plugins/tree/master/staging/maven-plugin), which automates many of the steps in publishing a Java package to the [Sonatype OSSRH](https://central.sonatype.org/pages/ossrh-guide.html).
 - Publishing to Maven Central requires that Javadoc can be run on all source files. Unfortunately, our source files have e-mail addresses in a format that caused Javadoc to fail. This PR removes those e-mail addresses.
 - Publishing to Maven Central requires some package metadata to be entered into the pom.xml file. This PR does that, and confirms that we meet all requirements to publish to Sonatype OSSRH. The code published to Maven Central as v0.3 have been tagged [v0.3](https://github.com/phyloref/jphyloref/releases/tag/v0.3). Closes #50.
 - I've also documented how to publish to Maven Central in the README file.
 - Updates the CHANGELOG and tags release v0.3.