### PR TITLE
Fix bug in return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 
 ## [Unreleased]
-- None as yet.
+- JPhyloRef was incorrectly returning an exit code of `0` whether or not
+  testing succeeded. It now returns `0` only if all testing succeeded,
+  `-1` if no phyloreferences succeeded, and the number of failing
+  phyloreferences otherwise.
 
 ## [0.3] - 2020-04-20
 - Replaced `System.err` and `System.out` with calls to SLF4J (#51).

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -77,8 +77,7 @@ public class JPhyloRef {
       for (Command cmd : commands) {
         if (cmd.getName().equalsIgnoreCase(command)) {
           // Found a match!
-          cmd.execute(cmdLine);
-          return 0;
+          return cmd.execute(cmdLine);
         }
       }
 

--- a/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
+++ b/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
@@ -169,5 +169,59 @@ class TestCommandTest {
         resetIO();
       }
     }
+
+    @Test
+    @DisplayName(
+        "can report an ontology with one correctly resolved and one incorrectly resolved phyloref")
+    void testJSONLDWithFailure() {
+      // The test file we're going to use in this test.
+      String testFilename = "src/test/resources/phylorefs/failing1.jsonld";
+
+      // We're going to take over STDIN, so let's save the real STDIN so we can
+      // restore it.
+      InputStream actualStdin = System.in;
+
+      try {
+        // Reset STDOUT and STDERR and set STDIN.
+        resetIO();
+
+        // Test the contents of STDIN.
+        int exitCode = jphyloref.execute(new String[] {"test", "--jsonld", testFilename});
+
+        // Obtain STDOUT and STDERR.
+        String outputStr = output.toString("UTF-8");
+        String errorStr = error.toString("UTF-8");
+
+        // Test whether the exit code, STDERR and STDOUT is as expected.
+        assertEquals(1, exitCode);
+        assertTrue(
+            errorStr.contains("Input: " + testFilename),
+            "Make sure JPhyloRef reports the name of the file being processed");
+        assertTrue(
+            errorStr.endsWith(
+                "Testing complete:1 successes, 1 failures, 0 failures marked TODO, 0 skipped.\n"),
+            "Stderr should end with single success but returned: " + errorStr);
+        assertEquals(
+            "1..2\n# From file: "
+                + testFilename
+                + "\n# Using reasoner: ELK/2016-01-11T13:41:15Z\n"
+                + "ok 1 Phyloreference '1'\n"
+                + "# The following nodes were matched and expected this phyloreference: [1]\n"
+                + "not ok 2 Phyloreference '2'\n"
+                + "# The following nodes were matched but did not expect this phyloreference: [1]\n\n",
+            outputStr);
+
+      } catch (UnsupportedEncodingException ex) {
+        // Could be thrown when converting STDOUT/STDERR to String as UTF-8.
+        throw new RuntimeException("'UTF-8' is not supported as an encoding: " + ex);
+      } catch (IOException ex) {
+        // Could be thrown if there were errors reading the testing file.
+        throw new RuntimeException(
+            "Expected testing file '" + testFilename + "' not found or could not be read: " + ex);
+      } finally {
+        // Reset STDOUT and STDERR.
+        resetIO();
+      }
+    }
   }
 }

--- a/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
+++ b/src/test/java/org/phyloref/jphyloref/TestCommandTest.java
@@ -185,7 +185,7 @@ class TestCommandTest {
         // Reset STDOUT and STDERR and set STDIN.
         resetIO();
 
-        // Test the contents of STDIN.
+        // Test the test file, which we expect to have one success and one failure.
         int exitCode = jphyloref.execute(new String[] {"test", "--jsonld", testFilename});
 
         // Obtain STDOUT and STDERR.

--- a/src/test/resources/phylorefs/failing1.json
+++ b/src/test/resources/phylorefs/failing1.json
@@ -1,0 +1,70 @@
+{
+    "phylorefs": [
+        {
+            "label": "1",
+            "internalSpecifiers": [
+                {
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                        "label": "Cc c",
+                        "nameComplete": "Cc c",
+                        "genusPart": "Cc",
+                        "specificEpithet": "c"
+                    },
+                    "label": "Cc c"
+                },
+                {
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                        "label": "Ee e",
+                        "nameComplete": "Ee e",
+                        "genusPart": "Ee",
+                        "specificEpithet": "e"
+                    },
+                    "label": "Ee e"
+                }
+            ],
+            "externalSpecifiers": []
+        },
+        {
+            "label": "2",
+            "internalSpecifiers": [
+                {
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                        "label": "Cc c",
+                        "nameComplete": "Cc c",
+                        "genusPart": "Cc",
+                        "specificEpithet": "c"
+                    },
+                    "label": "Cc c"
+                },
+                {
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                        "label": "Ee e",
+                        "nameComplete": "Ee e",
+                        "genusPart": "Ee",
+                        "specificEpithet": "e"
+                    },
+                    "label": "Ee e"
+                }
+            ],
+            "externalSpecifiers": []
+        }
+
+    ],
+    "phylogenies": [
+        {
+            "newick": "(Aa_a, (Bb_b, (Cc_c, Dd_d, Ee_e)1)2)3"
+        }
+    ]
+}

--- a/src/test/resources/phylorefs/failing1.jsonld
+++ b/src/test/resources/phylorefs/failing1.jsonld
@@ -1,0 +1,442 @@
+[
+    {
+        "phylorefs": [
+            {
+                "label": "1",
+                "internalSpecifiers": [
+                    {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                        "hasName": {
+                            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                            "label": "Cc c",
+                            "nameComplete": "Cc c",
+                            "genusPart": "Cc",
+                            "specificEpithet": "c"
+                        },
+                        "label": "Cc c"
+                    },
+                    {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                        "hasName": {
+                            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                            "label": "Ee e",
+                            "nameComplete": "Ee e",
+                            "genusPart": "Ee",
+                            "specificEpithet": "e"
+                        },
+                        "label": "Ee e"
+                    }
+                ],
+                "externalSpecifiers": [],
+                "@id": "#phyloref0",
+                "@type": "owl:Class",
+                "subClassOf": "phyloref:Phyloreference",
+                "hasAdditionalClass": [],
+                "equivalentClass": [
+                    {
+                        "@type": "owl:Restriction",
+                        "onProperty": "obo:CDAO_0000149",
+                        "someValuesFrom": {
+                            "@type": "owl:Class",
+                            "intersectionOf": [
+                                {
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "phyloref:excludes_TU",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                        "someValuesFrom": {
+                                            "@type": "owl:Restriction",
+                                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                            "hasValue": "Cc c"
+                                        }
+                                    }
+                                },
+                                {
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "phyloref:includes_TU",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                        "someValuesFrom": {
+                                            "@type": "owl:Restriction",
+                                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                            "hasValue": "Ee e"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            {
+                "label": "2",
+                "internalSpecifiers": [
+                    {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                        "hasName": {
+                            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                            "label": "Cc c",
+                            "nameComplete": "Cc c",
+                            "genusPart": "Cc",
+                            "specificEpithet": "c"
+                        },
+                        "label": "Cc c"
+                    },
+                    {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                        "hasName": {
+                            "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                            "label": "Ee e",
+                            "nameComplete": "Ee e",
+                            "genusPart": "Ee",
+                            "specificEpithet": "e"
+                        },
+                        "label": "Ee e"
+                    }
+                ],
+                "externalSpecifiers": [],
+                "@id": "#phyloref1",
+                "@type": "owl:Class",
+                "subClassOf": "phyloref:Phyloreference",
+                "hasAdditionalClass": [],
+                "equivalentClass": [
+                    {
+                        "@type": "owl:Restriction",
+                        "onProperty": "obo:CDAO_0000149",
+                        "someValuesFrom": {
+                            "@type": "owl:Class",
+                            "intersectionOf": [
+                                {
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "phyloref:excludes_TU",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                        "someValuesFrom": {
+                                            "@type": "owl:Restriction",
+                                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                            "hasValue": "Cc c"
+                                        }
+                                    }
+                                },
+                                {
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "phyloref:includes_TU",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                        "someValuesFrom": {
+                                            "@type": "owl:Restriction",
+                                            "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                            "hasValue": "Ee e"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ],
+        "phylogenies": [
+            {
+                "newick": "(Aa_a, (Bb_b, (Cc_c, Dd_d, Ee_e)1)2)3",
+                "@id": "#phylogeny0",
+                "@type": "testcase:PhyloreferenceTestPhylogeny",
+                "nodes": [
+                    {
+                        "@id": "#phylogeny0_node0",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            }
+                        ],
+                        "labels": [
+                            "3"
+                        ],
+                        "representsTaxonomicUnits": [],
+                        "children": [
+                            "#phylogeny0_node1",
+                            "#phylogeny0_node7"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node1",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            }
+                        ],
+                        "labels": [
+                            "2"
+                        ],
+                        "representsTaxonomicUnits": [],
+                        "parent": "#phylogeny0_node0",
+                        "siblings": [
+                            "#phylogeny0_node7"
+                        ],
+                        "children": [
+                            "#phylogeny0_node2",
+                            "#phylogeny0_node6"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node2",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            }
+                        ],
+                        "labels": [
+                            "1"
+                        ],
+                        "representsTaxonomicUnits": [],
+                        "parent": "#phylogeny0_node1",
+                        "siblings": [
+                            "#phylogeny0_node6"
+                        ],
+                        "children": [
+                            "#phylogeny0_node3",
+                            "#phylogeny0_node4",
+                            "#phylogeny0_node5"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node3",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            },
+                            {
+                                "@type": "owl:Restriction",
+                                "onProperty": "obo:CDAO_0000187",
+                                "someValuesFrom": {
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                        "hasValue": "Ee e"
+                                    }
+                                }
+                            }
+                        ],
+                        "labels": [
+                            "Ee_e"
+                        ],
+                        "representsTaxonomicUnits": [
+                            {
+                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                                "hasName": {
+                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                                    "label": "Ee_e",
+                                    "nameComplete": "Ee e",
+                                    "genusPart": "Ee",
+                                    "specificEpithet": "e"
+                                },
+                                "label": "Ee_e"
+                            }
+                        ],
+                        "parent": "#phylogeny0_node2",
+                        "siblings": [
+                            "#phylogeny0_node4",
+                            "#phylogeny0_node5"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node4",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            },
+                            {
+                                "@type": "owl:Restriction",
+                                "onProperty": "obo:CDAO_0000187",
+                                "someValuesFrom": {
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                        "hasValue": "Dd d"
+                                    }
+                                }
+                            }
+                        ],
+                        "labels": [
+                            "Dd_d"
+                        ],
+                        "representsTaxonomicUnits": [
+                            {
+                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                                "hasName": {
+                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                                    "label": "Dd_d",
+                                    "nameComplete": "Dd d",
+                                    "genusPart": "Dd",
+                                    "specificEpithet": "d"
+                                },
+                                "label": "Dd_d"
+                            }
+                        ],
+                        "parent": "#phylogeny0_node2",
+                        "siblings": [
+                            "#phylogeny0_node3",
+                            "#phylogeny0_node5"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node5",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            },
+                            {
+                                "@type": "owl:Restriction",
+                                "onProperty": "obo:CDAO_0000187",
+                                "someValuesFrom": {
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                        "hasValue": "Cc c"
+                                    }
+                                }
+                            }
+                        ],
+                        "labels": [
+                            "Cc_c"
+                        ],
+                        "representsTaxonomicUnits": [
+                            {
+                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                                "hasName": {
+                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                                    "label": "Cc_c",
+                                    "nameComplete": "Cc c",
+                                    "genusPart": "Cc",
+                                    "specificEpithet": "c"
+                                },
+                                "label": "Cc_c"
+                            }
+                        ],
+                        "parent": "#phylogeny0_node2",
+                        "siblings": [
+                            "#phylogeny0_node3",
+                            "#phylogeny0_node4"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node6",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            },
+                            {
+                                "@type": "owl:Restriction",
+                                "onProperty": "obo:CDAO_0000187",
+                                "someValuesFrom": {
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                        "hasValue": "Bb b"
+                                    }
+                                }
+                            }
+                        ],
+                        "labels": [
+                            "Bb_b"
+                        ],
+                        "representsTaxonomicUnits": [
+                            {
+                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                                "hasName": {
+                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                                    "label": "Bb_b",
+                                    "nameComplete": "Bb b",
+                                    "genusPart": "Bb",
+                                    "specificEpithet": "b"
+                                },
+                                "label": "Bb_b"
+                            }
+                        ],
+                        "parent": "#phylogeny0_node1",
+                        "siblings": [
+                            "#phylogeny0_node2"
+                        ]
+                    },
+                    {
+                        "@id": "#phylogeny0_node7",
+                        "rdf:type": [
+                            {
+                                "@id": "obo:CDAO_0000140"
+                            },
+                            {
+                                "@type": "owl:Restriction",
+                                "onProperty": "obo:CDAO_0000187",
+                                "someValuesFrom": {
+                                    "@type": "owl:Restriction",
+                                    "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName",
+                                    "someValuesFrom": {
+                                        "@type": "owl:Restriction",
+                                        "onProperty": "http://rs.tdwg.org/ontology/voc/TaxonName#nameComplete",
+                                        "hasValue": "Aa a"
+                                    }
+                                }
+                            }
+                        ],
+                        "labels": [
+                            "Aa_a"
+                        ],
+                        "representsTaxonomicUnits": [
+                            {
+                                "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                                "hasName": {
+                                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000036",
+                                    "label": "Aa_a",
+                                    "nameComplete": "Aa a",
+                                    "genusPart": "Aa",
+                                    "specificEpithet": "a"
+                                },
+                                "label": "Aa_a"
+                            }
+                        ],
+                        "parent": "#phylogeny0_node0",
+                        "siblings": [
+                            "#phylogeny0_node1"
+                        ]
+                    }
+                ],
+                "hasRootNode": {
+                    "@id": "#phylogeny0_node0"
+                }
+            }
+        ],
+        "hasTaxonomicUnitMatches": [],
+        "@id": "",
+        "@type": [
+            "testcase:PhyloreferenceTestCase",
+            "owl:Ontology"
+        ],
+        "owl:imports": [
+            "http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl",
+            "http://ontology.phyloref.org/2018-12-14/phyloref.owl",
+            "http://ontology.phyloref.org/2018-12-14/tcan.owl"
+        ],
+        "@context": "http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json"
+    }
+]


### PR DESCRIPTION
This PR fixes a bug which caused the Test Command to always return an exit code of 0 whether or not the input file passed testing. This PR restores the expected behavior: it returns 0 if all phyloreferences resolved as expected, -1 if no phyloreferences resolved as expected, and the number of failing phyloreferences otherwise.

Should be merged after PR #66.

I'm not sure why automated Travis testing has suddenly stopped working; it looks like Travis is still picking up new pull requests, but their pass/fail status is not being picked up by Github correctly. However, this PR has passed testing as of 6e24c6b: https://travis-ci.org/github/phyloref/jphyloref/builds/686258092