### PR TITLE
Updated Cellinese 2021 citation to "accepted"

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -27,8 +27,7 @@
               names, they meet all requirements for effective data-integration.",
   journal  = "Philosophy, Theory and Practice in Biology",
   year     = {2021},
-  pages    = {Accepted. Preprint available on {EcoEvoRxiv}},
-  url      = {https://doi.org/10.32942/osf.io/57yjs}
+  pages    = {Accepted. Preprint available on {EcoEvoRxiv} at \url{https://doi.org/10.32942/osf.io/57yjs}},
 }
 
 @ARTICLE{De_Queiroz1992-oq,

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -27,7 +27,7 @@
               names, they meet all requirements for effective data-integration.",
   journal  = "Philosophy, Theory and Practice in Biology",
   year     = {2021},
-  pages    = "Accepted",
+  pages    = {Accepted. Preprint available on {EcoEvoXiv}},
   url      = {https://doi.org/10.32942/osf.io/57yjs}
 }
 

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -25,10 +25,10 @@
               definitions transformed into formal logic expressions. We call
               such expressions phyloreferences, and argue that, unlike Linnaean
               names, they meet all requirements for effective data-integration.",
-  journal  = "EcoEvoRxiv",
-  month    =  mar,
-  year     =  2021,
-  doi      =  {10.32942/osf.io/57yjs}
+  journal  = "Philosophy, Theory and Practice in Biology",
+  year     = {2021},
+  pages    = "Accepted",
+  url      = {https://doi.org/10.32942/osf.io/57yjs}
 }
 
 @ARTICLE{De_Queiroz1992-oq,

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -27,7 +27,7 @@
               names, they meet all requirements for effective data-integration.",
   journal  = "Philosophy, Theory and Practice in Biology",
   year     = {2021},
-  pages    = {Accepted. Preprint available on {EcoEvoXiv}},
+  pages    = {Accepted. Preprint available on {EcoEvoRxiv}},
   url      = {https://doi.org/10.32942/osf.io/57yjs}
 }
 

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,6 +1,6 @@
 @article{Cellinese2021-gp,
-  title    = "Phyloreferences: {{Tree-Native}}, Reproducible, and
-              {Machine-Interpretable} Taxon Concepts",
+  title    = "Phyloreferences: {Tree-Native}, {Reproducible}, and
+              {Machine-Interpretable} {Taxon} {Concepts}",
   author   = "Cellinese, Nico and Conix, Stijn and Lapp, Hilmar",
   abstract = "Evolutionary and organismal biology, similar to other fields in
               biology, have become inundated with data. At the same rate, we


### PR DESCRIPTION
This PR updates the citation status of the Cellinese 2021 citation to indicate that it has been accepted to *Philosophy, Theory and Practice in Biology*, and tweaks the BibTeX to fix the capitalization of the paper title as well.