### PR TITLE
Fix XML/Markdown/JSON formatting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,10 @@
                       <include>**/*.md</include>
                       <include>**/*.json</include>
                     </includes>
-
+                    <excludes>
+                      <exclude>target/**</exclude>
+                      <exclude>dependency-reduced-pom.xml</exclude>
+                    </excludes>
 
                     <trimTrailingWhitespace/>
                     <endWithNewline/>

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,25 @@
                   </googleJavaFormat>
                   <removeUnusedImports/>
                 </java>
+
+                <formats>
+                  <!-- Clean up indentation in XML, Markdown and JSON files in this project. -->
+                  <format>
+                    <includes>
+                      <include>**/*.xml</include>
+                      <include>**/*.md</include>
+                      <include>**/*.json</include>
+                    </includes>
+
+
+                    <trimTrailingWhitespace/>
+                    <endWithNewline/>
+                    <indent>
+                      <spaces>true</spaces>
+                      <spacesPerTab>2</spacesPerTab>
+                    </indent>
+                  </format>
+                </formats>
               </configuration>
               <executions>
                 <execution>
@@ -245,12 +264,12 @@
             <!-- Recreate JAR file on every run -->
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
-	      <artifactId>maven-jar-plugin</artifactId>
-	      <version>3.2.0</version>
-	      <configuration>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
                 <forceCreation>true</forceCreation>
-	      </configuration>
-	    </plugin>
+        </configuration>
+      </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/webhook/hooks.json
+++ b/webhook/hooks.json
@@ -1,35 +1,35 @@
 [
-	{
-		"id": "reason",
-		"execute-command": "./exec_jphyloref_webhook.sh",
-		"command-working-directory": ".",
-		"pass-file-to-command": [
-			{
-				"source": "payload",
-				"name": "jsonld",
-				"envname": "JSONLD_FILENAME"
-			}
-		],
-		"include-command-output-in-response": true,
-		"response-headers": [
-			{
-				"name": "Content-type",
-				"value": "application/json"
-			},
-			{
-				"name": "Access-Control-Allow-Origin",
-				"value": "*"
-			}
-		],
-		"trigger-rule": {
-			"match": {
-				"type": "payload-hash-sha1",
-				"secret": "$SECRET",
-				"parameter": {
-					"source": "header",
-					"name": "X-Hub-Signature"
-				}
-			}
-		}
-	}
+  {
+    "id": "reason",
+    "execute-command": "./exec_jphyloref_webhook.sh",
+    "command-working-directory": ".",
+    "pass-file-to-command": [
+      {
+        "source": "payload",
+        "name": "jsonld",
+        "envname": "JSONLD_FILENAME"
+      }
+    ],
+    "include-command-output-in-response": true,
+    "response-headers": [
+      {
+        "name": "Content-type",
+        "value": "application/json"
+      },
+      {
+        "name": "Access-Control-Allow-Origin",
+        "value": "*"
+      }
+    ],
+    "trigger-rule": {
+      "match": {
+        "type": "payload-hash-sha1",
+        "secret": "$SECRET",
+        "parameter": {
+          "source": "header",
+          "name": "X-Hub-Signature"
+        }
+      }
+    }
+  }
 ]


### PR DESCRIPTION
This PR updates our [Spotless](https://github.com/diffplug/spotless) configuration so that indentation is standardized in XML, Markdown and JSON files. This should be checked when building code as well as during CI testing.

Should be merged after PR #84.