### PR TITLE
Updated README to add `-SNAPSHOT` to the filename and to make the version number clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,10 @@ JPhyloRef can be built from source by running `mvn package` from the root direct
 for example:
 
 ```
-$ java -jar target/jphyloref-1.0.0.jar test src/test/resources/phylorefs/dummy1.owl
+$ java -jar target/jphyloref-1.1.0-SNAPSHOT.jar test src/test/resources/phylorefs/dummy1.owl
 ```
+
+(Note that `1.1.0` should be replaced by the correct version number -- look for the `Building JPhyloRef 1.1.0-SNAPSHOT` line in the output from `mvn package`)
 
 You can also download any published version of this software directly from Maven
 at https://search.maven.org/artifact/org.phyloref/jphyloref.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ for example:
 $ java -jar target/jphyloref-1.1.0-SNAPSHOT.jar test src/test/resources/phylorefs/dummy1.owl
 ```
 
-(Note that `1.1.0` should be replaced by the correct version number -- look for the `Building JPhyloRef 1.1.0-SNAPSHOT` line in the output from `mvn package`)
+(Note that `1.1.0` should be replaced by the correct version number -- look for the `Building JPhyloRef N.M.K-SNAPSHOT` line in the output from `mvn package`, where N.M.K is the version, such as 1.1.0)
 
 You can also download any published version of this software directly from Maven
 at https://search.maven.org/artifact/org.phyloref/jphyloref.


### PR DESCRIPTION
This PR updates the README file to make it clearer that:
1. The target JAR file will include `-SNAPSHOT` when in development.
2. The version number will change, and the version number output during `mvn package` should be used.

Closes #92