### PR TITLE
JPhyloRef v1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 
+## [Unreleased]
+
 ## [1.1.0] - 2021-08-07
 - Prepared manuscript for submission to the Journal of Open Source Software (JOSS).
 - Improved documentation based on JOSS reviewer feedback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 - Prepared manuscript for submission to the Journal of Open Source Software (JOSS).
 - Improved documentation based on JOSS reviewer feedback.
 - Improved pom.xml based on JOSS reviewer feedback.
-- Removed JFact reasoner as it no longer works with Java 16.
+- Removed JFact reasoner as it only works on Java 15 and earlier versions of Java.
+  This allows us to support Java 16.
 
 ## [1.0.0] - 2021-04-15
 - Improved README by adding badges and build and execution instructions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 
-## [Unreleased]
+## [1.1.0] - 2021-08-07
+- Prepared manuscript for submission to the Journal of Open Source Software (JOSS).
+- Improved documentation based on JOSS reviewer feedback.
+- Improved pom.xml based on JOSS reviewer feedback.
 - Removed JFact reasoner as it no longer works with Java 16.
 
 ## [1.0.0] - 2021-04-15
@@ -57,7 +60,8 @@ Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 - Initial release, with support for testing phyloreferences expressed in OWL
   and stored in RDF/XML.
 
-[Unreleased]: https://github.com/phyloref/jphyloref/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/phyloref/jphyloref/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/phyloref/jphyloref/releases/tag/v1.1.0
 [1.0.0]: https://github.com/phyloref/jphyloref/releases/tag/v1.0.0
 [0.4.0]: https://github.com/phyloref/jphyloref/releases/tag/v0.4.0
 [0.3.1]: https://github.com/phyloref/jphyloref/releases/tag/v0.3.1

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ JPhyloRef can be built from source by running `mvn package` from the root direct
 for example:
 
 ```
-$ java -jar target/jphyloref-1.1.0-SNAPSHOT.jar test src/test/resources/phylorefs/dummy1.owl
+$ java -jar target/jphyloref-1.2.0-SNAPSHOT.jar test src/test/resources/phylorefs/dummy1.owl
 ```
 
-(Note that `1.1.0` should be replaced by the correct version number -- look for the `Building JPhyloRef N.M.K-SNAPSHOT` line in the output from `mvn package`, where N.M.K is the version, such as 1.1.0)
+(Note that `1.2.0` should be replaced by the correct version number -- look for the `Building JPhyloRef N.M.K-SNAPSHOT` line in the output from `mvn package`, where N.M.K is the version, such as 1.2.0)
 
 You can also download any published version of this software directly from Maven
 at https://search.maven.org/artifact/org.phyloref/jphyloref.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you have [Coursier] installed, you can download and run JPhyloRef in one step
 by running:
 
 ```
-$ coursier launch org.phyloref:jphyloref:1.0.0 -- test input.owl
+$ coursier launch org.phyloref:jphyloref:1.1.0 -- test input.owl
 ```
 
 # Hosting a server with Webhook

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.phyloref</groupId>
     <artifactId>jphyloref</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JPhyloRef</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.phyloref</groupId>
     <artifactId>jphyloref</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>JPhyloRef</name>


### PR DESCRIPTION
This PR prepares the release of JPhyloRef v1.1.0.

As with previous releases, once this PR has been reviewed, I will publish it to the Sonotype Maven repository, tag it and publish it to Zenodo. Once that's done, I'll increment the version number, add `-SNAPSHOT` back to the version number, and merge these changes back into `master`.