### PR TITLE
Quick fix for the context download issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-rio-jsonld</artifactId>
-            <version>2.3.2</version>
+            <version>3.7.7</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-rio-api</artifactId>
-            <version>2.3.2</version>
+            <version>3.7.7</version>
         </dependency>
 
         <!-- REASONERS -->

--- a/src/main/java/org/phyloref/jphyloref/helpers/JSONLDHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/JSONLDHelper.java
@@ -83,7 +83,7 @@ public class JSONLDHelper {
             // Load built-in context files as injected documents.
             try {
               this.addInjectedDoc(
-                  "https://ww.phyloref.org/phyx.js/context/v1.0.0/phyx.json",
+                  "https://www.phyloref.org/phyx.js/context/v1.0.0/phyx.json",
                   loadResourceFileAsString("context/phyx-context-v1.0.0.json"));
             } catch (IOException e) {
               logger.error("Could not load Phyx context v1.0.0: " + e);

--- a/src/main/java/org/phyloref/jphyloref/helpers/JSONLDHelper.java
+++ b/src/main/java/org/phyloref/jphyloref/helpers/JSONLDHelper.java
@@ -1,14 +1,20 @@
 package org.phyloref.jphyloref.helpers;
 
+import com.github.jsonldjava.core.DocumentLoader;
+import com.github.jsonldjava.core.JsonLdError;
+import com.github.jsonldjava.core.RemoteDocument;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.JSONLDSettings;
 import org.semanticweb.owlapi.formats.RDFJsonLDDocumentFormat;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyLoaderConfiguration;
 import org.semanticweb.owlapi.rio.RioOWLRDFConsumerAdapter;
 import org.semanticweb.owlapi.util.AnonymousNodeChecker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * JSONLDHelper provides methods to help read and process JSON-LD files.
@@ -16,6 +22,8 @@ import org.semanticweb.owlapi.util.AnonymousNodeChecker;
  * @author Gaurav Vaidya
  */
 public class JSONLDHelper {
+  private static final Logger logger = LoggerFactory.getLogger(JSONLDHelper.class);
+
   /**
    * Create an RDFParser for JSON-LD files. When the parser's <code>parse()</code> method is called,
    * its contents will be added to the OWLOntology passed to this method.
@@ -59,6 +67,23 @@ public class JSONLDHelper {
     // Set up an RDF parser to read the JSON-LD file.
     RDFParser parser = Rio.createParser(RDFFormat.JSONLD);
     parser.setRDFHandler(rdfHandler);
+
+    // We get some indistinct errors if any of the context URLs in the JSON-LD file are
+    // incorrect or inaccessible. However, we can set up our own document loader so we
+    // can detect when this occurs.)
+    parser.set(
+        JSONLDSettings.DOCUMENT_LOADER,
+        new DocumentLoader() {
+          @Override
+          public RemoteDocument loadDocument(String url) throws JsonLdError {
+            try {
+              return super.loadDocument(url);
+            } catch (Exception err) {
+              logger.error("Error occurred while loading document " + url + ": " + err);
+              throw new JsonLdError(JsonLdError.Error.LOADING_REMOTE_CONTEXT_FAILED, url, err);
+            }
+          }
+        });
 
     return parser;
   }

--- a/src/main/resources/context/phyx-context-v1.0.0.json
+++ b/src/main/resources/context/phyx-context-v1.0.0.json
@@ -1,0 +1,143 @@
+{
+  "@context": {
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "dwc": "http://rs.tdwg.org/dwc/terms/",
+    "dct": "http://purl.org/dc/terms/",
+    "tc": "http://rs.tdwg.org/ontology/voc/TaxonConcept#",
+    "tn": "http://rs.tdwg.org/ontology/voc/TaxonName#",
+    "testcase": "http://vocab.phyloref.org/phyloref/testcase.owl#",
+    "pso": "http://purl.org/spar/pso/",
+    "tvc": "http://www.essepuntato.it/2012/04/tvc/",
+    "timeinterval": "http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#",
+    "phyloref": "http://ontology.phyloref.org/phyloref.owl#",
+    "opentree": "http://purl.org/opentree/nexson#",
+    "subClasses": {
+      "@reverse": "rdfs:subClassOf"
+    },
+    "label": {
+      "@id": "rdfs:label",
+      "@type": "xsd:string"
+    },
+    "labels": {
+      "@id": "rdfs:label",
+      "@type": "xsd:string",
+      "@container": "@set"
+    },
+    "namePublishedIn": "dwc:namePublishedIn",
+    "definitionSource": "obo:IAO_0000119",
+    "definition": {
+      "@id": "obo:IAO_0000115",
+      "@type": "xsd:string"
+    },
+    "hasName": {
+      "@id": "tc:hasName",
+      "@type": "tn:TaxonName"
+    },
+    "nameComplete": {
+      "@id": "tn:nameComplete",
+      "@type": "xsd:string"
+    },
+    "nomenclaturalCode": {
+      "@id": "tn:nomenclaturalCode",
+      "@type": "@id"
+    },
+    "scientificName": {
+      "@id": "dwc:scientificName",
+      "@type": "xsd:string"
+    },
+    "genusPart": {
+      "@id": "tn:genusPart",
+      "@type": "xsd:string"
+    },
+    "specificEpithet": {
+      "@id": "tn:specificEpithet",
+      "@type": "xsd:string"
+    },
+    "basisOfRecord": "dwc:basisOfRecord",
+    "occurrenceID": "dwc:occurrenceID",
+    "catalogNumber": "dwc:catalogNumber",
+    "collectionCode": "dwc:collectionCode",
+    "institutionCode": "dwc:institutionCode",
+    "subClassOf": {
+      "@id": "rdfs:subClassOf",
+      "@type": "@id"
+    },
+    "parent": {
+      "@id": "obo:CDAO_0000179",
+      "@type": "@id"
+    },
+    "children": {
+      "@id": "obo:CDAO_0000149",
+      "@type": "@id"
+    },
+    "siblings": {
+      "@id": "phyloref:has_Sibling",
+      "@type": "@id"
+    },
+    "owl:imports": {
+      "@id": "owl:imports",
+      "@type": "@id"
+    },
+    "equivalentClass": "owl:equivalentClass",
+    "intersectionOf": {
+      "@id": "owl:intersectionOf",
+      "@container": "@list"
+    },
+    "onProperty": {
+      "@id": "owl:onProperty",
+      "@type": "@id"
+    },
+    "someValuesFrom": {
+      "@id": "owl:someValuesFrom",
+      "@container": "@set"
+    },
+    "unionOf": {
+      "@id": "owl:unionOf",
+      "@container": "@list"
+    },
+    "hasValue": {
+      "@id": "owl:hasValue",
+      "@type": "xsd:string"
+    },
+    "nodes": {
+      "@reverse": "obo:CDAO_0000200",
+      "@container": "@set"
+    },
+    "hasRootNode": {
+      "@id": "obo:CDAO_0000148",
+      "@type": "@id"
+    },
+    "newick": {
+      "@id": "phyloref:newick_expression",
+      "@type": "xsd:string"
+    },
+    "curator": {
+      "@id": "opentree:curatorName",
+      "@type": "xsd:string"
+    },
+    "scientificNameAuthorship": {
+      "@id": "dwc:scientificNameAuthorship",
+      "@type": "xsd:string"
+    },
+    "nameAccordingTo": "tc:accordingTo",
+    "phylogenies": {
+      "@reverse": "rdfs:isDefinedBy",
+      "@container": "@set"
+    },
+    "phylorefs": {
+      "@reverse": "rdfs:isDefinedBy",
+      "@container": "@set"
+    },
+    "title": "dct:title",
+    "source": "dct:source",
+    "bibliographicCitation": "dct:bibliographicCitation",
+    "doi": "http://prismstandard.org/namespaces/basic/2.0/doi",
+    "representsTaxonomicUnits": "obo:CDAO_0000187",
+    "apomorphy": "phyloref:apomorphy"
+  }
+}

--- a/src/main/resources/context/phyx-context-v1.1.0.json
+++ b/src/main/resources/context/phyx-context-v1.1.0.json
@@ -1,0 +1,146 @@
+{
+  "@context": {
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "dwc": "http://rs.tdwg.org/dwc/terms/",
+    "dct": "http://purl.org/dc/terms/",
+    "tc": "http://rs.tdwg.org/ontology/voc/TaxonConcept#",
+    "tn": "http://rs.tdwg.org/ontology/voc/TaxonName#",
+    "pso": "http://purl.org/spar/pso/",
+    "tvc": "http://www.essepuntato.it/2012/04/tvc/",
+    "timeinterval": "http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#",
+    "phyloref": "http://ontology.phyloref.org/phyloref.owl#",
+    "subClasses": {
+      "@reverse": "rdfs:subClassOf"
+    },
+    "label": {
+      "@id": "rdfs:label",
+      "@type": "xsd:string"
+    },
+    "labels": {
+      "@id": "rdfs:label",
+      "@type": "xsd:string",
+      "@container": "@set"
+    },
+    "namePublishedIn": "dwc:namePublishedIn",
+    "definitionSource": "obo:IAO_0000119",
+    "definition": {
+      "@id": "obo:IAO_0000115",
+      "@type": "xsd:string"
+    },
+    "hasName": {
+      "@id": "tc:hasName",
+      "@type": "tn:TaxonName"
+    },
+    "nameComplete": {
+      "@id": "tn:nameComplete",
+      "@type": "xsd:string"
+    },
+    "nomenclaturalCode": {
+      "@id": "tn:nomenclaturalCode",
+      "@type": "@id"
+    },
+    "scientificName": {
+      "@id": "dwc:scientificName",
+      "@type": "xsd:string"
+    },
+    "genusPart": {
+      "@id": "tn:genusPart",
+      "@type": "xsd:string"
+    },
+    "specificEpithet": {
+      "@id": "tn:specificEpithet",
+      "@type": "xsd:string"
+    },
+    "basisOfRecord": "dwc:basisOfRecord",
+    "occurrenceID": "dwc:occurrenceID",
+    "catalogNumber": "dwc:catalogNumber",
+    "collectionCode": "dwc:collectionCode",
+    "institutionCode": "dwc:institutionCode",
+    "subClassOf": {
+      "@id": "rdfs:subClassOf",
+      "@type": "@id"
+    },
+    "parent": {
+      "@id": "obo:CDAO_0000179",
+      "@type": "@id"
+    },
+    "children": {
+      "@id": "obo:CDAO_0000149",
+      "@type": "@id"
+    },
+    "siblings": {
+      "@id": "phyloref:has_Sibling",
+      "@type": "@id"
+    },
+    "owl:imports": {
+      "@id": "owl:imports",
+      "@type": "@id"
+    },
+    "equivalentClass": "owl:equivalentClass",
+    "intersectionOf": {
+      "@id": "owl:intersectionOf",
+      "@container": "@list"
+    },
+    "onProperty": {
+      "@id": "owl:onProperty",
+      "@type": "@id"
+    },
+    "someValuesFrom": {
+      "@id": "owl:someValuesFrom",
+      "@container": "@set"
+    },
+    "unionOf": {
+      "@id": "owl:unionOf",
+      "@container": "@list"
+    },
+    "hasValue": {
+      "@id": "owl:hasValue",
+      "@type": "xsd:string"
+    },
+    "nodes": {
+      "@reverse": "obo:CDAO_0000200",
+      "@container": "@set"
+    },
+    "hasRootNode": {
+      "@id": "obo:CDAO_0000148",
+      "@type": "@id"
+    },
+    "newick": {
+      "@id": "phyloref:newick_expression",
+      "@type": "xsd:string"
+    },
+    "curatorNotes": {
+      "@id": "obo:IAO_0000232",
+      "@type": "xsd:string"
+    },
+    "scientificNameAuthorship": {
+      "@id": "dwc:scientificNameAuthorship",
+      "@type": "xsd:string"
+    },
+    "nameAccordingTo": "tc:accordingTo",
+    "phylogenies": {
+      "@reverse": "rdfs:isDefinedBy",
+      "@container": "@set"
+    },
+    "phylorefs": {
+      "@reverse": "rdfs:isDefinedBy",
+      "@container": "@set"
+    },
+    "title": "dct:title",
+    "source": "dct:source",
+    "bibliographicCitation": "dct:bibliographicCitation",
+    "doi": "http://prismstandard.org/namespaces/basic/2.0/doi",
+    "representsTaxonomicUnits": "obo:CDAO_0000187",
+    "apomorphy": "phyloref:apomorphy",
+    "contributors": {
+      "@id": "http://purl.org/dc/terms/contributor",
+      "@container": "@set"
+    },
+    "name": "http://xmlns.com/foaf/0.1/name"
+  }
+}


### PR DESCRIPTION
This PR provides a quick fix for the context download issue, but storing the two most recent contexts in the JAR file so that they can used even without an internet connection. We will need the internet to download the Phyloref, CDAO and TCAN ontologies, but those can be stored in an `ontologies/` directory, so in theory this gets us to the point where JPhyloRef can be run without an internet connection. However, this has not yet been tested on HiPerGaTor as we are in the process of moving from one server to another there.