### PR TITLE
Release of JPhyloRef v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 
 ## [Unreleased]
 
+## [1.1.1] - 2021-08-10
+- Fixed manuscript for submission to the Journal of Open Source Software (JOSS).
+
 ## [1.1.0] - 2021-08-07
 - Prepared manuscript for submission to the Journal of Open Source Software (JOSS).
 - Improved documentation based on JOSS reviewer feedback.
@@ -63,7 +66,8 @@ Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 - Initial release, with support for testing phyloreferences expressed in OWL
   and stored in RDF/XML.
 
-[Unreleased]: https://github.com/phyloref/jphyloref/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/phyloref/jphyloref/compare/v1.1.1...HEAD
+[1.1.0]: https://github.com/phyloref/jphyloref/releases/tag/v1.1.1
 [1.1.0]: https://github.com/phyloref/jphyloref/releases/tag/v1.1.0
 [1.0.0]: https://github.com/phyloref/jphyloref/releases/tag/v1.0.0
 [0.4.0]: https://github.com/phyloref/jphyloref/releases/tag/v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
   and stored in RDF/XML.
 
 [Unreleased]: https://github.com/phyloref/jphyloref/compare/v1.1.1...HEAD
-[1.1.0]: https://github.com/phyloref/jphyloref/releases/tag/v1.1.1
+[1.1.1]: https://github.com/phyloref/jphyloref/releases/tag/v1.1.1
 [1.1.0]: https://github.com/phyloref/jphyloref/releases/tag/v1.1.0
 [1.0.0]: https://github.com/phyloref/jphyloref/releases/tag/v1.0.0
 [0.4.0]: https://github.com/phyloref/jphyloref/releases/tag/v0.4.0

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you have [Coursier] installed, you can download and run JPhyloRef in one step
 by running:
 
 ```
-$ coursier launch org.phyloref:jphyloref:1.1.0 -- test input.owl
+$ coursier launch org.phyloref:jphyloref:1.1.1 -- test input.owl
 ```
 
 # Hosting a server with Webhook

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -186,11 +186,11 @@
 @software{gaurav_vaidya_2021_4697965,
   author       = {Gaurav Vaidya and
                   Hilmar Lapp},
-  title        = {phyloref/jphyloref: JPhyloRef v1.0.0},
-  month        = apr,
+  title        = {{phyloref}/{jphyloref}: JPhyloRef v1.1.0},
+  month        = aug,
   year         = 2021,
   publisher    = {Zenodo},
-  version      = {v1.0.0},
-  doi          = {10.5281/zenodo.4697965},
-  url          = {https://doi.org/10.5281/zenodo.4697965}
+  version      = {v1.1.0},
+  doi          = {10.5281/zenodo.5172998},
+  url          = {https://doi.org/10.5281/zenodo.5172998}
 }

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -186,11 +186,11 @@
 @software{gaurav_vaidya_2021_4697965,
   author       = {Gaurav Vaidya and
                   Hilmar Lapp},
-  title        = {{phyloref}/{jphyloref}: JPhyloRef v1.1.0},
+  title        = {{phyloref}/{jphyloref}: JPhyloRef v1.1.1},
   month        = aug,
   year         = 2021,
   publisher    = {Zenodo},
-  version      = {v1.1.0},
-  doi          = {10.5281/zenodo.5172998},
-  url          = {https://doi.org/10.5281/zenodo.5172998}
+  version      = {v1.1.1},
+  doi          = {10.5281/zenodo.5178723},
+  url          = {https://doi.org/10.5281/zenodo.5178723}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.phyloref</groupId>
     <artifactId>jphyloref</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JPhyloRef</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.phyloref</groupId>
     <artifactId>jphyloref</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.1.1</version>
     <packaging>jar</packaging>
 
     <name>JPhyloRef</name>


### PR DESCRIPTION
This PR is intended to release JPhyloRef v1.1.1. The only difference from v1.1.0 is some minor changes to the JOSS manuscript.

As with previous releases, once this PR has been reviewed, I will publish it to the Sonotype Maven repository, tag it and publish it to Zenodo. Once that's done, I'll update the paper to refer to the latest version of JPhyloRef in Zenodo, increment the version number, add `-SNAPSHOT` back to the version number, and merge these changes back into `master`.