### PR TITLE
Add javadoc.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # JPhyloRef
 
 [![Build Status](https://github.com/phyloref/jphyloref/workflows/Build%20with%20Maven/badge.svg)](https://github.com/phyloref/jphyloref/actions?query=workflow%3A%22Build+with+Maven%22)
+[![javadoc](https://javadoc.io/badge2/org.phyloref/jphyloref/javadoc.svg)](https://javadoc.io/doc/org.phyloref/jphyloref) 
 
 JPhyloRef wraps multiple OWL 2 reasoners and provides three ways in which they
 can be used to resolve [phyloreferences](http://phyloref.org):


### PR DESCRIPTION
http://javadoc.io offers free Javadoc documentation hosting for projects in the Central Maven repository. This PR adds a badge that links to the JPhyloRef documentation on their site.