### PR TITLE
Removed FaCT++ JNI as a built-in reasoner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,14 +40,6 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>BBOP</id>
-            <name>Berkeley BOP</name>
-            <url>http://code.berkeleybop.org/maven/repository/</url>
-        </repository>
-    </repositories>
-
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
@@ -129,13 +121,6 @@
       	    <artifactId>jfact</artifactId>
       	    <version>4.0.4</version>
       	</dependency>
-
-        <!-- Fact++ is a very fast JNI-based reasoner -->
-        <dependency>
-            <groupId>uk.ac.manchester.cs</groupId>
-            <artifactId>factplusplus</artifactId>
-            <version>1.5.2</version>
-        </dependency>
 
         <!-- Adds a StaticLoggerBinder for logging (as per phyloref/jphyloref#18) -->
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->

--- a/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/ReasonerHelper.java
@@ -10,7 +10,6 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 import org.semanticweb.owlapi.util.Version;
-import uk.ac.manchester.cs.factplusplus.owlapiv3.FaCTPlusPlusReasonerFactory;
 import uk.ac.manchester.cs.jfact.JFactFactory;
 
 /**
@@ -29,7 +28,6 @@ public class ReasonerHelper {
      */
     reasonerFactories.put("null", null);
     reasonerFactories.put("jfact", new JFactFactory());
-    reasonerFactories.put("fact++", new FaCTPlusPlusReasonerFactory());
     reasonerFactories.put("elk", new ElkReasonerFactory());
   }
 


### PR DESCRIPTION
[FaCT++ JNI](https://bitbucket.org/dtsarkov/factplusplus/src/master/) is a native port of the [FaCT++ reasoner](http://owl.cs.manchester.ac.uk/tools/fact/) to Java, and is one of the built-in reasoners supported by JPhyloRef. As of Maven 3.8.1, [external repositories must use HTTPS](https://maven.apache.org/docs/3.8.1/release-notes.html#how-to-fix-when-i-get-a-http-repository-blocked). This is a problem since the only repository on which FaCT++ is available, the [Berkeley BOP repository](http://code.berkeleybop.org/maven/repository/uk/ac/manchester/cs/factplusplus/index.html), is currently HTTP only.

It would be worth finding a workaround for if we needed to use FaCT++ JNI, but since we rely exclusively on Elk now, I think it makes more sense to just remove FaCT++ JNI and the Berkeley BOP repository from JPhyloRef. We will continue to include [JFact](http://jfact.sourceforge.net/), a pure Java port of the FaCT++ reasoner, as a built-in reasoner for JPhyloRef.