### PR TITLE
Fix IntelliJ settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,7 @@
     <properties>
         <mainClass>org.phyloref.jphyloref.JPhyloRef</mainClass>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>15</maven.compiler.release>
     </properties>
 
     <distributionManagement>
@@ -260,6 +259,7 @@
               <artifactId>maven-compiler-plugin</artifactId>
               <version>3.8.0</version>
               <configuration>
+                <release>${maven.compiler.release}</release>
                 <compilerArgument>-Xlint:unchecked</compilerArgument>
                 <showDeprecation>true</showDeprecation>
               </configuration>
@@ -285,8 +285,6 @@
                             implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                             <manifestEntries>
                                 <Main-Class>${mainClass}</Main-Class>
-                                <X-Compile-Source-JDK>${maven.compile.source}</X-Compile-Source-JDK>
-                                <X-Compile-Target-JDK>${maven.compile.target}</X-Compile-Target-JDK>
                             </manifestEntries>
                         </transformer>
                     </transformers>


### PR DESCRIPTION
IntelliJ gets confused by this repository because different parts of it appear to use different versions of Java. This PR merges the two maven.compiler.source/target values with the new [java --release parameter](http://openjdk.java.net/jeps/247). This seems to make IntelliJ happy.