### PR TITLE
JPhyloRef v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 
 ## [1.0.0] - 2021-04-15
 - Improved README by adding badges and build and execution instructions.
-- Updated Berkeley BOP URL from HTTP to HTTPS.
+- Removed FaCT++ JNI reasoner (JFact is still included.)
 
 ## [0.4.0] - 2021-02-03
 - Updated JPhyloRef to use model 2.0 expectations, encoded as logical expressions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 
 ## [Unreleased]
 
+## [1.0.0] - 2021-04-15
+- Improved README by adding badges and build and execution instructions.
+- Updated Berkeley BOP URL from HTTP to HTTPS.
+
 ## [0.4.0] - 2021-02-03
 - Updated JPhyloRef to use model 2.0 expectations, encoded as logical expressions
   on the phylogeny node, rather than comparing labels or using text-based properties.
@@ -52,7 +56,8 @@ Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 - Initial release, with support for testing phyloreferences expressed in OWL
   and stored in RDF/XML.
 
-[Unreleased]: https://github.com/phyloref/jphyloref/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/phyloref/jphyloref/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/phyloref/jphyloref/releases/tag/v1.0.0
 [0.4.0]: https://github.com/phyloref/jphyloref/releases/tag/v0.4.0
 [0.3.1]: https://github.com/phyloref/jphyloref/releases/tag/v0.3.1
 [0.3]: https://github.com/phyloref/jphyloref/releases/tag/v0.3

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ JPhyloRef can be built from source by running `mvn package` from the root direct
 for example:
 
 ```
-$ java -jar target/jphyloref-0.4.0.jar test src/test/resources/phylorefs/dummy1.owl
+$ java -jar target/jphyloref-1.0.0.jar test src/test/resources/phylorefs/dummy1.owl
 ```
 
 You can also download any published version of this software directly from Maven
@@ -38,7 +38,7 @@ If you have [Coursier] installed, you can download and run JPhyloRef in one step
 by running:
 
 ```
-$ coursier launch org.phyloref:jphyloref:0.4.0 -- test input.owl
+$ coursier launch org.phyloref:jphyloref:1.0.0 -- test input.owl
 ```
 
 # Command line options

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.phyloref</groupId>
     <artifactId>jphyloref</artifactId>
-    <version>0.4.0</version>
+    <version>1.0.0</version>
     <packaging>jar</packaging>
 
     <name>JPhyloRef</name>

--- a/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
+++ b/src/main/java/org/phyloref/jphyloref/JPhyloRef.java
@@ -27,7 +27,7 @@ public class JPhyloRef {
   private static final Logger logger = LoggerFactory.getLogger(JPhyloRef.class);
 
   /** Version of JPhyloRef. */
-  public static final String VERSION = "0.4.0";
+  public static final String VERSION = "1.0.0";
 
   /** List of all commands included in JPhyloRef. */
   private List<Command> commands =


### PR DESCRIPTION
This PR creates release JPhyloRef v1.0.0 by updating the version number and the CHANGELOG.

Once it has been approved, I'll publish JPhyloRef v1.0.0 to Maven Central.

Should be merged after PR #76.