### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 
-## [Unreleased]
+## [0.3.1] - 2020-05-13
 - JPhyloRef was incorrectly returning an exit code of `0` whether or not
   testing succeeded. It now returns `0` only if all testing succeeded,
   `-1` if no phyloreferences succeeded, and the number of failing
@@ -43,6 +43,7 @@ Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
   and stored in RDF/XML.
 
 [Unreleased]: https://github.com/phyloref/jphyloref/compare/v0.3...HEAD
+[0.3.1]: https://github.com/phyloref/jphyloref/releases/tag/v0.3.1
 [0.3]: https://github.com/phyloref/jphyloref/releases/tag/v0.3
 [0.2]: https://github.com/phyloref/jphyloref/releases/tag/v0.2
 [0.1]: https://github.com/phyloref/jphyloref/releases/tag/v0.1

--- a/README.md
+++ b/README.md
@@ -54,10 +54,7 @@ package for publication.
 
 Once you're set up, you can run `mvn clean deploy` to publish the package
 to the OSSRH. If your version number ends in `-SNAPSHOT`, this will be
-published to the OSSRH Snapshots repository. Otherwise, it will be
-published to a staging repository. Once you have confirmed that OSSRH is
-happy with the package to be published, you can run
-`mvn clean deploy -P release` to release it to Maven Central.
+published to the OSSRH Snapshots repository.
 
   [Sonatype OSSRH]: https://central.sonatype.org/pages/ossrh-guide.html
   [the Sonatype website]: https://central.sonatype.org/pages/apache-maven.html

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.phyloref</groupId>
     <artifactId>jphyloref</artifactId>
-    <version>0.3</version>
+    <version>0.3.1</version>
     <packaging>jar</packaging>
 
     <name>JPhyloRef</name>

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -27,7 +27,7 @@ public class JPhyloRef {
   private static final Logger logger = LoggerFactory.getLogger(JPhyloRef.class);
 
   /** Version of JPhyloRef. */
-  public static final String VERSION = "0.3";
+  public static final String VERSION = "0.3.1";
 
   /** List of all commands included in JPhyloRef. */
   private List<Command> commands =


### PR DESCRIPTION
This release is solely for releasing PR #67 to OSSRH, since we need it to finish phyloref/phyx.js#52. The [only differences](https://github.com/phyloref/jphyloref/compare/v0.3...release/v0.3.1?expand=1) between v0.3 and v0.3.1 are that bug fix, concomitant tests and an addition to the README describing how to publish JPhyloRef to OSSRH. Once reviewed, I'll tag and publish this release.