### PR TITLE
JPhyloRef v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@
 Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 
 ## [Unreleased]
+
+## [0.4.0] - 2021-02-03
 - Updated JPhyloRef to use model 2.0 expectations, encoded as logical expressions
   on the phylogeny node, rather than comparing labels or using text-based properties.
   You will need to use Phyx.js 0.2.0 or higher to generate ontologies that can be
   tested with this version of JPhyloRef.
+- Phyloreferences without any expected resolution are now skipped during testing.
+- Replaced Travis CI as continuous integration system with Github Actions.
 
 ## [0.3.1] - 2020-05-13
 - JPhyloRef was incorrectly returning an exit code of `0` whether or not
@@ -48,7 +52,8 @@ Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 - Initial release, with support for testing phyloreferences expressed in OWL
   and stored in RDF/XML.
 
-[Unreleased]: https://github.com/phyloref/jphyloref/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/phyloref/jphyloref/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/phyloref/jphyloref/releases/tag/v0.4.0
 [0.3.1]: https://github.com/phyloref/jphyloref/releases/tag/v0.3.1
 [0.3]: https://github.com/phyloref/jphyloref/releases/tag/v0.3
 [0.2]: https://github.com/phyloref/jphyloref/releases/tag/v0.2

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.phyloref</groupId>
     <artifactId>jphyloref</artifactId>
-    <version>0.3.1</version>
+    <version>0.4.0</version>
     <packaging>jar</packaging>
 
     <name>JPhyloRef</name>

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -27,7 +27,7 @@ public class JPhyloRef {
   private static final Logger logger = LoggerFactory.getLogger(JPhyloRef.class);
 
   /** Version of JPhyloRef. */
-  public static final String VERSION = "0.3.1";
+  public static final String VERSION = "0.4.0";
 
   /** List of all commands included in JPhyloRef. */
   private List<Command> commands =


### PR DESCRIPTION
This PR creates a new release for the changes made in PRs #60, #71 and #72. Once this PR is approved, I'll publish this to Maven and create a v0.4.0 tag.